### PR TITLE
fix: design token logic breaks auto height for empty containers []

### DIFF
--- a/packages/experience-builder-sdk/src/core/designTokenRegistry.ts
+++ b/packages/experience-builder-sdk/src/core/designTokenRegistry.ts
@@ -26,7 +26,8 @@ export const getDesignTokenRegistration = (breakpointValue: string) => {
     resolvedValue += `${tokenValue} `;
   });
 
-  return resolvedValue;
+  // Not trimming would end up with a trailing space that breaks the check in `calculateNodeDefaultHeight`
+  return resolvedValue.trim();
 };
 
 // Using this because export const StringTemplateRegex = /\${(.*?)\}/g doesn't work


### PR DESCRIPTION
<img width="1710" alt="image" src="https://github.com/contentful/experience-builder/assets/113918657/c53470e3-b0cb-4f11-b0f7-86ab99f719e3">
