### PR TITLE
chore: support unbound and bound values in variable definitions [SPA-1639]

### DIFF
--- a/packages/experience-builder-types/src/types.ts
+++ b/packages/experience-builder-types/src/types.ts
@@ -133,7 +133,11 @@ export type BindingMapByBlockId = Record<string, BindingMap>;
 export type DataSourceEntryValueType = Link<'Entry' | 'Asset'>;
 
 export type CompositionVariableValueType = string | boolean | number | Record<any, any> | undefined;
-type CompositionComponentPropType = 'BoundValue' | 'UnboundValue' | 'DesignValue';
+type CompositionComponentPropType =
+  | 'BoundValue'
+  | 'UnboundValue'
+  | 'DesignValue'
+  | 'ComponentValue';
 
 export type CompositionComponentPropValue<
   T extends CompositionComponentPropType = CompositionComponentPropType
@@ -228,11 +232,11 @@ export type Breakpoint = {
 export type SchemaVersions = '2023-09-28' | '2023-06-27' | '2023-07-26' | '2023-08-23';
 
 export type ExperienceComponentSettings = {
-  // Later these definitions will be a bit different from developer components as
-  // they will support bound/ unbound values as default values.
   variableDefinitions: Record<
     string,
-    ComponentDefinitionVariableBase<ComponentDefinitionVariableType>
+    Omit<ComponentDefinitionVariableBase<ComponentDefinitionVariableType>, 'defaultValue'> & {
+      defaultValue: CompositionComponentPropValue<'BoundValue' | 'UnboundValue'>;
+    }
   >;
 };
 


### PR DESCRIPTION
 Support unbound and bound values in variable definitions types