### PR TITLE
fix: container default sizing height to fit all children []

### DIFF
--- a/packages/experience-builder-sdk/src/core/stylesUtils.spec.ts
+++ b/packages/experience-builder-sdk/src/core/stylesUtils.spec.ts
@@ -41,28 +41,6 @@ describe('calculateNodeDefaultHeight', () => {
     expect(result).toBe('200px')
   })
 
-  it('should return defaultValue of "200px" when container is on "root" and has only container children', () => {
-    const childNode: CompositionComponentNode = {
-      type: 'block',
-      data: {
-        id: 'node-1',
-        blockId: CONTENTFUL_CONTAINER_ID,
-        props: {},
-        dataSource: {},
-        unboundValues: {},
-        breakpoints: [],
-      },
-      children: [],
-    }
-    const result = calculateNodeDefaultHeight({
-      blockId: CONTENTFUL_CONTAINER_ID,
-      children: [childNode],
-      value: 'auto',
-    })
-
-    expect(result).toBe('200px')
-  })
-
   it('should return "fit-content" when container has a non-container child', () => {
     const childNode: CompositionComponentNode = {
       type: 'block',

--- a/packages/experience-builder-sdk/src/core/stylesUtils.ts
+++ b/packages/experience-builder-sdk/src/core/stylesUtils.ts
@@ -89,7 +89,7 @@ export const calculateNodeDefaultHeight = ({
     return value
   }
 
-  if (!children.every((child) => child.data.blockId === CONTENTFUL_CONTAINER_ID)) {
+  if (children.length) {
     return 'fit-content'
   }
 

--- a/packages/experience-builder-sdk/src/core/stylesUtils.ts
+++ b/packages/experience-builder-sdk/src/core/stylesUtils.ts
@@ -72,9 +72,8 @@ export const buildCfStyles = ({
 }
 /**
  * Container/section default behaviour:
- * If the container is dropped on root => height: '200px'
- * If the container is nested in another container => height: 'fill'
- * If a non-container component is nested in a container => height: 'fit-content'
+ * Default height => height: '200px'
+ * If a container component has children => height: 'fit-content'
  */
 export const calculateNodeDefaultHeight = ({
   blockId,


### PR DESCRIPTION
**Previous default behavior**
When a parent container has all container children, we leave the parent container's default height as 200px. The side effect of this is that if the nested container height is more than 200px, the parent doesn't expand to fit the child - which is not a great default behavior 

**After this change**
We fit the content if a parent container has children, regardless of whether it's container or non-container children. 