### PR TITLE
[ALT-148] Allows user defined styling layout through Component Definition injection at the root level

### DIFF
--- a/packages/experience-builder-sdk/src/core/designTokenRegistry.ts
+++ b/packages/experience-builder-sdk/src/core/designTokenRegistry.ts
@@ -1,0 +1,14 @@
+import { OUTGOING_EVENTS } from '../constants';
+import { sendMessage } from '../communication/sendMessage';
+import { DesignTokensDefinition } from '../types';
+
+/**
+ * Register design tokens styling
+ * @param designTokenDefinition - {[key:string]: Record<string, string>}
+ * @returns void
+ */
+export const defineDesignTokens = (designTokenDefinition: DesignTokensDefinition) => {
+  sendMessage(OUTGOING_EVENTS.DesignTokens, {
+    designTokens: designTokenDefinition,
+  });
+};

--- a/packages/experience-builder-sdk/src/index.ts
+++ b/packages/experience-builder-sdk/src/index.ts
@@ -1,6 +1,7 @@
 export { ExperienceRoot } from './ExperienceRoot';
 export { useExperienceBuilder, getValueForBreakpoint, useFetchExperience } from './hooks';
 export { defineComponents } from './core/componentRegistry';
+export { defineDesignTokens } from './core/designTokenRegistry';
 export { calculateNodeDefaultHeight } from './utils/stylesUtils';
 export { checkIfDesignComponent } from './utils/utils';
 export type {

--- a/packages/experience-builder-types/src/constants.ts
+++ b/packages/experience-builder-types/src/constants.ts
@@ -12,6 +12,7 @@ export const OUTGOING_EVENTS = {
   NewHoveredElement: 'newHoveredElement',
   ComponentSelected: 'componentSelected',
   RegisteredComponents: 'registeredComponents',
+  DesignTokens: 'registerDesignTokens',
   RequestComponentTreeUpdate: 'requestComponentTreeUpdate',
   ComponentDropped: 'componentDropped',
   CanvasReload: 'canvasReload',

--- a/packages/experience-builder-types/src/types.ts
+++ b/packages/experience-builder-types/src/types.ts
@@ -254,6 +254,8 @@ export type Composition = {
   componentSettings?: ExperienceComponentSettings;
 };
 
+export type DesignTokensDefinition = { [key: string]: Record<string, string> };
+
 export type ExperienceEntry = {
   sys: Entry['sys'];
   fields: Composition;


### PR DESCRIPTION
This PR allows the user to define their layoutDefinition for the layout sidebar as follows below.
Here's the user_interface associated PR that shows the UI and the mechanics of how it would work https://github.com/contentful/user_interface/pull/18533

```
export const buttonDefinition: ComponentDefinition = {
  id: 'ryuns-button',
  name: 'ryuns-button',
  category: 'buttons',
  **designTokensDefinition: {
    spacing: { XS: '0px', S: '16px', M: '32px', L: '64px' },
  },**
  // thumbnailUrl: string | undefined;
  variables: {
    buttonTitle: {
      type: 'Text',
      displayName: 'Button Title',
      defaultValue: 'Click Me'
    },
    marginValues: {
      type: 'Text',
      displayName: 'Margin Values',
      defaultValue: ['0px', '16px', '32px', '64px']
    }
  },
  builtInStyles: ["cfHorizontalAlignment", "cfVerticalAlignment", "cfMargin", "cfPadding", "cfBackgroundImageAlignment",
    "cfBackgroundColor", "cfWidth", "cfHeight", 'cfMaxWidth', 'cfFlexDirection', 'cfFlexWrap', 'cfBorder',
    'cfGap', 'cfBackgroundImageUrl', 'cfBackgroundImageScaling', 'cfBackgroundImageAlignment'
  ]
  // children?: boolean | undefined,
}
```