### PR TITLE
fix: replace component values with actual onces before rendering []

### DIFF
--- a/packages/experience-builder-sdk/src/blocks/editor/VisualEditorBlock.test.tsx
+++ b/packages/experience-builder-sdk/src/blocks/editor/VisualEditorBlock.test.tsx
@@ -15,7 +15,7 @@ import { VisualEditorBlock } from './VisualEditorBlock';
 import {
   createDesignComponentEntry,
   designComponentGeneratedVariableName,
-} from '../../../test/__fixtures__/composition';
+} from '../../../test/__fixtures__/designComponent';
 import { EditorModeEntityStore } from '../../core/editor/EditorModeEntityStore';
 import { assets } from '../../../test/__fixtures__/entities';
 import { Asset, Entry } from 'contentful';

--- a/packages/experience-builder-sdk/src/blocks/editor/VisualEditorBlock.tsx
+++ b/packages/experience-builder-sdk/src/blocks/editor/VisualEditorBlock.tsx
@@ -149,18 +149,6 @@ export const VisualEditorBlock = ({
             ...acc,
             [variableName]: transformContentValue(value, variableDefinition),
           };
-        } else if (variableMapping.type === 'ComponentValue') {
-          // For design component, we are only handling binding for UnboundValues for now
-          const value = getUnboundValues({
-            key: variableMapping.key,
-            fallback: variableDefinition.defaultValue,
-            unboundValues: node.data.unboundValues || {},
-          });
-
-          return {
-            ...acc,
-            [variableName]: value,
-          };
         } else {
           const value = getUnboundValues({
             key: variableMapping.key,
@@ -178,9 +166,9 @@ export const VisualEditorBlock = ({
     );
   }, [
     componentRegistration,
+    node.type,
     node.data.props,
     node.data.blockId,
-    node.data.unboundValues,
     node.children,
     resolveDesignValue,
     dataSource,

--- a/packages/experience-builder-sdk/src/blocks/editor/VisualEditorContext.tsx
+++ b/packages/experience-builder-sdk/src/blocks/editor/VisualEditorContext.tsx
@@ -212,21 +212,20 @@ export function VisualEditorContextProvider({
             designComponentDefinition,
           }: {
             designComponent: Entry;
-            designComponentDefinition: ComponentRegistration['definition'];
+            designComponentDefinition?: ComponentRegistration['definition'];
           } = payload;
-          if (designComponent) {
-            entityStore.current.updateEntity(designComponent);
-            // Using a Map here to avoid setting state and rerending all existing design components when a new design component is added
-            // TODO: Figure out if we can extend this love to data source and unbound values. Maybe that'll solve the blink
-            // of all bound and unbound values when new values are added
-            designComponentsRegistry.set(designComponent.sys.id, {
-              sys: { id: designComponent.sys.id, linkType: 'Entry', type: 'Link' },
-            } as Link<'Entry'>);
-            designComponentDefinition &&
-              addComponentRegistration({
-                component: DesignComponent,
-                definition: designComponentDefinition,
-              });
+          entityStore.current.updateEntity(designComponent);
+          // Using a Map here to avoid setting state and rerending all existing design components when a new design component is added
+          // TODO: Figure out if we can extend this love to data source and unbound values. Maybe that'll solve the blink
+          // of all bound and unbound values when new values are added
+          designComponentsRegistry.set(designComponent.sys.id, {
+            sys: { id: designComponent.sys.id, linkType: 'Entry', type: 'Link' },
+          } as Link<'Entry'>);
+          if (designComponentDefinition) {
+            addComponentRegistration({
+              component: DesignComponent,
+              definition: designComponentDefinition,
+            });
           }
           break;
         }

--- a/packages/experience-builder-sdk/src/blocks/preview/CompositionBlock.spec.tsx
+++ b/packages/experience-builder-sdk/src/blocks/preview/CompositionBlock.spec.tsx
@@ -7,11 +7,11 @@ import { defineComponents, resetComponentRegistry } from '../../core/componentRe
 import { CompositionNode, ExperienceEntry } from '../../types';
 import { CompositionBlock } from './CompositionBlock';
 import type { Entry } from 'contentful';
+import { compositionEntry } from '../../../test/__fixtures__/composition';
 import {
-  compositionEntry,
   createDesignComponentEntry,
   designComponentGeneratedVariableName,
-} from '../../../test/__fixtures__/composition';
+} from '../../../test/__fixtures__/designComponent';
 import { EntityStore } from '../../core/preview/EntityStore';
 import { assets, entries } from '../../../test/__fixtures__/entities';
 

--- a/packages/experience-builder-sdk/src/core/editor/designComponentUtils.spec.ts
+++ b/packages/experience-builder-sdk/src/core/editor/designComponentUtils.spec.ts
@@ -1,8 +1,9 @@
 import { Asset, Entry } from 'contentful';
 import {
   createDesignComponentEntry,
+  createDesignComponentNode,
   designComponentGeneratedVariableName,
-} from '../../../test/__fixtures__/composition';
+} from '../../../test/__fixtures__/designComponent';
 import { assets } from '../../../test/__fixtures__/entities';
 import { designComponentsRegistry } from '../../blocks/editor/VisualEditorContext';
 import { DESIGN_COMPONENT_BLOCK_NODE_TYPE, DESIGN_COMPONENT_NODE_TYPE } from '../../constants';
@@ -48,6 +49,7 @@ describe('deserializeDesignComponentNode', () => {
       componentInstanceUnboundValues: {
         unbound_uuid1Experience: { value: 'New year Eve' },
       },
+      componentInstanceDataSource: {},
     });
 
     expect(result).toEqual({
@@ -80,10 +82,10 @@ describe('deserializeDesignComponentNode', () => {
               data: {
                 blockId: 'custom-component',
                 id: expect.any(String),
-                props: { text: { key: 'text_uuid1DesignComponent', type: 'ComponentValue' } },
+                props: { text: { key: 'unbound_uuid1Experience', type: 'UnboundValue' } },
                 dataSource: {},
                 unboundValues: {
-                  text_uuid1DesignComponent: {
+                  unbound_uuid1Experience: {
                     value: 'New year Eve',
                   },
                 },
@@ -152,6 +154,7 @@ describe('resolveDesignComponent', () => {
 
     const entityStore = null;
 
+    // Throws warning "Entry for design component with ID 'design-component-id' not found"
     const result = resolveDesignComponent({ node, entityStore });
 
     expect(result).toEqual(node);
@@ -197,32 +200,20 @@ describe('resolveDesignComponent', () => {
 
     const entityStore = null;
 
+    // Throws warning "Entry for design component with ID 'design-component-id' not found"
     const result = resolveDesignComponent({ node, entityStore });
 
     expect(result).toEqual(node);
   });
 
-  it('should return a deserialized design component node with unboundValues and props', () => {
-    const node: CompositionComponentNode = {
-      type: DESIGN_COMPONENT_NODE_TYPE,
-      data: {
-        blockId: 'design-component-id',
-        id: 'random-node-id',
-        props: {
-          [designComponentGeneratedVariableName]: {
-            type: 'UnboundValue',
-            key: 'unbound_uuid1Experience',
-          },
-        },
-        dataSource: {},
-        unboundValues: {
-          unbound_uuid1Experience: { value: 'New year Eve' },
-        },
-        breakpoints: [],
-      },
-      children: [],
-      parentId: 'root',
-    };
+  // TODO: This tests is basically a plain snapshot test and missing specific assertions.
+  // Also it is testing almost completley the same as above for `deserializeDesignComponentNode`.
+  it('returns a deserialized design component node with unboundValues and props', () => {
+    const node = createDesignComponentNode({
+      id: 'random-node-id',
+      unboundValueKey: 'unbound_uuid1Experience',
+      unboundValue: 'New year Eve',
+    });
 
     const entityStore = new EditorModeEntityStore({
       entities: [designComponentEntry, ...assets] as Array<Entry | Asset>,
@@ -264,13 +255,13 @@ describe('resolveDesignComponent', () => {
                 id: expect.any(String),
                 props: {
                   text: {
-                    key: designComponentGeneratedVariableName,
-                    type: 'ComponentValue',
+                    key: 'unbound_uuid1Experience',
+                    type: 'UnboundValue',
                   },
                 },
                 dataSource: {},
                 unboundValues: {
-                  [designComponentGeneratedVariableName]: {
+                  unbound_uuid1Experience: {
                     value: 'New year Eve',
                   },
                 },
@@ -281,6 +272,34 @@ describe('resolveDesignComponent', () => {
           ],
         },
       ],
+    });
+  });
+
+  it('returns a deserialized design component node with a bound value', () => {
+    const node = createDesignComponentNode({
+      id: 'random-node-id',
+      boundValueKey: 'bound_uuid1Experience',
+    });
+
+    const entityStore = new EditorModeEntityStore({
+      entities: [designComponentEntry, ...assets] as Array<Entry | Asset>,
+      locale: 'en-US',
+    });
+
+    const result = resolveDesignComponent({ node, entityStore });
+
+    expect(result).not.toEqual(node);
+    expect(result.children[0].children[0].data.props.text).toEqual({
+      type: 'BoundValue',
+      path: '/bound_uuid1Experience/fields/someFieldId/~locale',
+    });
+    expect(result.children[0].children[0].data.unboundValues).toEqual({});
+    expect(result.children[0].children[0].data.dataSource['bound_uuid1Experience']).toEqual({
+      sys: {
+        type: 'Link',
+        linkType: 'Entry',
+        id: 'someEntryId',
+      },
     });
   });
 });

--- a/packages/experience-builder-sdk/src/core/editor/designComponentUtils.ts
+++ b/packages/experience-builder-sdk/src/core/editor/designComponentUtils.ts
@@ -19,6 +19,7 @@ export const deserializeDesignComponentNode = ({
   designComponentUnboundValues,
   componentInstanceProps,
   componentInstanceUnboundValues,
+  componentInstanceDataSource,
 }: {
   node: CompositionNode;
   nodeId: string;
@@ -27,6 +28,7 @@ export const deserializeDesignComponentNode = ({
   designComponentUnboundValues: CompositionUnboundValues;
   componentInstanceProps: Record<string, CompositionComponentPropValue>;
   componentInstanceUnboundValues: CompositionUnboundValues;
+  componentInstanceDataSource: CompositionDataSource;
 }): CompositionComponentNode => {
   const childNodeVariable: Record<string, CompositionComponentPropValue> = {};
   const dataSource: CompositionDataSource = {};
@@ -35,18 +37,26 @@ export const deserializeDesignComponentNode = ({
   for (const [variableName, variable] of Object.entries(node.variables)) {
     childNodeVariable[variableName] = variable;
     if (variable.type === 'ComponentValue') {
-      const uuid = variable.key;
-      const variableMapping = componentInstanceProps[uuid];
+      const componentValueKey = variable.key;
+      const instanceProperty = componentInstanceProps[componentValueKey];
 
-      // For design component, we are only handling binding for UnboundValues for now
-      if (variableMapping?.type === 'UnboundValue') {
-        const componentInstanceValue = componentInstanceUnboundValues[variableMapping.key].value;
-
-        if (typeof componentInstanceValue === 'object' && componentInstanceValue !== null) {
-          unboundValues[uuid] = designComponentUnboundValues[componentInstanceValue['key']];
-        } else {
-          unboundValues[uuid] = componentInstanceUnboundValues[variableMapping.key];
-        }
+      // For design component, we look up the value in the design component instance and
+      // replace the componentValue with that one.
+      if (instanceProperty?.type === 'UnboundValue') {
+        const componentInstanceValue = componentInstanceUnboundValues[instanceProperty.key];
+        unboundValues[instanceProperty.key] = componentInstanceValue;
+        childNodeVariable[variableName] = {
+          type: 'UnboundValue',
+          key: instanceProperty.key,
+        };
+      } else if (instanceProperty?.type === 'BoundValue') {
+        const [, dataSourceKey] = instanceProperty.path.split('/');
+        const componentInstanceValue = componentInstanceDataSource[dataSourceKey];
+        dataSource[dataSourceKey] = componentInstanceValue;
+        childNodeVariable[variableName] = {
+          type: 'BoundValue',
+          path: instanceProperty.path,
+        };
       }
     }
   }
@@ -62,6 +72,7 @@ export const deserializeDesignComponentNode = ({
       designComponentUnboundValues,
       componentInstanceProps,
       componentInstanceUnboundValues,
+      componentInstanceDataSource,
     })
   );
 
@@ -121,6 +132,7 @@ export const resolveDesignComponent = ({
     designComponentUnboundValues: componentFields.unboundValues,
     componentInstanceProps: node.data.props,
     componentInstanceUnboundValues: node.data.unboundValues,
+    componentInstanceDataSource: node.data.dataSource,
   });
 
   return deserializedNode;

--- a/packages/experience-builder-sdk/src/core/preview/designComponentUtils.spec.ts
+++ b/packages/experience-builder-sdk/src/core/preview/designComponentUtils.spec.ts
@@ -1,8 +1,6 @@
 import type { Entry } from 'contentful';
-import {
-  compositionEntry,
-  createDesignComponentEntry,
-} from '../../../test/__fixtures__/composition';
+import { compositionEntry } from '../../../test/__fixtures__/composition';
+import { createDesignComponentEntry } from '../../../test/__fixtures__/designComponent';
 import { assets, entries } from '../../../test/__fixtures__/entities';
 import { CONTENTFUL_CONTAINER_ID } from '../../constants';
 import { CompositionNode } from '../../types';

--- a/packages/experience-builder-sdk/test/__fixtures__/composition.ts
+++ b/packages/experience-builder-sdk/test/__fixtures__/composition.ts
@@ -1,4 +1,4 @@
-import { CONTENTFUL_CONTAINER_ID, LATEST_SCHEMA_VERSION } from '../../src';
+import { LATEST_SCHEMA_VERSION } from '../../src';
 import { Composition, ExperienceEntry, SchemaVersions } from '../../src/types';
 import { entityIds } from './entities';
 
@@ -166,87 +166,6 @@ export const createCompositionEntry = ({
       unboundValues: {
         uuid1: {
           value: 'test',
-        },
-      },
-    },
-  };
-};
-
-export const designComponentGeneratedVariableName = 'text_uuid1DesignComponent';
-export const createDesignComponentEntry = ({
-  schemaVersion = LATEST_SCHEMA_VERSION,
-  id = 'design-component-id',
-}: createCompositionEntryArgs & { id: string }) => {
-  return {
-    sys: {
-      id,
-      type: 'Entry',
-      contentType: {
-        sys: {
-          id: 'layout',
-          type: 'Link',
-          linkType: 'ContentType',
-        },
-      },
-      createdAt: '2023-06-27T00:00:00.000Z',
-      updatedAt: '2023-06-27T00:00:00.000Z',
-      revision: 1,
-      space: {
-        sys: {
-          type: 'Link',
-          linkType: 'Space',
-          id: 'cfexampleSpace',
-        },
-      },
-      environment: {
-        sys: {
-          type: 'Link',
-          linkType: 'Environment',
-          id: 'cfexampleEnvironment',
-        },
-      },
-    },
-    metadata: { tags: [] },
-    fields: {
-      title: 'Test Composition',
-      slug: 'test',
-      componentTree: {
-        children: [
-          {
-            definitionId: CONTENTFUL_CONTAINER_ID,
-            variables: {},
-            children: [
-              {
-                definitionId: 'custom-component',
-                variables: {
-                  text: {
-                    key: designComponentGeneratedVariableName,
-                    type: 'ComponentValue',
-                  },
-                },
-                children: [],
-              },
-            ],
-          },
-        ],
-        breakpoints: [],
-        schemaVersion,
-      },
-      dataSource: {},
-      unboundValues: {
-        unbound_uuid1DesignComponent: {
-          value: 'custom component title',
-        },
-      },
-      componentSettings: {
-        variableDefinitions: {
-          [designComponentGeneratedVariableName]: {
-            id: 'text',
-            name: 'Text',
-            type: 'Text',
-            defaultValue: { type: 'UnboundValue', key: 'unbound_uuid1DesignComponent' },
-            required: false,
-          },
         },
       },
     },

--- a/packages/experience-builder-sdk/test/__fixtures__/designComponent.ts
+++ b/packages/experience-builder-sdk/test/__fixtures__/designComponent.ts
@@ -1,0 +1,148 @@
+import {
+  CompositionComponentNode,
+  DESIGN_COMPONENT_NODE_TYPE,
+  SchemaVersions,
+} from '@contentful/experience-builder-types';
+import { CONTENTFUL_CONTAINER_ID, LATEST_SCHEMA_VERSION } from '../../src';
+
+type createDesignComponentEntryArgs = {
+  schemaVersion: SchemaVersions;
+  id: string;
+};
+
+export const defaultDesignComponentId = 'design-component-id';
+
+export const designComponentGeneratedVariableName = 'text_uuid1DesignComponent';
+export const createDesignComponentEntry = ({
+  schemaVersion = LATEST_SCHEMA_VERSION,
+  id = defaultDesignComponentId,
+}: createDesignComponentEntryArgs) => {
+  return {
+    sys: {
+      id,
+      type: 'Entry',
+      contentType: {
+        sys: {
+          id: 'layout',
+          type: 'Link',
+          linkType: 'ContentType',
+        },
+      },
+      createdAt: '2023-06-27T00:00:00.000Z',
+      updatedAt: '2023-06-27T00:00:00.000Z',
+      revision: 1,
+      space: {
+        sys: {
+          type: 'Link',
+          linkType: 'Space',
+          id: 'cfexampleSpace',
+        },
+      },
+      environment: {
+        sys: {
+          type: 'Link',
+          linkType: 'Environment',
+          id: 'cfexampleEnvironment',
+        },
+      },
+    },
+    metadata: { tags: [] },
+    fields: {
+      title: 'Test Composition',
+      slug: 'test',
+      componentTree: {
+        children: [
+          {
+            definitionId: CONTENTFUL_CONTAINER_ID,
+            variables: {},
+            children: [
+              {
+                definitionId: 'custom-component',
+                variables: {
+                  text: {
+                    key: designComponentGeneratedVariableName,
+                    type: 'ComponentValue',
+                  },
+                },
+                children: [],
+              },
+            ],
+          },
+        ],
+        breakpoints: [],
+        schemaVersion,
+      },
+      dataSource: {},
+      unboundValues: {
+        unbound_uuid1DesignComponent: {
+          value: 'custom component title',
+        },
+      },
+      componentSettings: {
+        variableDefinitions: {
+          [designComponentGeneratedVariableName]: {
+            id: 'text',
+            name: 'Text',
+            type: 'Text',
+            defaultValue: { type: 'UnboundValue', key: 'unbound_uuid1DesignComponent' },
+            required: false,
+          },
+        },
+      },
+    },
+  };
+};
+
+type createDesignComponentNodeArgs = {
+  id: string;
+  blockId?: string;
+  unboundValue?: string;
+  unboundValueKey?: string;
+  boundValueKey?: string;
+};
+
+export const createDesignComponentNode = ({
+  id,
+  blockId = defaultDesignComponentId,
+  unboundValue = 'New year Eve',
+  unboundValueKey = undefined,
+  boundValueKey = undefined,
+}: createDesignComponentNodeArgs): CompositionComponentNode => {
+  const node: CompositionComponentNode = {
+    type: DESIGN_COMPONENT_NODE_TYPE,
+    data: {
+      blockId,
+      id,
+      props: {},
+      dataSource: {},
+      unboundValues: {},
+      breakpoints: [],
+    },
+    children: [],
+    parentId: 'root',
+  };
+  if (unboundValueKey) {
+    node.data.props[designComponentGeneratedVariableName] = {
+      type: 'UnboundValue',
+      key: unboundValueKey,
+    };
+    node.data.unboundValues = {
+      [unboundValueKey]: { value: unboundValue },
+    };
+  } else if (boundValueKey) {
+    node.data.props[designComponentGeneratedVariableName] = {
+      type: 'BoundValue',
+      path: `/${boundValueKey}/fields/someFieldId/~locale`,
+    };
+    node.data.dataSource = {
+      [boundValueKey]: {
+        sys: {
+          type: 'Link',
+          linkType: 'Entry',
+          id: 'someEntryId',
+        },
+      },
+    };
+  }
+  return node;
+};


### PR DESCRIPTION
As shown here in [this Miro board](https://miro.com/app/board/uXjVNL-mFho=/?moveToWidget=3458764570954909785&cot=14), we want to replace the component value pointers with the actual unbound value or bound value. We now replace those correctly, so in the final rendering we don't have to handle `ComponentValue` anymore.