### PR TITLE
feat: replace isStyle variable config with group []

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,8 +68,14 @@
       "main",
       "next",
       "next-major",
-      { "name": "beta", "prerelease": true },
-      { "name": "alpha", "prerelease": true }
+      {
+        "name": "beta",
+        "prerelease": true
+      },
+      {
+        "name": "alpha",
+        "prerelease": true
+      }
     ],
     "plugins": [
       [

--- a/src/Test.tsx
+++ b/src/Test.tsx
@@ -2,16 +2,16 @@ import React from 'react'
 import { useComponents } from './hooks'
 import { ComponentDefinitionVariableArrayItemType, ComponentDefinitionVariableType } from './types'
 
-const Com = () => {
+const TestComponent = () => {
   return null
 }
 
 export const Test = () => {
   const { defineComponent } = useComponents()
 
-  defineComponent(Com, {
-    id: 'Com',
-    name: 'Com',
+  defineComponent(TestComponent, {
+    id: 'TestComponent',
+    name: 'TestComponent',
     variables: {
       name: {
         type: ComponentDefinitionVariableType.LINK,

--- a/src/hooks/useComponents.spec.tsx
+++ b/src/hooks/useComponents.spec.tsx
@@ -1,0 +1,57 @@
+import React from 'react'
+import { renderHook } from '@testing-library/react'
+import { useComponents } from './useComponents'
+
+import { ComponentDefinitionVariableArrayItemType, ComponentDefinitionVariableType } from '../types'
+
+const TestComponent = () => {
+  return <div data-test-id="test">Test</div>
+}
+
+describe('ComponentDefinitions', () => {
+  it('should apply fallback to group: content for variables that have it undefined', () => {
+    const { result } = renderHook(() => useComponents())
+
+    const definitionId = 'TestComponent'
+
+    result.current.defineComponent(TestComponent, {
+      id: definitionId,
+      name: 'TestComponent',
+      variables: {
+        name: {
+          type: ComponentDefinitionVariableType.LINK,
+          linkType: 'Asset',
+        },
+        isChecked: {
+          type: ComponentDefinitionVariableType.BOOLEAN,
+        },
+        elements: {
+          type: ComponentDefinitionVariableType.ARRAY,
+          items: {
+            linkType: 'Entry',
+            type: ComponentDefinitionVariableArrayItemType.LINK,
+          },
+        },
+        elementsSymbol: {
+          type: ComponentDefinitionVariableType.ARRAY,
+          items: {
+            type: ComponentDefinitionVariableArrayItemType.SYMBOL,
+          },
+        },
+        elementsComponent: {
+          type: ComponentDefinitionVariableType.ARRAY,
+          items: {
+            type: ComponentDefinitionVariableArrayItemType.COMPONENT,
+          },
+        },
+      },
+    })
+
+    const definition = result.current.getComponent(definitionId)
+    expect(definition).toBeDefined()
+
+    for (const variable of Object.values(definition!.componentDefinition.variables)) {
+      expect(variable.group).toBe('content')
+    }
+  })
+})

--- a/src/hooks/useComponents.ts
+++ b/src/hooks/useComponents.ts
@@ -7,6 +7,24 @@ export type ComponentDefinitionWithComponentType = {
   componentDefinition: ComponentDefinition
 }
 
+const cloneObject = <T>(targetObject: T): T => {
+  if (typeof structuredClone !== 'undefined') {
+    return structuredClone(targetObject)
+  }
+
+  return JSON.parse(JSON.stringify(targetObject))
+}
+
+const applyFallbacks = (componentDefinition: ComponentDefinition) => {
+  const clone = cloneObject(componentDefinition)
+  for (const variable of Object.values(clone.variables)) {
+    if (!variable.group) {
+      variable.group = 'content'
+    }
+  }
+  return clone
+}
+
 const registeredComponentDefinitions: ComponentDefinitionWithComponentType[] = []
 
 export const useComponents = () => {
@@ -14,7 +32,11 @@ export const useComponents = () => {
 
   const defineComponent = useCallback(
     (component: ElementType, parameters: ComponentDefinition) => {
-      registeredComponentDefinitions.push({ component, componentDefinition: parameters })
+      const definitionWithFallbacks = applyFallbacks(parameters)
+      registeredComponentDefinitions.push({
+        component,
+        componentDefinition: definitionWithFallbacks,
+      })
       sendMessage('registeredComponents', parameters)
     },
     [sendMessage]

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,7 +21,7 @@ export type ComponentDefinitionVariableValidation = {
 export interface ComponentDefinitionVariableBase<T extends ComponentDefinitionVariableType> {
   type: T
   validations?: ComponentDefinitionVariableValidation
-  isStyle?: boolean
+  group?: 'style' | 'content'
   description?: string
   defaultValue?: string | boolean | number
 }


### PR DESCRIPTION
To align with the latest decision log, `isStyle` has been replaced with `group` with a value of `content` by default