### PR TITLE
feat: add error boundary [SPA-1507]

### DIFF
--- a/src/blocks/ErrorBoundary.css
+++ b/src/blocks/ErrorBoundary.css
@@ -1,0 +1,13 @@
+.error-message {
+    margin: 24px;
+    font-size: var(--font-size-m);
+    font-family: var(--font-stack-primary);
+    color: var(--red-800);
+    padding: 16px;
+    background-color: var(--red-200);
+}
+
+.error-message .title {
+    margin-top: 0;
+    font-size: var(--font-size-l);
+}

--- a/src/blocks/ErrorBoundary.css
+++ b/src/blocks/ErrorBoundary.css
@@ -1,4 +1,4 @@
-.error-message {
+.cf-error-message {
   margin: 24px;
   font-size: var(--font-size-m);
   font-family: var(--font-stack-primary);
@@ -7,12 +7,12 @@
   background-color: var(--red200);
 }
 
-.error-message .title {
+.cf-error-message .title {
   margin-top: 0;
   font-size: var(--font-size-l);
 }
 
-.more-details {
+.cf-error-message .more-details {
   cursor: pointer;
   color: var(--blue700);
 }

--- a/src/blocks/ErrorBoundary.css
+++ b/src/blocks/ErrorBoundary.css
@@ -1,13 +1,13 @@
 .error-message {
-    margin: 24px;
-    font-size: var(--font-size-m);
-    font-family: var(--font-stack-primary);
-    color: var(--red-800);
-    padding: 16px;
-    background-color: var(--red-200);
+  margin: 24px;
+  font-size: var(--font-size-m);
+  font-family: var(--font-stack-primary);
+  color: var(--red-800);
+  padding: 16px;
+  background-color: var(--red-200);
 }
 
 .error-message .title {
-    margin-top: 0;
-    font-size: var(--font-size-l);
+  margin-top: 0;
+  font-size: var(--font-size-l);
 }

--- a/src/blocks/ErrorBoundary.css
+++ b/src/blocks/ErrorBoundary.css
@@ -2,12 +2,17 @@
   margin: 24px;
   font-size: var(--font-size-m);
   font-family: var(--font-stack-primary);
-  color: var(--red-800);
+  color: var(--red800);
   padding: 16px;
-  background-color: var(--red-200);
+  background-color: var(--red200);
 }
 
 .error-message .title {
   margin-top: 0;
   font-size: var(--font-size-l);
+}
+
+.more-details {
+  cursor: pointer;
+  color: var(--blue700);
 }

--- a/src/blocks/ErrorBoundary.tsx
+++ b/src/blocks/ErrorBoundary.tsx
@@ -1,0 +1,34 @@
+import React, { ErrorInfo, ReactElement } from 'react'
+import './ErrorBoundary.css'
+
+export class ErrorBoundary extends React.Component<
+  { children: ReactElement },
+  { hasError: boolean; error: Error | null; errorInfo: ErrorInfo | null }
+> {
+  constructor(props: { children: ReactElement }) {
+    super(props)
+    this.state = { hasError: false, error: null, errorInfo: null }
+  }
+
+  static getDerivedStateFromError() {
+    return { hasError: true }
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+    this.setState({ error, errorInfo })
+    console.error(error, errorInfo)
+    // let's catch this error somehow?
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className="error-message">
+          <h2 className="title">{`Something went wrong rendering the composition in editor mode:`}</h2>
+          <div>{`${this.state.error}`}</div>
+        </div>
+      )
+    }
+    return this.props.children
+  }
+}

--- a/src/blocks/ErrorBoundary.tsx
+++ b/src/blocks/ErrorBoundary.tsx
@@ -7,11 +7,11 @@ class ImportedComponentError extends Error {}
 
 export class ErrorBoundary extends React.Component<
   { children: ReactElement },
-  { hasError: boolean; error: Error | null; errorInfo: ErrorInfo | null }
+  { hasError: boolean; error: Error | null; errorInfo: ErrorInfo | null; showErrorDetails: boolean }
 > {
   constructor(props: { children: ReactElement }) {
     super(props)
-    this.state = { hasError: false, error: null, errorInfo: null }
+    this.state = { hasError: false, error: null, errorInfo: null, showErrorDetails: false }
   }
 
   static getDerivedStateFromError() {
@@ -29,8 +29,36 @@ export class ErrorBoundary extends React.Component<
     if (this.state.hasError) {
       return (
         <div className="error-message">
-          <h2 className="title">{`Something went wrong rendering the composition in editor mode:`}</h2>
-          <div>{`${this.state.error}`}</div>
+          <h2 className="title">{`Something went wrong while rendering the experience`}</h2>
+          <div>
+            The Experience Builder SDK has encountered an error. It may be that the SDK has not been
+            set up properly or an imported component has thrown this error. Try to refresh the page
+            and find more guidance in our{' '}
+            <a
+              href="https://www.contentful.com/developers/docs/tutorials/general/experience-builder/"
+              rel="noreferrer"
+              target="_blank">
+              documentation
+            </a>
+            .
+          </div>
+          <br />
+          <span
+            className="more-details"
+            onClick={() =>
+              this.setState((prevState) => ({
+                showErrorDetails: !prevState.showErrorDetails,
+              }))
+            }>
+            {this.state.showErrorDetails ? 'Hide' : 'See'} details
+          </span>
+          {this.state.showErrorDetails && (
+            <code>
+              {this.state.error?.stack?.split('\n').map((i, key) => {
+                return <div key={key}>{i}</div>
+              })}
+            </code>
+          )}
         </div>
       )
     }

--- a/src/blocks/ErrorBoundary.tsx
+++ b/src/blocks/ErrorBoundary.tsx
@@ -22,13 +22,15 @@ export class ErrorBoundary extends React.Component<
     this.setState({ error, errorInfo })
     if (!(error instanceof ImportedComponentError)) {
       sendMessage(OutgoingExperienceBuilderEvent.CANVAS_ERROR, error)
+    } else {
+      throw error
     }
   }
 
   render() {
     if (this.state.hasError) {
       return (
-        <div className="error-message">
+        <div className="cf-error-message">
           <h2 className="title">{`Something went wrong while rendering the experience`}</h2>
           <div>
             The Experience Builder SDK has encountered an error. It may be that the SDK has not been

--- a/src/blocks/ErrorBoundary.tsx
+++ b/src/blocks/ErrorBoundary.tsx
@@ -1,5 +1,9 @@
 import React, { ErrorInfo, ReactElement } from 'react'
+import { sendMessage } from '../communication/sendMessage'
+import { OutgoingExperienceBuilderEvent } from '../types'
 import './ErrorBoundary.css'
+
+class ImportedComponentError extends Error {}
 
 export class ErrorBoundary extends React.Component<
   { children: ReactElement },
@@ -16,8 +20,9 @@ export class ErrorBoundary extends React.Component<
 
   componentDidCatch(error: Error, errorInfo: ErrorInfo) {
     this.setState({ error, errorInfo })
-    console.error(error, errorInfo)
-    // let's catch this error somehow?
+    if (!(error instanceof ImportedComponentError)) {
+      sendMessage(OutgoingExperienceBuilderEvent.CANVAS_ERROR, error)
+    }
   }
 
   render() {
@@ -29,6 +34,18 @@ export class ErrorBoundary extends React.Component<
         </div>
       )
     }
+    return this.props.children
+  }
+}
+
+export class ImportedComponentErrorBoundary extends React.Component<{ children: ReactElement }> {
+  componentDidCatch(error: Error, _errorInfo: ErrorInfo) {
+    const err = new ImportedComponentError(error.message)
+    err.stack = error.stack
+    throw err
+  }
+
+  render() {
     return this.props.children
   }
 }

--- a/src/blocks/ExperienceRoot.tsx
+++ b/src/blocks/ExperienceRoot.tsx
@@ -4,6 +4,7 @@ import { VisualEditorRoot } from './VisualEditorRoot'
 import { PreviewDeliveryRoot } from './PreviewDeliveryRoot'
 import { supportedModes } from '../constants'
 import { validateExperienceBuilderConfig } from '../validation'
+import { ErrorBoundary } from './ErrorBoundary'
 
 type ExperienceRootProps = {
   experience: Experience
@@ -23,7 +24,11 @@ export const ExperienceRoot = ({ locale, experience, slug }: ExperienceRootProps
   if (!mode || !supportedModes.includes(mode)) return null
 
   if (mode === 'editor') {
-    return <VisualEditorRoot initialLocale={locale} mode={mode} />
+    return (
+      <ErrorBoundary>
+        <VisualEditorRoot initialLocale={locale} mode={mode} />
+      </ErrorBoundary>
+    )
   }
 
   return <PreviewDeliveryRoot locale={locale} slug={slug} experience={experience} />

--- a/src/blocks/VisualEditorBlock.tsx
+++ b/src/blocks/VisualEditorBlock.tsx
@@ -24,6 +24,7 @@ import omit from 'lodash.omit'
 import { sendMessage } from '../communication/sendMessage'
 import { getComponentRegistration } from '../core/componentRegistry'
 import { useEditorContext } from './useEditorContext'
+import { ImportedComponentErrorBoundary } from './ErrorBoundary'
 
 type PropsType =
   | StyleProps
@@ -180,8 +181,7 @@ export const VisualEditorBlock = ({
     )
   }
 
-  // imported component
-  return React.createElement(
+  const importedComponent = React.createElement(
     component,
     {
       onMouseDown: (e: MouseEvent) => {
@@ -205,4 +205,6 @@ export const VisualEditorBlock = ({
     },
     children
   )
+
+  return <ImportedComponentErrorBoundary>{importedComponent}</ImportedComponentErrorBoundary>
 }

--- a/src/blocks/VisualEditorRoot.tsx
+++ b/src/blocks/VisualEditorRoot.tsx
@@ -61,8 +61,11 @@ const VisualEditorRootComponents = () => {
       await entityStore.current.fetchEntities(entityLinks)
       setEntitiesFetched(true)
     }
+
     resolveEntities()
+    throw new Error('testing error')
   }, [dataSource, entityStore, locale])
+
   if (!tree?.root.children.length) {
     return React.createElement(EmptyEditorContainer, { isDragging }, [])
   }

--- a/src/blocks/VisualEditorRoot.tsx
+++ b/src/blocks/VisualEditorRoot.tsx
@@ -63,7 +63,6 @@ const VisualEditorRootComponents = () => {
     }
 
     resolveEntities()
-    throw new Error('testing error')
   }, [dataSource, entityStore, locale])
 
   if (!tree?.root.children.length) {

--- a/src/styles/variables.css
+++ b/src/styles/variables.css
@@ -18,8 +18,8 @@
   --gray700: #414d63;
   --gray800: #1b273a;
   --gray900: #111b2b;
-  --red-200: #ffe0e0;
-  --red-800: #7f0010;
+  --red200: #ffe0e0;
+  --red800: #7f0010;
   --color-white: #ffffff;
   --glow-primary: 0px 0px 0px 3px #e8f5ff;
 

--- a/src/styles/variables.css
+++ b/src/styles/variables.css
@@ -18,6 +18,8 @@
   --gray700: #414d63;
   --gray800: #1b273a;
   --gray900: #111b2b;
+  --red-200: #ffe0e0;
+  --red-800: #7f0010;
   --color-white: #ffffff;
   --glow-primary: 0px 0px 0px 3px #e8f5ff;
 
@@ -27,6 +29,7 @@
 
   /* typography */
   --font-size-m: 1.475rem;
+  --font-size-l: 1rem;
   --font-stack-primary: -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif,
     Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol;
   --line-height-condensed: 1.25;

--- a/src/styles/variables.css
+++ b/src/styles/variables.css
@@ -28,8 +28,8 @@
   --spacing-2xs: 0.25rem;
 
   /* typography */
-  --font-size-m: 1.475rem;
   --font-size-l: 1rem;
+  --font-size-m: 1.475rem;
   --font-stack-primary: -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif,
     Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol;
   --line-height-condensed: 1.25;

--- a/src/types.ts
+++ b/src/types.ts
@@ -26,6 +26,7 @@ export enum OutgoingExperienceBuilderEvent {
   UPDATE_SELECTED_COMPONENT_COORDINATES = 'updateSelectedComponentCoordinates',
   UPDATE_HOVERED_COMPONENT_COORDINATES = 'updateHoveredComponentCoordinates',
   CANVAS_SCROLL = 'canvasScrolling',
+  CANVAS_ERROR = 'canvasError',
 }
 
 export enum IncomingExperienceBuilderEvent {


### PR DESCRIPTION
* Catch errors happening during rendering of the experience and display them in the Canvas when operating in `editor` mode.
* Send errors to the web app if error originated from the SDK and not the imported components.
* Display informative error screen instead of blank screen when an error happens as shown below:

<img width="1033" alt="Screenshot 2023-10-10 at 14 43 13" src="https://github.com/contentful/experience-builder/assets/2773012/f6e6d3cf-d24e-490b-9a0c-8b1b5ebf5f3e">

<img width="1040" alt="Screenshot 2023-10-10 at 14 43 19" src="https://github.com/contentful/experience-builder/assets/2773012/6693a63e-41bc-4503-9a9a-b606f836b316">

