### PR TITLE
fix(experience-builder-sdk): update rollup config to not include react in build []

### DIFF
--- a/packages/experience-builder-sdk/package.json
+++ b/packages/experience-builder-sdk/package.json
@@ -54,6 +54,7 @@
     "jsdom": "^21.1.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "rollup-plugin-peer-deps-external": "^2.2.4",
     "semantic-release": "19.0.5",
     "ts-jest": "^29.1.0",
     "typescript": "^5.2.2",

--- a/packages/experience-builder-sdk/vite.config.ts
+++ b/packages/experience-builder-sdk/vite.config.ts
@@ -4,6 +4,8 @@ import { resolve } from 'path';
 import { defineConfig } from 'vite';
 import dts from 'vite-plugin-dts';
 import svgr from 'vite-plugin-svgr';
+//@ts-ignore
+import peerDepsExternal from 'rollup-plugin-peer-deps-external';
 
 export default defineConfig({
   build: {
@@ -16,7 +18,8 @@ export default defineConfig({
       formats: ['cjs', 'es'],
     },
     rollupOptions: {
-      external: ['react'],
+      plugins: [peerDepsExternal()],
+      external: ['react', 'react-dom'],
       output: {
         globals: {
           react: 'React',

--- a/yarn.lock
+++ b/yarn.lock
@@ -9831,6 +9831,11 @@ rimraf@^4.4.1:
   dependencies:
     glob "^9.2.0"
 
+rollup-plugin-peer-deps-external@^2.2.4:
+  version "2.2.4"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-peer-deps-external/-/rollup-plugin-peer-deps-external-2.2.4.tgz#8a420bbfd6dccc30aeb68c9bf57011f2f109570d"
+  integrity sha512-AWdukIM1+k5JDdAqV/Cxd+nejvno2FVLVeZ74NKggm3Q5s9cbbcOgUPGdbxPi4BXu7xGaZ8HG12F+thImYu/0g==
+
 rollup@^3.21.0:
   version "3.24.0"
   resolved "https://registry.npmjs.org/rollup/-/rollup-3.24.0.tgz"


### PR DESCRIPTION
Currently, React is included in the production build, which could cause issues and increases the size of the built bundle. This update adds the rollup-plugin-peer-deps-external package and updates the Vite config to use it. This will exclude any external libraries marked as external peer deps. This drops the bundle size from 167KB to 89KB.