### PR TITLE
fix(experience-builder-types): extend variables type on component definition [ALT-57]

### DIFF
--- a/packages/experience-builder-types/src/types.ts
+++ b/packages/experience-builder-types/src/types.ts
@@ -109,7 +109,8 @@ export type ComponentDefinition<
   name: string;
   category?: string;
   thumbnailUrl?: string;
-  variables: Record<string, ComponentDefinitionVariable<T>>;
+  variables: Partial<Record<ContainerStyleVariableName, ComponentDefinitionVariable<T>>> &
+    Record<string, ComponentDefinitionVariable<T>>;
   builtInStyles?: Array<keyof Omit<StyleProps, 'cfHyperlink' | 'cfOpenInNewTab'>>;
   children?: boolean;
 };


### PR DESCRIPTION
Suggested by @chasepoirier, this changes the type for `variables` in the Component Definition object to include hints for the keys of built in style variables.

![](https://github.com/contentful/experience-builder/assets/8539634/dcd856d9-80ca-48ca-afad-88b3dd848e50)

Users can set default values for the built in styles we provide so this extended type can help inform the variable names for styles we provide.

```diff
   variables: {
+    cfPadding: {
+      displayName: 'Padding',
+      type: 'Text',
+      group: 'style',
+      defaultValue: '0px 10px 0px 10px',
+    },
```