### PR TITLE
fix: empty container highlight on hover [ALT-60]

### DIFF
--- a/packages/experience-builder-sdk/src/styles/EmptyContainer.css
+++ b/packages/experience-builder-sdk/src/styles/EmptyContainer.css
@@ -12,7 +12,7 @@
   border: 1px dashed var(--exp-builder-gray500);
 }
 
-#EmptyContainer.highlight {
+#EmptyContainer.highlight:hover {
   border: 1px dashed var(--exp-builder-blue500);
   background-color: var(--exp-builder-blue100);
   cursor: grabbing;


### PR DESCRIPTION
Minor change to apply the highlight styles when a dragged component is hovering over the Empty Container, to give visual feedback to the user that the component can be dropped/inserted.

(Previously the blue highlight styles were shown when a component is active/dragged)

Dragged component not hovering:
![Screenshot 2023-11-06 at 5 02 46 PM](https://github.com/contentful/experience-builder/assets/8539634/11e6b515-de90-4b0e-8118-218c7ee557f3)

Dragged component is hovering:
![Screenshot 2023-11-06 at 5 03 06 PM](https://github.com/contentful/experience-builder/assets/8539634/647e0b43-0160-4779-a1f7-35877bce9fe5)
