### PR TITLE
fix: pass the right breakpoints object to hook for preview/delivery mode []

### DIFF
--- a/src/blocks/PreviewDeliveryRoot.tsx
+++ b/src/blocks/PreviewDeliveryRoot.tsx
@@ -16,7 +16,6 @@ type DeliveryRootProps = {
 export const PreviewDeliveryRoot = ({ experience, slug }: DeliveryRootProps) => {
   const { spaceId, environmentId, accessToken, locale, host } =
     useCheckForExperienceConfig(experience)
-  const { resolveDesignValue } = useBreakpoints(experience.breakpoints)
 
   if (!slug) {
     throw new Error('Preview and delivery mode requires a composition slug to be provided')
@@ -43,6 +42,8 @@ export const PreviewDeliveryRoot = ({ experience, slug }: DeliveryRootProps) => 
     slug: slug,
     locale: locale as string,
   })
+
+  const { resolveDesignValue } = useBreakpoints(breakpoints)
 
   if (!composition || isLoadingData) {
     return null


### PR DESCRIPTION
Fixes: 
<img width="755" alt="Screenshot 2023-08-15 at 10 37 51" src="https://github.com/contentful/experience-builder/assets/2773012/90151ad6-d45c-448f-b391-232a37cb12a0">
