### PR TITLE
fix(experience-builder-sdk): export ExternalSDKMode type []

### DIFF
--- a/packages/experience-builder-sdk/src/index.ts
+++ b/packages/experience-builder-sdk/src/index.ts
@@ -5,6 +5,7 @@ export { calculateNodeDefaultHeight } from './core/stylesUtils';
 export type {
   ComponentDefinition,
   ComponentRegistration,
+  EntityStore,
   Experience,
   ExternalSDKMode,
   DeprecatedExperience,

--- a/packages/experience-builder-sdk/src/index.ts
+++ b/packages/experience-builder-sdk/src/index.ts
@@ -6,6 +6,7 @@ export type {
   ComponentDefinition,
   ComponentRegistration,
   Experience,
+  ExternalSDKMode,
   DeprecatedExperience,
   ComponentDefinitionVariable,
   ComponentDefinitionVariableType,

--- a/packages/experience-builder-sdk/src/types.ts
+++ b/packages/experience-builder-sdk/src/types.ts
@@ -1,1 +1,2 @@
 export * from '@contentful/experience-builder-types/dist/types';
+export { EntityStore } from '@contentful/visual-sdk';


### PR DESCRIPTION
Exports the ExternalSDKMode from the main types entry point. This appeared to be accidentally missing.