### PR TITLE
fix: switching locale makes design components disappear [SPA-1711]

### DIFF
--- a/packages/experience-builder-sdk/src/blocks/editor/VisualEditorContext.tsx
+++ b/packages/experience-builder-sdk/src/blocks/editor/VisualEditorContext.tsx
@@ -228,7 +228,9 @@ export function VisualEditorContextProvider({
             changedValueType?: CompositionComponentPropValue['type'];
           } = payload;
           // Make sure to first store the design components before setting the tree and thus triggering a rerender
-          designComponents && setDesignComponents(designComponents);
+          if (designComponents) {
+            setDesignComponents(designComponents);
+          }
           setTree(tree);
           setLocale(locale);
 
@@ -296,7 +298,9 @@ export function VisualEditorContextProvider({
         }
         case INCOMING_EVENTS.UpdatedEntity: {
           const { entity } = payload;
-          entity && entityStore.updateEntity(entity);
+          if (entity) {
+            entityStore.updateEntity(entity);
+          }
           break;
         }
         case INCOMING_EVENTS.RequestEditorMode: {

--- a/packages/experience-builder-sdk/src/blocks/editor/VisualEditorContext.tsx
+++ b/packages/experience-builder-sdk/src/blocks/editor/VisualEditorContext.tsx
@@ -122,11 +122,12 @@ export function VisualEditorContextProvider({
     const resolveEntities = async () => {
       const dataSourceEntityLinks = Object.values(dataSource || {});
       const entityLinks = [...dataSourceEntityLinks, ...(designComponentsRegistry.values() || [])];
-      const deferredEntities = entityStore.fetchEntities(entityLinks);
+      const fetchingResponse = entityStore.fetchEntities(entityLinks);
       // Only update the state and rerender when we're actually fetching something
-      if (deferredEntities === false) return;
+      if (fetchingResponse === false) return;
       setEntitiesFetched(false);
-      await deferredEntities;
+      // Await until the fetching is done to update the state variable at the right moment
+      await fetchingResponse;
       setEntitiesFetched(true);
     };
 

--- a/packages/experience-builder-sdk/src/core/designTokenRegistry.ts
+++ b/packages/experience-builder-sdk/src/core/designTokenRegistry.ts
@@ -17,7 +17,9 @@ export const defineDesignTokens = (designTokenDefinition: DesignTokensDefinition
   });
 };
 
-export const getDesignTokenRegistration = (breakpointValue: string) => {
+export const getDesignTokenRegistration = (breakpointValue?: string) => {
+  if (!breakpointValue) return breakpointValue;
+
   let resolvedValue = '';
   const values = breakpointValue.split(' ');
   values.forEach((value) => {

--- a/packages/experience-builder-sdk/src/core/editor/EditorModeEntityStore.ts
+++ b/packages/experience-builder-sdk/src/core/editor/EditorModeEntityStore.ts
@@ -40,7 +40,14 @@ export class EditorModeEntityStore extends EditorEntityStore {
     this.locale = locale;
   }
 
-  fetchEntities(entityLinks: UnresolvedLink<'Entry' | 'Asset'>[]) {
+  /**
+   * This function collects and returns the list of requested entries and assets. Additionally, it checks
+   * upfront whether any async fetching logic is actually happening. If not, it returns a plain `false` value, so we
+   * can detect this early and avoid unnecessary re-renders.
+   * @param entityLinks
+   * @returns false if no async fetching is happening, otherwise a promise that resolves when all entities are fetched
+   */
+  fetchEntities(entityLinks: UnresolvedLink<'Entry' | 'Asset'>[]): false | Promise<void> {
     const entryLinks = entityLinks.filter((link) => link.sys?.linkType === 'Entry');
     const assetLinks = entityLinks.filter((link) => link.sys?.linkType === 'Asset');
 
@@ -55,7 +62,7 @@ export class EditorModeEntityStore extends EditorEntityStore {
 
     // Entries and assets will be stored in entryMap and assetMap
     return Promise.all([this.fetchEntries(uniqueEntryIds), this.fetchAssets(uniqueAssetIds)]).then(
-      ([entries, assets]) => [...entries, ...assets]
+      () => Promise.resolve()
     );
   }
 

--- a/packages/experience-builder-sdk/src/hooks/useBreakpoints.ts
+++ b/packages/experience-builder-sdk/src/hooks/useBreakpoints.ts
@@ -65,9 +65,9 @@ export const getValueForBreakpoint = (
         variableName === 'cfHeight' ||
         variableName === 'cfBackgroundColor'
       ) {
-        const breakPointValue =
+        const breakpointValue =
           valuesByBreakpoint[breakpointId] || valuesByBreakpoint[fallbackBreakpointId];
-        return getDesignTokenRegistration(breakPointValue);
+        return getDesignTokenRegistration(breakpointValue);
       }
       if (valuesByBreakpoint[breakpointId]) {
         // If the value is defined, we use it and stop the breakpoints cascade


### PR DESCRIPTION
I discovered a few flaws that might end up in the design components and content not loading at all initially. I implements some small tweaks that are likely to fix this :)

In some cases, we already have a pre-filled entity store. This happens sometimes as we start in preview mode and then switch over to editor mode taking over the already-fetched entities. It also happens when using hot reloading.
In those cases, we should try to render the tree which we currently block via the boolean `areEntitiesFetched`.

To not silently just render nothing, we now try to render from the beginning on by setting `areEntitiesFetched` to true initially.

Also, we only update this variable only and only if we are really fetching something. The editor entity store is not returning either a boolean or a promise depending on whether it needs to fetch or not.

Last but not least, the design component registry is sometimes empty even though we update it when the new tree update arrives. I suspect a wrong order of the logic and thus switch the order of code lines when receiving the new tree.