### PR TITLE
fix: [] Remove hover element id on mouse leave

### DIFF
--- a/src/communication/MouseOverHandler.ts
+++ b/src/communication/MouseOverHandler.ts
@@ -131,8 +131,7 @@ export class MouseOverHandler {
     this.handleMouseMove(target)
   }
 
-  onMouseLeave = (event: MouseEvent) => {
-    const target: HTMLElement | null = event.target as HTMLElement
+  onMouseLeave = () => {
     this.currentHoveredElementId = null
   }
 


### PR DESCRIPTION
The element is not reset when leaving it, which led to not sending a new hovered element when leaving the element on the side and also leaving the document. 

