### PR TITLE
chore(core): fix typings issue

### DIFF
--- a/packages/core/rollup.config.mjs
+++ b/packages/core/rollup.config.mjs
@@ -1,5 +1,6 @@
 import { nodeResolve } from '@rollup/plugin-node-resolve';
 import typescript from '@rollup/plugin-typescript';
+import dts from 'rollup-plugin-dts';
 export default [
   {
     input: 'src/index.ts',
@@ -13,9 +14,11 @@ export default [
     ],
     plugins: [nodeResolve(), typescript({ tsconfig: './tsconfig.json' })],
     external: [/node_modules\/(?!tslib.*)/],
+    treeshake: false,
   },
+  //specific exports in package.json
   {
-    input: 'src/constants.ts',
+    input: 'src/exports.ts',
     output: [
       {
         dir: 'dist',
@@ -26,5 +29,21 @@ export default [
     ],
     plugins: [nodeResolve(), typescript({ tsconfig: './tsconfig.json' })],
     external: [/node_modules\/(?!tslib.*)/],
+    treeshake: false,
+  },
+  //typings
+  {
+    input: 'src/index.ts',
+    output: [{ dir: 'dist', format: 'esm', preserveModules: true }],
+    plugins: [dts({ tsconfig: './tsconfig.json' })],
+    external: [/.css/],
+    treeshake: false,
+  },
+  {
+    input: 'src/exports.ts',
+    output: [{ dir: 'dist', format: 'esm', preserveModules: true }],
+    plugins: [dts({ tsconfig: './tsconfig.json' })],
+    external: [/.css/],
+    treeshake: false,
   },
 ];

--- a/packages/core/src/exports.ts
+++ b/packages/core/src/exports.ts
@@ -1,0 +1,3 @@
+//this file maintains the exports (ie: '@contentful/experience-builder-core/constants') used in the package.json file
+export * from './constants';
+export * from './types';

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -178,11 +178,6 @@ export type CompositionTree = {
 export type ExternalSDKMode = 'preview' | 'delivery';
 export type InternalSDKMode = ExternalSDKMode | 'editor';
 
-export enum VisualEditorMode {
-  LazyLoad = 'lazyLoad',
-  InjectScript = 'injectScript',
-}
-
 /**
  * Internally defined style variables are prefix with `cf` to avoid
  * collisions with user defined variables.

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -10,7 +10,6 @@
     "moduleResolution": "node",
     "allowSyntheticDefaultImports": true,
     "forceConsistentCasingInFileNames": true,
-    "declaration": true,
     "baseUrl": ".",
     "noImplicitAny": false,
     "paths": {


### PR DESCRIPTION
This PR fixes a typings bug. Before, the typings would export code that would include the internal paths imports (IE: `import { blah } from '@types'. These should be resolved to their relative paths, which this PR fixes.