### PR TITLE
fix: dont show warning about alien message, don't render invalid attributes []

### DIFF
--- a/packages/experience-builder-sdk/package.json
+++ b/packages/experience-builder-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contentful/experience-builder",
-  "version": "2.11.0-alpha-21",
+  "version": "2.11.0",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "typings": "./dist/src/index.d.ts",

--- a/packages/experience-builder-sdk/package.json
+++ b/packages/experience-builder-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contentful/experience-builder",
-  "version": "2.11.0",
+  "version": "2.11.0-alpha-21",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "typings": "./dist/src/index.d.ts",

--- a/packages/experience-builder-sdk/src/blocks/editor/VisualEditorBlock.tsx
+++ b/packages/experience-builder-sdk/src/blocks/editor/VisualEditorBlock.tsx
@@ -87,7 +87,8 @@ export const VisualEditorBlock = ({
   useSelectedInstanceCoordinates({ node });
 
   const props: PropsType = useMemo(() => {
-    if (!componentRegistration) {
+    // Don't enrich the design component wrapper node with props
+    if (!componentRegistration || node.type === DESIGN_COMPONENT_NODE_TYPE) {
       return {};
     }
 

--- a/packages/experience-builder-sdk/src/blocks/editor/VisualEditorContext.tsx
+++ b/packages/experience-builder-sdk/src/blocks/editor/VisualEditorContext.tsx
@@ -25,6 +25,7 @@ import { getDataFromTree } from '../../utils/utils';
 import { doesMismatchMessageSchema, tryParseMessage } from '../../utils/validation';
 import { Entry } from 'contentful';
 import { DesignComponent } from '../../components/DesignComponent';
+import { PostMessageMethods } from '@contentful/visual-sdk';
 
 type VisualEditorContextType = {
   tree: CompositionTree | undefined;
@@ -152,6 +153,10 @@ export function VisualEditorContextProvider({
       }
 
       const eventData = tryParseMessage(event);
+      if (eventData.eventType === PostMessageMethods.REQUESTED_ENTITIES) {
+        // Expected message: This message is handled in the visual-sdk to store fetched entities
+        return;
+      }
 
       console.debug(
         `[exp-builder.sdk::onMessage] Received message [${eventData.eventType}]`,

--- a/packages/experience-builder-sdk/src/blocks/preview/CompositionBlock.tsx
+++ b/packages/experience-builder-sdk/src/blocks/preview/CompositionBlock.tsx
@@ -79,7 +79,8 @@ export const CompositionBlock = ({
   }, [isDesignComponent, node.definitionId]);
 
   const nodeProps = useMemo(() => {
-    if (!componentRegistration) {
+    // Don't enrich the design component wrapper node with props
+    if (!componentRegistration || isDesignComponent) {
       return {};
     }
 
@@ -115,6 +116,7 @@ export const CompositionBlock = ({
     }, propMap);
   }, [
     componentRegistration,
+    isDesignComponent,
     node.variables,
     resolveDesignValue,
     dataSource,

--- a/packages/experience-builder-sdk/src/core/editor/designComponentUtils.ts
+++ b/packages/experience-builder-sdk/src/core/editor/designComponentUtils.ts
@@ -96,6 +96,7 @@ export const resolveDesignComponent = ({
   const designComponent = designComponentsRegistry.get(componentId);
 
   if (!designComponent) {
+    console.warn(`Link to design component with ID '${componentId}' not found`);
     return node;
   }
 
@@ -104,6 +105,7 @@ export const resolveDesignComponent = ({
   ]) as unknown as Composition;
 
   if (!componentFields) {
+    console.warn(`Entry for design component with ID '${componentId}' not found`);
     return node;
   }
 

--- a/packages/experience-builder-sdk/src/utils/validation.ts
+++ b/packages/experience-builder-sdk/src/utils/validation.ts
@@ -1,6 +1,7 @@
 import { supportedModes } from '../constants';
 import { InternalSDKMode, IncomingEvent } from '../types';
 import { INCOMING_EVENTS } from '../constants';
+import { PostMessageMethods } from '@contentful/visual-sdk';
 
 export type VisualEditorMessagePayload = {
   source: string;
@@ -65,11 +66,14 @@ export const tryParseMessage = (event: MessageEvent): VisualEditorMessagePayload
   // check eventData.eventType
   const supportedEventTypes = Object.values(INCOMING_EVENTS);
   if (!supportedEventTypes.includes(eventData.eventType)) {
-    throw new ParseError(
-      `Field eventData.eventType must be one of the supported values: [${supportedEventTypes.join(
-        ', '
-      )}]`
-    );
+    // Expected message: This message is handled in the visual-sdk to store fetched entities
+    if (eventData.eventType !== PostMessageMethods.REQUESTED_ENTITIES) {
+      throw new ParseError(
+        `Field eventData.eventType must be one of the supported values: [${supportedEventTypes.join(
+          ', '
+        )}]`
+      );
+    }
   }
 
   return eventData;


### PR DESCRIPTION
1. Don't pass any custom `props` to the rendered `div` as it will basically render HTML attributes like `text_randomUUID=[ Object object ]`
2. When the visual SDK receives the `REQUESTED_ENTITIES`, don't log a warning about an unexpected message.


How the DOM looked before this PR:
![Screenshot 2023-11-28 at 11 11 51](https://github.com/contentful/experience-builder/assets/9327071/560c397f-93e7-420b-a064-570586d6c427)
