### PR TITLE
fix: render component values in preview and resolve links properly []

### DIFF
--- a/packages/experience-builder-sdk/src/blocks/preview/CompositionBlock.spec.tsx
+++ b/packages/experience-builder-sdk/src/blocks/preview/CompositionBlock.spec.tsx
@@ -10,6 +10,7 @@ import type { Entry } from 'contentful';
 import { compositionEntry } from '../../../test/__fixtures__/composition';
 import {
   createDesignComponentEntry,
+  defaultDesignComponentId,
   designComponentGeneratedVariableName,
 } from '../../../test/__fixtures__/designComponent';
 import { EntityStore } from '../../core/preview/EntityStore';
@@ -117,26 +118,35 @@ describe('CompositionBlock', () => {
   });
 
   it('renders design component node', () => {
+    const unboundValueKey = 'some-unbound-value-key';
     const designComponentEntry = createDesignComponentEntry({
-      id: 'design-component-id',
+      id: defaultDesignComponentId,
       schemaVersion: '2023-09-28',
     });
+    const experienceEntry = {
+      ...compositionEntry,
+      fields: {
+        ...compositionEntry.fields,
+        usedComponents: [designComponentEntry],
+        unboundValues: {
+          [unboundValueKey]: {
+            value: 'New year eve',
+          },
+        },
+      },
+    } as ExperienceEntry;
 
     const entityStore = new EntityStore({
-      experienceEntry: {
-        ...compositionEntry,
-        fields: {
-          ...compositionEntry.fields,
-          usedComponents: [designComponentEntry],
-        },
-      } as unknown as Entry,
+      experienceEntry: experienceEntry as unknown as Entry,
       entities: [...entries, ...assets],
       locale: 'en-US',
     });
 
     const designComponentNode: CompositionNode = {
-      definitionId: 'design-component-id',
-      variables: {},
+      definitionId: defaultDesignComponentId,
+      variables: {
+        [designComponentGeneratedVariableName]: { type: 'UnboundValue', key: unboundValueKey },
+      },
       children: [],
     };
 
@@ -148,11 +158,7 @@ describe('CompositionBlock', () => {
         breakpoints={[]}
         entityStore={entityStore}
         usedComponents={[designComponentEntry] as ExperienceEntry[]}
-        unboundValues={{
-          [designComponentGeneratedVariableName]: {
-            value: 'New year eve',
-          },
-        }}
+        unboundValues={experienceEntry.fields.unboundValues}
         resolveDesignValue={jest.fn()}
       />
     );

--- a/packages/experience-builder-sdk/src/blocks/preview/CompositionBlock.tsx
+++ b/packages/experience-builder-sdk/src/blocks/preview/CompositionBlock.tsx
@@ -111,12 +111,8 @@ export const CompositionBlock = ({
         }
         case 'UnboundValue': {
           const uuid = variable.key;
+          console.log(variableName, uuid, acc[variableName]);
           acc[variableName] = (entityStore?.unboundValues || unboundValues)[uuid]?.value;
-          break;
-        }
-        case 'ComponentValue': {
-          const uuid = variable.key;
-          acc[variableName] = unboundValues[uuid]?.value;
           break;
         }
         default:

--- a/packages/experience-builder-sdk/src/blocks/preview/CompositionBlock.tsx
+++ b/packages/experience-builder-sdk/src/blocks/preview/CompositionBlock.tsx
@@ -111,7 +111,6 @@ export const CompositionBlock = ({
         }
         case 'UnboundValue': {
           const uuid = variable.key;
-          console.log(variableName, uuid, acc[variableName]);
           acc[variableName] = (entityStore?.unboundValues || unboundValues)[uuid]?.value;
           break;
         }

--- a/packages/experience-builder-sdk/src/core/preview/EntityStore.ts
+++ b/packages/experience-builder-sdk/src/core/preview/EntityStore.ts
@@ -78,16 +78,29 @@ export class EntityStore extends VisualSdkEntityStore {
       }
       entity = resolvedEntity;
     } else {
+      // We already have the complete entity in preview & delivery (resolved by the CMA client)
       entity = entityLinkOrEntity;
     }
 
-    // We already have the complete entity in preview and don't need to resolve links
-    // but we need the logic from the super class to resolve the path with the value.
-    const fieldValue = super.getValue(entity as any, path);
+    const fieldValue = get<string>(entity, path);
 
     // walk around to render asset files
     return fieldValue && typeof fieldValue == 'object' && (fieldValue as AssetFile).url
       ? (fieldValue as AssetFile).url
       : fieldValue;
+  }
+}
+
+// Taken from visual-sdk. We need this when we already have the full entity instead of the link (preview & delivery)
+function get<T>(obj: Record<string, any>, path: string[]): T | undefined {
+  if (!path.length) {
+    return obj as T;
+  }
+
+  try {
+    const [currentPath, ...nextPath] = path;
+    return get(obj[currentPath], nextPath);
+  } catch (err) {
+    return undefined;
   }
 }

--- a/packages/experience-builder-sdk/src/core/preview/designComponentUtils.ts
+++ b/packages/experience-builder-sdk/src/core/preview/designComponentUtils.ts
@@ -41,8 +41,6 @@ export const deserializeDesignComponentNode = ({
   );
 
   return {
-    // separate node type identifiers for design components and their blocks, so we can treat them differently in as much as we want
-    // type: isDesignComponent ? DESIGN_COMPONENT_NODE_TYPE : DESIGN_COMPONENT_BLOCK_NODE_TYPE,
     definitionId: node.definitionId,
     variables,
     children,


### PR DESCRIPTION
Apply the same changes as in https://github.com/contentful/experience-builder/pull/192 but for preview mode where we have a different structure (the raw data format).

Also, the function `EntityStore.getValue` renders warnings when it receives full entities instead of links. The links are already resolved by default through our APIs, thus the logic needs to be aware of both cases.