### PR TITLE
fix: use the flex safe orientation to horizontally scroll overflowing content [SPA-1401]

### DIFF
--- a/src/blocks/ContentfulSection.css
+++ b/src/blocks/ContentfulSection.css
@@ -4,6 +4,7 @@
   overflow: scroll;
   flex-wrap: wrap;
   justify-content: center;
+  justify-content: safe center;
   position: relative;
   display: flex;
 

--- a/src/blocks/transformers.ts
+++ b/src/blocks/transformers.ts
@@ -23,11 +23,11 @@ export const transformAlignment = (
   flexDirection === 'row'
     ? {
         alignItems: `${horizontalAlignment}`,
-        justifyContent: `${verticalAlignment}`,
+        justifyContent: `safe ${verticalAlignment}`,
       }
     : {
         alignItems: `${verticalAlignment}`,
-        justifyContent: `${horizontalAlignment}`,
+        justifyContent: `safe ${horizontalAlignment}`,
       }
 
 type CssPropertiesForBackground =


### PR DESCRIPTION
A flex box with justify-content center is not meant to overflow horizontally. If it does, the content on the left of the view becomes not accessible. There is no simple solution that just makes scrolling work (see this [SO post](https://stackoverflow.com/questions/46059398/css-flex-overflow-and-center/46059525#46059525)).
Instead, we can use the `safe` parameter for `justify-content` that will center the content as long as it doesn't overflow. If it overflows, it will make it behave like `flex-start` which makes everything left alignment and thereby accessible via scrolling