### PR TITLE
fix: explicitly pass null as children if element is not a container []

### DIFF
--- a/src/blocks/CompositionBlock.tsx
+++ b/src/blocks/CompositionBlock.tsx
@@ -91,22 +91,23 @@ export const CompositionBlock = ({
 
   const { component } = componentRegistration
 
-  const children = componentRegistration.definition.children === true
-    ? node.children.map((childNode: CompositionNode, index) => {
-        return (
-          <CompositionBlock
-            node={childNode}
-            key={index}
-            locale={locale}
-            dataSource={dataSource}
-            unboundValues={unboundValues}
-            entityStore={entityStore}
-            breakpoints={breakpoints}
-            resolveDesignValue={resolveDesignValue}
-          />
-        )
-      })
-    : null
+  const children =
+    componentRegistration.definition.children === true
+      ? node.children.map((childNode: CompositionNode, index) => {
+          return (
+            <CompositionBlock
+              node={childNode}
+              key={index}
+              locale={locale}
+              dataSource={dataSource}
+              unboundValues={unboundValues}
+              entityStore={entityStore}
+              breakpoints={breakpoints}
+              resolveDesignValue={resolveDesignValue}
+            />
+          )
+        })
+      : null
 
   if ([CONTENTFUL_CONTAINER_ID, CONTENTFUL_SECTION_ID].includes(node.definitionId)) {
     return (

--- a/src/blocks/VisualEditorBlock.tsx
+++ b/src/blocks/VisualEditorBlock.tsx
@@ -124,23 +124,24 @@ export const VisualEditorBlock = ({
 
   const { component, definition } = componentRegistration
 
-  const children = definition.children === true
-    ? node.children.map((childNode) => {
-        return (
-          <VisualEditorBlock
-            node={childNode}
-            key={childNode.data.id}
-            locale={locale}
-            dataSource={dataSource}
-            unboundValues={unboundValues}
-            selectedNodeId={selectedNodeId}
-            resolveDesignValue={resolveDesignValue}
-            entityStore={entityStore}
-            areEntitiesFetched={areEntitiesFetched}
-          />
-        )
-      })
-    : null
+  const children =
+    definition.children === true
+      ? node.children.map((childNode) => {
+          return (
+            <VisualEditorBlock
+              node={childNode}
+              key={childNode.data.id}
+              locale={locale}
+              dataSource={dataSource}
+              unboundValues={unboundValues}
+              selectedNodeId={selectedNodeId}
+              resolveDesignValue={resolveDesignValue}
+              entityStore={entityStore}
+              areEntitiesFetched={areEntitiesFetched}
+            />
+          )
+        })
+      : null
 
   // contentful section
   if ([CONTENTFUL_SECTION_ID, CONTENTFUL_CONTAINER_ID].includes(definition.id)) {


### PR DESCRIPTION
For elements that are called `void tag element` like `img` or `input`, react errors out in case some value is set as a "slot"

which leads to the error as the following:

```
Error: img is a void element tag and must neither have `children` nor use `dangerouslySetInnerHTML`.
```

and a blank canvas

To reproduce, register the following component and run it in [colorful coin demo](https://github.com/contentful/colorful-coin-eb) with the latest v of the sdk and drop the element on canvas

```tsx
import { ComponentDefinition } from "@contentful/experience-builder";

export interface IAtImageProps {
  width: number;
  height: number;
  src: string;
  altText: string;
  className: string;
}

const AtImage = ({
  width,
  height,
  src,
  altText,
  className,
  ...ctflProps
}: IAtImageProps) => {
  return (
    <img
      alt={altText}
      width={width}
      height={height}
      className={className}
      src={src}
      {...ctflProps}
    />
  );
};

export default AtImage

AtImage.ComponentDefinition = {
  name: 'Image',
  id: 'image',
  category: 'Atoms',
  children: false,        // this is what caused the problem
  variables: {
    width: {
      displayName: 'Width',
      type: 'Number',
      group: "style",
      defaultValue: 500,
    },
    height: {
      displayName: 'Height',
      type: 'Number',
      group: 'style',
      defaultValue: 500
    },
    src: {
      displayName: 'Image Source',
      type: 'Text',
      defaultValue: 'https://picsum.photos/500',
    },
    altText: {
      displayName: 'Alt Text',
      type: 'Text',
      group: 'style',
      defaultValue: 'Some alt text'
    }
  }
} as ComponentDefinition

```