### PR TITLE
feat: improve logs and add more debug logs to understand the entity store issues [SPA-1711]

### DIFF
--- a/packages/experience-builder-sdk/src/blocks/editor/VisualEditorContext.tsx
+++ b/packages/experience-builder-sdk/src/blocks/editor/VisualEditorContext.tsx
@@ -97,7 +97,11 @@ export function VisualEditorContextProvider({
 
   // Reload the entity store when the locale changed
   useEffect(() => {
-    if (!locale || locale === entityStore.current.locale) return;
+    const storeLocale = entityStore.current.locale;
+    if (!locale || locale === storeLocale) return;
+    console.debug(
+      `[exp-builder.sdk] Resetting entity store because the locale changed from '${storeLocale}' to '${locale}'.`
+    );
     entityStore.current = new EditorModeEntityStore({
       entities: [],
       locale: locale,
@@ -187,15 +191,15 @@ export function VisualEditorContextProvider({
       }
 
       const eventData = tryParseMessage(event);
-      if (eventData.eventType === PostMessageMethods.REQUESTED_ENTITIES) {
-        // Expected message: This message is handled in the visual-sdk to store fetched entities
-        return;
-      }
-
       console.debug(
         `[exp-builder.sdk::onMessage] Received message [${eventData.eventType}]`,
         eventData
       );
+
+      if (eventData.eventType === PostMessageMethods.REQUESTED_ENTITIES) {
+        // Expected message: This message is handled in the visual-sdk to store fetched entities
+        return;
+      }
 
       const { payload } = eventData;
 

--- a/packages/experience-builder-sdk/src/communication/sendMessage.ts
+++ b/packages/experience-builder-sdk/src/communication/sendMessage.ts
@@ -7,7 +7,7 @@ export const sendMessage = (eventType: OutgoingEvent | PostMessageMethods, data?
     return;
   }
 
-  console.debug('data sent', {
+  console.debug(`[exp-builder.sdk::sendMessage] Sending message [${eventType}]`, {
     source: 'customer-app',
     eventType,
     payload: data,

--- a/packages/experience-builder-sdk/src/core/editor/EditorModeEntityStore.ts
+++ b/packages/experience-builder-sdk/src/core/editor/EditorModeEntityStore.ts
@@ -6,6 +6,10 @@ export class EditorModeEntityStore extends EditorEntityStore {
   public locale: string;
 
   constructor({ entities, locale }: { entities: Array<Entry | Asset>; locale: string }) {
+    console.debug(
+      `[exp-builder.sdk] Initializing editor entity store with ${entities.length} entities for locale ${locale}.`,
+      { entities }
+    );
     const subscribe = (method: unknown, cb: (payload: RequestedEntitiesMessage) => void) => {
       const listeners = (event: MessageEvent) => {
         const data: {


### PR DESCRIPTION
Currently, the entity store is sometimes not holding the entries for design components. It looks like a race condition that only happens on a hosted SDK, so we need to ship this via new version to our demo project and deploy it to better understand why the entity store is empty when rendering design components.