### PR TITLE
fix: only send coordinates for children of type 'block' []

### DIFF
--- a/src/communication/HoverIndicatorHandler.ts
+++ b/src/communication/HoverIndicatorHandler.ts
@@ -67,7 +67,7 @@ export class HoverIndicatorHandler {
     const rawCoordinates = this.getCoordinatesOfElement(element)
 
     const childrenCoordinates: RawCoordinates[] = Array.from(element.children)
-      .filter((child) => child.id !== 'SectionTooltip')
+      .filter((child) => child instanceof HTMLElement && child.dataset.cfNodeBlockType === 'block')
       .map((child) => this.getCoordinatesOfElement(child))
 
     return {


### PR DESCRIPTION
Small fix to not show hover outlines for children that are not actual experience builder components.

#### Before
<img width="300" alt="Screenshot 2023-08-15 at 08 28 51" src="https://github.com/contentful/experience-builder/assets/2773012/e008ee76-d111-4978-955b-1fc934add8ff">

#### After
<img width="389" alt="Screenshot 2023-08-15 at 08 27 35" src="https://github.com/contentful/experience-builder/assets/2773012/c5e268ca-a7ae-4f9e-b2f8-a8ddf4f4c598">
