### PR TITLE
fix: minor change to empty container font color [ALT-59]

### DIFF
--- a/packages/experience-builder-sdk/src/styles/EmptyContainer.css
+++ b/packages/experience-builder-sdk/src/styles/EmptyContainer.css
@@ -6,7 +6,7 @@
   align-items: center;
   justify-content: center;
   flex-direction: row;
-  color: var(--exp-builder-gray500);
+  color: var(--exp-builder-gray400);
   font-size: var(--exp-builder-font-size-l);
   font-family: var(--exp-builder-font-stack-primary);
   border: 1px dashed var(--exp-builder-gray500);


### PR DESCRIPTION
Minor font color change to the Empty Container.

Before:
![Screenshot 2023-11-06 at 11 20 04 AM](https://github.com/contentful/experience-builder/assets/8539634/d22368be-f211-4dd8-9d7c-14db478e70f4)

After:
![Screenshot 2023-11-06 at 11 09 17 AM](https://github.com/contentful/experience-builder/assets/8539634/f708becf-ca9b-49fd-91e1-918ca29af846)
