### PR TITLE
fix: dont initialise entity store on every render by using state [SPA-1711]

### DIFF
--- a/packages/experience-builder-sdk/src/blocks/editor/VisualEditorBlock.test.tsx
+++ b/packages/experience-builder-sdk/src/blocks/editor/VisualEditorBlock.test.tsx
@@ -96,7 +96,7 @@ describe('VisualEditorBlock', () => {
         node={mockCompositionComponentNode}
         dataSource={{}}
         areEntitiesFetched={true}
-        entityStore={{ current: {} as EntityStore }}
+        entityStore={{} as EntityStore}
         unboundValues={mockCompositionComponentNode.data.unboundValues}
         resolveDesignValue={jest.fn()}
       />
@@ -109,7 +109,7 @@ describe('VisualEditorBlock', () => {
         node={mockCompositionComponentNode}
         dataSource={{}}
         areEntitiesFetched={true}
-        entityStore={{ current: {} as EntityStore }}
+        entityStore={{} as EntityStore}
         unboundValues={mockCompositionComponentNode.data.unboundValues}
         resolveDesignValue={jest.fn()}
       />
@@ -138,7 +138,7 @@ describe('VisualEditorBlock', () => {
         node={sectionNode}
         dataSource={{}}
         areEntitiesFetched={true}
-        entityStore={{ current: {} as EntityStore }}
+        entityStore={{} as EntityStore}
         unboundValues={sectionNode.data.unboundValues}
         resolveDesignValue={jest.fn()}
       />
@@ -166,7 +166,7 @@ describe('VisualEditorBlock', () => {
         node={containerNode}
         dataSource={{}}
         areEntitiesFetched={true}
-        entityStore={{ current: {} as EntityStore }}
+        entityStore={{} as EntityStore}
         unboundValues={containerNode.data.unboundValues}
         resolveDesignValue={jest.fn()}
       />
@@ -213,7 +213,7 @@ describe('VisualEditorBlock', () => {
         node={designComponentNode}
         dataSource={{}}
         areEntitiesFetched={true}
-        entityStore={{ current: entityStore }}
+        entityStore={entityStore}
         unboundValues={designComponentNode.data.unboundValues}
         resolveDesignValue={jest.fn()}
       />

--- a/packages/experience-builder-sdk/src/blocks/editor/VisualEditorBlock.tsx
+++ b/packages/experience-builder-sdk/src/blocks/editor/VisualEditorBlock.tsx
@@ -1,4 +1,4 @@
-import React, { RefObject, useCallback, useMemo } from 'react';
+import React, { useCallback, useMemo } from 'react';
 
 import type { EntityStore } from '@contentful/visual-sdk';
 import omit from 'lodash.omit';
@@ -49,7 +49,7 @@ type VisualEditorBlockProps = {
   unboundValues: CompositionUnboundValues;
 
   resolveDesignValue: ResolveDesignValueType;
-  entityStore: RefObject<EntityStore>;
+  entityStore: EntityStore;
   areEntitiesFetched: boolean;
 };
 
@@ -65,7 +65,7 @@ export const VisualEditorBlock = ({
     if (rawNode.type === DESIGN_COMPONENT_NODE_TYPE && areEntitiesFetched) {
       return resolveDesignComponent({
         node: rawNode,
-        entityStore: entityStore.current,
+        entityStore,
       });
     }
 
@@ -126,7 +126,7 @@ export const VisualEditorBlock = ({
           const binding = dataSource[uuid] as Link<'Entry' | 'Asset'>;
 
           let boundValue: string | Link<'Asset'> | undefined = areEntitiesFetched
-            ? entityStore.current?.getValue(binding, path.slice(0, -1))
+            ? entityStore.getValue(binding, path.slice(0, -1))
             : undefined;
 
           // In some cases, there may be an asset linked in the path, so we need to consider this scenario:
@@ -135,7 +135,7 @@ export const VisualEditorBlock = ({
 
           if (!boundValue) {
             const maybeBoundAsset = areEntitiesFetched
-              ? entityStore.current?.getValue(binding, path.slice(0, -2))
+              ? entityStore.getValue(binding, path.slice(0, -2))
               : undefined;
 
             if (isLinkToAsset(maybeBoundAsset)) {
@@ -144,7 +144,7 @@ export const VisualEditorBlock = ({
           }
 
           if (typeof boundValue === 'object' && boundValue.sys.linkType === 'Asset') {
-            boundValue = entityStore.current?.getValue(boundValue, ['fields', 'file']);
+            boundValue = entityStore.getValue(boundValue, ['fields', 'file']);
           }
 
           const value = boundValue || variableDefinition.defaultValue;

--- a/packages/experience-builder-sdk/src/core/editor/EditorModeEntityStore.ts
+++ b/packages/experience-builder-sdk/src/core/editor/EditorModeEntityStore.ts
@@ -41,8 +41,8 @@ export class EditorModeEntityStore extends EditorEntityStore {
   }
 
   async fetchEntities(entityLinks: UnresolvedLink<'Entry' | 'Asset'>[]) {
-    const entryLinks = entityLinks.filter((link) => link.sys.linkType === 'Entry');
-    const assetLinks = entityLinks.filter((link) => link.sys.linkType === 'Asset');
+    const entryLinks = entityLinks.filter((link) => link.sys?.linkType === 'Entry');
+    const assetLinks = entityLinks.filter((link) => link.sys?.linkType === 'Asset');
 
     const uniqueEntryLinks = new Set(entryLinks.map((link) => link.sys.id));
     const uniqueAssetLinks = new Set(assetLinks.map((link) => link.sys.id));


### PR DESCRIPTION
The initial value of `useRef` is only accepted on the first render. However, this value is still calculated on every render cycle. So we create a new entity store on every render cycle.
I'm not sure if this caused the seen side effects of race conditions in the colorful coin demo. Still, it is very likely a bigger memory leak and can eventually have side effects as it registers subscribers to the message protocol each time.

![Screenshot 2023-12-20 at 11 39 55](https://github.com/contentful/experience-builder/assets/9327071/2d06bb99-f329-4fb2-92b8-04c63dfedcbc)

By having this as a state variable, we integrate the initialization better into Reacts render cycle as the value is guaranteed to be defined on each render but also we don't regenerate it when not necessary as it's protected through the setter method.
