### PR TITLE
Fix: selected component jumps around on scroll [ALT-62]

### DIFF
--- a/packages/experience-builder-sdk/src/hooks/useSelectedInstanceCoordinates.ts
+++ b/packages/experience-builder-sdk/src/hooks/useSelectedInstanceCoordinates.ts
@@ -17,5 +17,5 @@ export const useSelectedInstanceCoordinates = ({ node }: { node: CompositionComp
     }
 
     sendSelectedComponentCoordinates(node.data.id);
-  }, [node, selectedNodeId]);
+  }, [node]);
 };

--- a/packages/experience-builder-types/src/constants.ts
+++ b/packages/experience-builder-types/src/constants.ts
@@ -26,7 +26,6 @@ export const INCOMING_EVENTS = {
   RequestEditorMode: 'requestEditorMode',
   CompositionUpdated: 'componentTreeUpdated',
   ComponentDraggingChanged: 'componentDraggingChanged',
-  SelectedComponentChanged: 'selectedComponentChanged',
   CanvasResized: 'canvasResized',
   SelectComponent: 'selectComponent',
   HoverComponent: 'hoverComponent',


### PR DESCRIPTION
The canvas interaction tooltip was jumping around to previous selected components when scrolling the page. It turns out this was due to the onScroll listener being registered multiple times - one for each time the selected node changed.
In order to avoid this I am switching the selected node to be Ref which won't trigger the useEffect to rerun on change, but it will still have the latest value when the listener runs.
See also this SO question: https://stackoverflow.com/questions/55565444/how-to-register-event-with-useeffect-hooks

#### Before

https://github.com/contentful/experience-builder/assets/2773012/2ba384d5-ed1a-4dc8-b6c3-adf023dba865


#### After

https://github.com/contentful/experience-builder/assets/2773012/a1673f8f-25de-4715-911a-3df6ab916872


