### PR TITLE
revert: "fix: remove padding at the bottom of editor root element in editor mode (#132)"

### DIFF
--- a/src/styles/VisualEditorRoot.css
+++ b/src/styles/VisualEditorRoot.css
@@ -17,4 +17,5 @@ html::-webkit-scrollbar {
 
 #VisualEditorRoot.root {
   height: 100%;
+  padding-bottom: 100px;
 }


### PR DESCRIPTION
Without padding it becomes harder to add the element to the bottom of the page