### PR TITLE
fix: correctly retrieve the url from the bound asset in preview/delivery []

### DIFF
--- a/packages/experience-builder-sdk/src/core/EntityStore.spec.ts
+++ b/packages/experience-builder-sdk/src/core/EntityStore.spec.ts
@@ -1,4 +1,4 @@
-import type { Entry } from 'contentful';
+import type { Asset, Entry } from 'contentful';
 
 import { entities, entityIds, entries } from '../../test/__fixtures__/entities';
 import { compositionEntry } from '../../test/__fixtures__/composition';
@@ -127,6 +127,35 @@ describe('EntityStore', () => {
           'title',
         ])
       ).toBeUndefined();
+    });
+
+    it('should url if given path to the asset file and entityType is Asset', () => {
+      const store = new EntityStore({
+        experienceEntry: compositionEntry as unknown as Entry,
+        entities: [
+          {
+            sys: {
+              id: 'assetId',
+              type: 'Asset',
+            },
+            fields: {
+              title: 'assetTitle',
+              file: {
+                url: 'assetFileUrl',
+                description: 'assetFileDescription',
+              },
+            },
+          } as unknown as Asset,
+        ],
+        locale,
+      });
+
+      expect(
+        store.getValue({ sys: { id: 'assetId', linkType: 'Asset', type: 'Link' } }, [
+          'fields',
+          'file',
+        ])
+      ).toBe('assetFileUrl');
     });
   });
 });

--- a/packages/experience-builder-sdk/src/core/EntityStore.ts
+++ b/packages/experience-builder-sdk/src/core/EntityStore.ts
@@ -41,7 +41,7 @@ export class EntityStore extends VisualSdkEntityStore {
     return this._experienceEntry?.unboundValues ?? {};
   }
 
-  public getFieldValue(
+  public getValue(
     entityLink: UnresolvedLink<'Entry' | 'Asset'>,
     path: string[]
   ): string | undefined {


### PR DESCRIPTION
Once migrating our gatsby project to SSG, I noticed failed builds, where a `url` prop of an `Image` component received the following:
```tsx
{
   url: "//images.ctfassets.net/fo9twyrwpveg/20xNXuZXY4wPsT3drodPvG/5d98ed2b7dd2da55def5862dc4b2444c/illu_3__1_.svg",
   details: { size: 34927, image: { width: 80, height: 80 } },
   fileName: "illu 3 (1).svg",
   contentType: "image/svg+xml"
}
```
Instead of a plain string.

So I investigated and found out that in preview and delivery mode, we [are calling `getValue` function](https://github.com/contentful/experience-builder/blob/main/packages/experience-builder-sdk/src/blocks/CompositionBlock.tsx#L62) of the entityStore, which is defined in base class and doesn't have the [fallback for handling bound assets](https://github.com/contentful/experience-builder/blob/main/packages/experience-builder-sdk/src/core/EntityStore.ts#L58-L60).

So, I created this PR to fix it.