### PR TITLE
chore: ignore local npmrc file [SPA-1242]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,5 @@ tmp/
 # Local script for cache invalidation with temporary version bumps
 bump-alpha.cjs
 
+# Necessary for pushing to alternative npm registry
+.npmrc


### PR DESCRIPTION
For easier estup, ignore the npmrc but keep it.