### PR TITLE
feat: initialise entity store sustainably in editor mode [SPA-1711]

### DIFF
--- a/packages/experience-builder-sdk/src/ExperienceRoot.tsx
+++ b/packages/experience-builder-sdk/src/ExperienceRoot.tsx
@@ -52,12 +52,12 @@ export const ExperienceRoot = ({ locale, experience, slug }: ExperienceRootProps
     mode,
   });
 
-  if (!mode || !supportedModes.includes(mode)) return null;
-
   if (mode === 'editor') {
+    const entityStore =
+      experience && !isDeprecatedExperience(experience) ? experience.entityStore : undefined;
     return (
       <ErrorBoundary>
-        <VisualEditorRoot initialLocale={locale} mode={mode} />
+        <VisualEditorRoot initialLocale={locale} mode={mode} previousEntityStore={entityStore} />
       </ErrorBoundary>
     );
   }

--- a/packages/experience-builder-sdk/src/blocks/editor/VisualEditorRoot.tsx
+++ b/packages/experience-builder-sdk/src/blocks/editor/VisualEditorRoot.tsx
@@ -1,47 +1,51 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect } from 'react';
 
 import { VisualEditorBlock } from './VisualEditorBlock';
 import { EmptyEditorContainer } from '../../components/EmptyEditorContainer';
 import '../../styles/VisualEditorRoot.css';
 import { onComponentDropped } from '../../communication/onComponentDrop';
-import { EditorModeEntityStore } from '../../core/editor/EditorModeEntityStore';
 import { useBreakpoints } from '../../hooks/useBreakpoints';
 import { useHoverIndicator } from '../../hooks/useHoverIndicator';
-import { CompositionComponentNode, InternalSDKMode } from '../../types';
+import { CompositionComponentNode, EntityStore, InternalSDKMode } from '../../types';
 import { useEditorContext } from './useEditorContext';
-import { VisualEditorContextProvider, designComponentsRegistry } from './VisualEditorContext';
+import { VisualEditorContextProvider } from './VisualEditorContext';
 
 type VisualEditorRootProps = {
   initialLocale: string;
   mode: InternalSDKMode;
+  previousEntityStore?: EntityStore;
 };
 
-export const VisualEditorRoot = ({ initialLocale, mode }: VisualEditorRootProps) => {
+export const VisualEditorRoot = ({
+  initialLocale,
+  mode,
+  previousEntityStore,
+}: VisualEditorRootProps) => {
   // in editor mode locale can change via sendMessage from web app, hence we use the locale from props only as initial locale
   return (
-    <VisualEditorContextProvider mode={mode} initialLocale={initialLocale}>
+    <VisualEditorContextProvider
+      mode={mode}
+      initialLocale={initialLocale}
+      previousEntityStore={previousEntityStore}>
       <VisualEditorRootComponents />
     </VisualEditorContextProvider>
   );
 };
 
 const VisualEditorRootComponents = () => {
-  const { tree, dataSource, isDragging, locale, unboundValues, breakpoints, entityStore } =
-    useEditorContext();
+  const {
+    tree,
+    dataSource,
+    isDragging,
+    unboundValues,
+    breakpoints,
+    entityStore,
+    areEntitiesFetched,
+  } = useEditorContext();
 
   // We call it here instead of on block-level to avoid registering too many even listeners for media queries
   const { resolveDesignValue } = useBreakpoints(breakpoints);
   useHoverIndicator(isDragging);
-  const [areEntitiesFetched, setEntitiesFetched] = useState(false);
-
-  useEffect(() => {
-    if (!locale) return;
-    entityStore.current = new EditorModeEntityStore({
-      entities: [],
-      locale: locale,
-    });
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [locale]);
 
   useEffect(() => {
     if (!tree || !tree?.root.children.length || !isDragging) return;
@@ -51,20 +55,6 @@ const VisualEditorRootComponents = () => {
     document.addEventListener('mouseup', onMouseUp);
     return () => document.removeEventListener('mouseup', onMouseUp);
   }, [tree, isDragging]);
-
-  useEffect(() => {
-    const resolveEntities = async () => {
-      setEntitiesFetched(false);
-      const dataSourceEntityLinks = Object.values(dataSource || {});
-      await entityStore.current.fetchEntities([
-        ...dataSourceEntityLinks,
-        ...(designComponentsRegistry.values() || []),
-      ]);
-      setEntitiesFetched(true);
-    };
-
-    resolveEntities();
-  }, [dataSource, entityStore, locale]);
 
   if (!tree?.root.children.length) {
     return React.createElement(EmptyEditorContainer, { isDragging }, []);

--- a/packages/experience-builder-sdk/src/core/editor/EditorModeEntityStore.ts
+++ b/packages/experience-builder-sdk/src/core/editor/EditorModeEntityStore.ts
@@ -3,6 +3,8 @@ import type { Asset, AssetFile, Entry, UnresolvedLink } from 'contentful';
 import { sendMessage } from '../../communication/sendMessage';
 
 export class EditorModeEntityStore extends EditorEntityStore {
+  public locale: string;
+
   constructor({ entities, locale }: { entities: Array<Entry | Asset>; locale: string }) {
     const subscribe = (method: unknown, cb: (payload: RequestedEntitiesMessage) => void) => {
       const listeners = (event: MessageEvent) => {
@@ -31,6 +33,7 @@ export class EditorModeEntityStore extends EditorEntityStore {
     };
 
     super({ entities, sendMessage, subscribe, locale });
+    this.locale = locale;
   }
 
   async fetchEntities(entityLinks: UnresolvedLink<'Entry' | 'Asset'>[]) {
@@ -40,7 +43,8 @@ export class EditorModeEntityStore extends EditorEntityStore {
     const uniqueEntryLinks = new Set(entryLinks.map((link) => link.sys.id));
     const uniqueAssetLinks = new Set(assetLinks.map((link) => link.sys.id));
 
-    return await Promise.allSettled([
+    // Entries and assets will be stored in entryMap and assetMap
+    await Promise.allSettled([
       this.fetchEntries([...uniqueEntryLinks]),
       this.fetchAssets([...uniqueAssetLinks]),
     ]);

--- a/packages/experience-builder-sdk/src/utils/validation.ts
+++ b/packages/experience-builder-sdk/src/utils/validation.ts
@@ -98,7 +98,7 @@ export const validateExperienceBuilderConfig = ({
 
   if (!locale) {
     throw new Error(
-      'Parameter "locale" is required for expereince builder initialization outside of editor mode'
+      'Parameter "locale" is required for experience builder initialization outside of editor mode'
     );
   }
 };


### PR DESCRIPTION
During the first initialization phase, the entity store is switching often between a "filled" and an "empty" state. When we're unlucky, somewhere in between it tries to render design component blocks but they are not yet in the entity store as it was emptied again. As a result, we see this warning everytime in the console and in some scenarios, the component is not rendered at all (e,g, colorful coin demo):
> `Entry for design component with ID '${componentId}' not found`

## Improvements

### 1. Recycle fetched entities from preview mode
The SDK will always start in non-editor mode and already load the entities in the preview entity store. After it switches to editor mode, it won't set the list of entities to `[]` but to `previousEntityStore?.entities` to eventually reuse already loaded entities.

### 2. Only reset entity store when locale actually changed
We have an effect that should re-initialize the entity store when the locale has changed. This would usually also get called in the first render cycle and therefore drop the preload entities. By adding a check `locale === entityStore.current.locale`, we are unsure to only reset it when necessary.

### 3. One place to manage the entity store
I moved logic that would change the entity store all in one place. Before, the "root" component would affect the context. This is now all happening in one single place (context).
_As a future improvement, we could extract this again into a separate hook, so the context becomes lighter again._

## Positive Side Effect
When changing code in the SDK, our demo project would hot reload but since a few versions ago, the canvas didn't catch up properly and just stayed empty. With these improvements, the canvas is now again able to hot reload, saving us from reloading the only web app every time we test changes in the SDK or demo.