### PR TITLE
fix: global styles, text size in ErrorContainer, styles in EmptyContainers [SPA-1587]

### DIFF
--- a/src/blocks/EmptyEditorContainer.tsx
+++ b/src/blocks/EmptyEditorContainer.tsx
@@ -17,6 +17,7 @@ export const EmptyEditorContainer = ({
   return (
     <div
       id="EmptyContainer"
+      className={isDragging ? 'highlight' : undefined}
       data-type="empty-container"
       onMouseUp={() => {
         if (!isDragging) {

--- a/src/blocks/VisualEditorRoot.tsx
+++ b/src/blocks/VisualEditorRoot.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react'
 import { VisualEditorBlock } from './VisualEditorBlock'
-import { EmptyEditorContainer } from './EmptyEdtorContainer'
+import { EmptyEditorContainer } from './EmptyEditorContainer'
 
 import '../styles/VisualEditorRoot.css'
 import { useHoverIndicator } from '../hooks/useHoverIndicator'
@@ -19,7 +19,6 @@ type VisualEditorRootProps = {
 
 export const VisualEditorRoot = ({ initialLocale, mode }: VisualEditorRootProps) => {
   // in editor mode locale can change via sendMessage from web app, hence we use the locale from props only as initial locale
-
   return (
     <VisualEditorContextProvider mode={mode} initialLocale={initialLocale}>
       <VisualEditorRootComponents />

--- a/src/styles/EmptyContainer.css
+++ b/src/styles/EmptyContainer.css
@@ -7,7 +7,7 @@
   justify-content: center;
   flex-direction: row;
   color: var(--gray500);
-  font-size: var(--font-size-m);
+  font-size: var(--font-size-l);
   font-family: var(--font-stack-primary);
   border: 1px dashed var(--gray500);
 }
@@ -15,8 +15,9 @@
 #EmptyContainer.highlight {
   border: 1px dashed var(--blue500);
   background-color: var(--blue100);
+  cursor: grabbing;
 }
 
-#EmptyContainer.icon {
+#EmptyContainer .icon {
   margin-left: var(--spacing-s);
 }

--- a/src/styles/variables.css
+++ b/src/styles/variables.css
@@ -1,3 +1,9 @@
+/*
+ * All of these variables are tokens from Forma-36 and may not be adjusted as these
+ * are global variables that may affect different places.
+ * Forma-36 tokens: https://f36.contentful.com/tokens/color-system
+ */
+
 :root {
   /* color */
   --blue100: #e8f5ff;
@@ -29,7 +35,7 @@
 
   /* typography */
   --font-size-l: 1rem;
-  --font-size-m: 1.475rem;
+  --font-size-m: 0.875rem;
   --font-stack-primary: -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif,
     Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol;
   --line-height-condensed: 1.25;


### PR DESCRIPTION
# Problem
Since we’re not using any CSS library but just adding global variables, we affect other UI elements in the web app when changing our CSS variables internally. Even when the SDK is not used for rendering, the CSS is registered.

We [recently changed](https://github.com/contentful/experience-builder/pull/137/files#) the `--font-size-m` variable to make the message on the empty canvas bigger. As we still used the same variable name, this affected any other place using those global Forma-36 variables as well. Since we use the same variables in the Osana cookie banner styles tag, they get overwritten by our definitions.

# Approach
- Revert the value of the global variables
- Further, adjust the styles of the EmptyEditorContainer to align with the Figma designs
- Fix typo in file name

# Screenshots

## EmptyEditorContainer
<img width="1067" alt="Screenshot 2023-10-25 at 11 52 01" src="https://github.com/contentful/experience-builder/assets/9327071/ecd2fbdc-f4c3-4acc-b2b6-3687a1d81c1b">

## ErrorContainer
<img width="1066" alt="Screenshot 2023-10-25 at 11 54 16" src="https://github.com/contentful/experience-builder/assets/9327071/5d15e3b6-a6e6-4997-b23f-c9d782c6e46f">
