### PR TITLE
fix: default height for containers

### DIFF
--- a/src/blocks/VisualEditorBlock.tsx
+++ b/src/blocks/VisualEditorBlock.tsx
@@ -78,7 +78,6 @@ export const VisualEditorBlock = ({
             variableName === 'cfHeight'
               ? calculateNodeDefaultHeight({
                   blockId: node.data.blockId,
-                  parentId: node.parentId,
                   children: node.children,
                   value: valueByBreakpoint,
                 })
@@ -121,7 +120,6 @@ export const VisualEditorBlock = ({
     componentRegistration,
     node.data.props,
     node.data.blockId,
-    node.parentId,
     node.children,
     resolveDesignValue,
     dataSource,

--- a/src/core/stylesUtils.spec.ts
+++ b/src/core/stylesUtils.spec.ts
@@ -6,7 +6,6 @@ describe('calculateNodeDefaultHeight', () => {
   it('should return value when blockId is undefined', () => {
     const result = calculateNodeDefaultHeight({
       children: [],
-      parentId: 'root',
       value: '400px',
     })
 
@@ -16,7 +15,6 @@ describe('calculateNodeDefaultHeight', () => {
   it('should return value when value is not "auto"', () => {
     const result = calculateNodeDefaultHeight({
       children: [],
-      parentId: 'root',
       value: '456px',
     })
 
@@ -27,7 +25,6 @@ describe('calculateNodeDefaultHeight', () => {
     const result = calculateNodeDefaultHeight({
       blockId: 'node-block-id',
       children: [],
-      parentId: 'root',
       value: '567px',
     })
 
@@ -38,7 +35,6 @@ describe('calculateNodeDefaultHeight', () => {
     const result = calculateNodeDefaultHeight({
       blockId: CONTENTFUL_CONTAINER_ID,
       children: [],
-      parentId: 'root',
       value: 'auto',
     })
 
@@ -61,7 +57,6 @@ describe('calculateNodeDefaultHeight', () => {
     const result = calculateNodeDefaultHeight({
       blockId: CONTENTFUL_CONTAINER_ID,
       children: [childNode],
-      parentId: 'root',
       value: 'auto',
     })
 
@@ -88,28 +83,5 @@ describe('calculateNodeDefaultHeight', () => {
     })
 
     expect(result).toBe('fit-content')
-  })
-
-  it('should return "fill" if container is nested', () => {
-    const childNode: CompositionComponentNode = {
-      type: 'block',
-      data: {
-        id: 'node-1',
-        blockId: CONTENTFUL_CONTAINER_ID,
-        props: {},
-        dataSource: {},
-        unboundValues: {},
-        breakpoints: [],
-      },
-      children: [],
-    }
-
-    const result = calculateNodeDefaultHeight({
-      blockId: CONTENTFUL_CONTAINER_ID,
-      children: [childNode],
-      value: 'auto',
-    })
-
-    expect(result).toBe('fill')
   })
 })

--- a/src/core/stylesUtils.ts
+++ b/src/core/stylesUtils.ts
@@ -94,9 +94,5 @@ export const calculateNodeDefaultHeight = ({
     return 'fit-content'
   }
 
-  if (parentId !== 'root') {
-    return 'fill'
-  }
-
   return '200px'
 }

--- a/src/core/stylesUtils.ts
+++ b/src/core/stylesUtils.ts
@@ -78,12 +78,10 @@ export const buildCfStyles = ({
 export const calculateNodeDefaultHeight = ({
   blockId,
   children,
-  parentId,
   value,
 }: {
   blockId?: string
   children: CompositionComponentNode['children']
-  parentId?: string
   value: CompositionVariableValueType
 }) => {
   if (!blockId || CONTENTFUL_CONTAINER_ID !== blockId || value !== 'auto') {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 export { ExperienceRoot } from './blocks'
 export { useExperienceBuilder, getValueForBreakpoint } from './hooks'
 export { defineComponents } from './core/componentRegistry'
+export { calculateNodeDefaultHeight } from './core/stylesUtils'
 export type {
   ComponentDefinition,
   ComponentRegistration,


### PR DESCRIPTION
Currently, when you nest a container within a parent container that has an existing `non-container` child, the child container defaults to 0 px height.

This PR gives all containers a default fixed height of `200px`.