### PR TITLE
refactor: generalize the DesignTokenDefinition type [ALT-137]

### DIFF
--- a/packages/experience-builder-types/src/types.ts
+++ b/packages/experience-builder-types/src/types.ts
@@ -260,7 +260,7 @@ export type Composition = {
   componentSettings?: ExperienceComponentSettings;
 };
 
-export type DesignTokensDefinition = { [key: string]: Record<string, string> };
+export type DesignTokensDefinition = { [key: string]: string | DesignTokensDefinition };
 
 export type ExperienceEntry = {
   sys: Entry['sys'];


### PR DESCRIPTION
This is needed because of how we want to represent borders for design token since they consist of the name, size, and color. Basically it's the same [name] -> [value] convention except the value in this case has multiple values, thus requires to be represented by an object.

```
  border: {
    "Hero": { size: '2px', color: "#ff0000", },
    "Card": { size: '4px', color: "#00ff00", }
  }

```