### PR TITLE
feat: [] send also the margins with the coordinates

### DIFF
--- a/packages/experience-builder-sdk/src/communication/MouseOverHandler.ts
+++ b/packages/experience-builder-sdk/src/communication/MouseOverHandler.ts
@@ -5,17 +5,28 @@ import { sendMessage } from './sendMessage';
 export class MouseOverHandler {
   private currentHoveredElementId: string | null = null;
 
+  private getMargins = (element: HTMLElement) => {
+    const styles = window.getComputedStyle(element);
+    const top = parseInt(styles.marginTop);
+    const bottom = parseInt(styles.marginBottom);
+    const left = parseInt(styles.marginLeft);
+    const right = parseInt(styles.marginRight);
+
+    return { top, bottom, left, right };
+  };
+
   private getFullCoordinates = (element: HTMLElement) => {
     const validChildren = Array.from(element.children).filter(
       (child) => child instanceof HTMLElement && child.dataset.cfNodeBlockType === 'block'
     );
 
     const { left, top, width, height } = element.getBoundingClientRect();
+    const margins = this.getMargins(element);
 
     const childrenCoordinates = validChildren.map((child) => {
       const { left, top, width, height } = child.getBoundingClientRect();
 
-      return { left, top, width, height };
+      return { left, top, width, height, margins };
     });
 
     return {
@@ -23,6 +34,7 @@ export class MouseOverHandler {
       top,
       width,
       height,
+      margins,
       childrenCoordinates,
     };
   };


### PR DESCRIPTION
To calcuate the dnd indicator also respecting the margins of the element, we need to also send the marings with every element. 

There will be a matching PR on the other side to support this.