### PR TITLE
style: remove padding at the bottom of editor root element [SPA-1496]

### DIFF
--- a/src/styles/VisualEditorRoot.css
+++ b/src/styles/VisualEditorRoot.css
@@ -17,5 +17,4 @@ html::-webkit-scrollbar {
 
 #VisualEditorRoot.root {
   height: 100%;
-  padding-bottom: 100px;
 }


### PR DESCRIPTION
Removes the bottom padding that is by default applied to the root element

![Screenshot 2023-10-04 at 16 43 01](https://github.com/contentful/experience-builder/assets/4171202/e68180b6-d23d-4d75-a54d-54d143125dc0)
