### PR TITLE
fix: update font weight validations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2759,6 +2759,7 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {

--- a/packages/components/src/components/Text/Text.css
+++ b/packages/components/src/components/Text/Text.css
@@ -1,7 +1,4 @@
 .cf-text {
-  color: var(--cf-text-color);
-  font-size: var(--cf-text-base);
-  font-weight: var(--cf-font-normal);
   font-family: var(--cf-font-family-sans);
   margin: var(--cf-spacing-0);
 }

--- a/packages/components/src/components/Text/index.ts
+++ b/packages/components/src/components/Text/index.ts
@@ -11,6 +11,7 @@ export const TextComponentDefinition: ComponentDefinition = {
     'cfMargin',
     'cfPadding',
     'cfFontSize',
+    'cfFontWeight',
     'cfLineHeight',
     'cfLetterSpacing',
     'cfTextColor',
@@ -22,29 +23,6 @@ export const TextComponentDefinition: ComponentDefinition = {
   ],
   thumbnailUrl: constants.thumbnails.text,
   variables: {
-    // Override Font Weight options
-    cfFontWeight: {
-      validations: {
-        in: [
-          {
-            value: '400',
-            displayName: 'Normal',
-          },
-          {
-            value: '500',
-            displayName: 'Medium',
-          },
-          {
-            value: '600',
-            displayName: 'Semi Bold',
-          },
-        ],
-      },
-      displayName: 'Font Weight',
-      type: 'Text',
-      group: 'style',
-      defaultValue: '400',
-    },
     value: {
       displayName: 'Value',
       description: 'The text to display. If not provided, children will be used instead.',

--- a/packages/components/src/components/Text/index.ts
+++ b/packages/components/src/components/Text/index.ts
@@ -11,7 +11,6 @@ export const TextComponentDefinition: ComponentDefinition = {
     'cfMargin',
     'cfPadding',
     'cfFontSize',
-    'cfFontWeight',
     'cfLineHeight',
     'cfLetterSpacing',
     'cfTextColor',
@@ -23,6 +22,29 @@ export const TextComponentDefinition: ComponentDefinition = {
   ],
   thumbnailUrl: constants.thumbnails.text,
   variables: {
+    // Override Font Weight options
+    cfFontWeight: {
+      validations: {
+        in: [
+          {
+            value: '400',
+            displayName: 'Normal',
+          },
+          {
+            value: '500',
+            displayName: 'Medium',
+          },
+          {
+            value: '600',
+            displayName: 'Semi Bold',
+          },
+        ],
+      },
+      displayName: 'Font Weight',
+      type: 'Text',
+      group: 'style',
+      defaultValue: '400',
+    },
     value: {
       displayName: 'Value',
       description: 'The text to display. If not provided, children will be used instead.',

--- a/packages/components/styles.css
+++ b/packages/components/styles.css
@@ -127,9 +127,6 @@ h6.cf-heading {
   font-family: var(--cf-font-family-sans);
 }
 .cf-text {
-  color: var(--cf-text-color);
-  font-size: var(--cf-text-base);
-  font-weight: var(--cf-font-normal);
   font-family: var(--cf-font-family-sans);
   margin: var(--cf-spacing-0);
 }

--- a/packages/core/src/definitions/styles.ts
+++ b/packages/core/src/definitions/styles.ts
@@ -183,11 +183,51 @@ export const optionalBuiltInStyles: Partial<
     defaultValue: '16px',
   },
   cfFontWeight: {
+    validations: {
+      in: [
+        {
+          value: '100',
+          displayName: 'Thin',
+        },
+        {
+          value: '200',
+          displayName: 'Extra Light',
+        },
+        {
+          value: '300',
+          displayName: 'Light',
+        },
+        {
+          value: '400',
+          displayName: 'Normal',
+        },
+        {
+          value: '500',
+          displayName: 'Medium',
+        },
+        {
+          value: '600',
+          displayName: 'Semi Bold',
+        },
+        {
+          value: '700',
+          displayName: 'Bold',
+        },
+        {
+          value: '800',
+          displayName: 'Extra Bold',
+        },
+        {
+          value: '900',
+          displayName: 'Black',
+        },
+      ],
+    },
     displayName: 'Font Weight',
     type: 'Text',
     group: 'style',
     description: 'The font weight of the section',
-    defaultValue: 'normal',
+    defaultValue: '400',
   },
   cfLineHeight: {
     displayName: 'Line Height',

--- a/packages/core/src/definitions/styles.ts
+++ b/packages/core/src/definitions/styles.ts
@@ -186,18 +186,6 @@ export const optionalBuiltInStyles: Partial<
     validations: {
       in: [
         {
-          value: '100',
-          displayName: 'Thin',
-        },
-        {
-          value: '200',
-          displayName: 'Extra Light',
-        },
-        {
-          value: '300',
-          displayName: 'Light',
-        },
-        {
           value: '400',
           displayName: 'Normal',
         },
@@ -208,18 +196,6 @@ export const optionalBuiltInStyles: Partial<
         {
           value: '600',
           displayName: 'Semi Bold',
-        },
-        {
-          value: '700',
-          displayName: 'Bold',
-        },
-        {
-          value: '800',
-          displayName: 'Extra Bold',
-        },
-        {
-          value: '900',
-          displayName: 'Black',
         },
       ],
     },

--- a/packages/experience-builder-sdk/src/core/definitions/variables.ts
+++ b/packages/experience-builder-sdk/src/core/definitions/variables.ts
@@ -189,18 +189,6 @@ export const optionalBuiltInStyles: Partial<
     validations: {
       in: [
         {
-          value: '100',
-          displayName: 'Thin',
-        },
-        {
-          value: '200',
-          displayName: 'Extra Light',
-        },
-        {
-          value: '300',
-          displayName: 'Light',
-        },
-        {
           value: '400',
           displayName: 'Normal',
         },
@@ -211,18 +199,6 @@ export const optionalBuiltInStyles: Partial<
         {
           value: '600',
           displayName: 'Semi Bold',
-        },
-        {
-          value: '700',
-          displayName: 'Bold',
-        },
-        {
-          value: '800',
-          displayName: 'Extra Bold',
-        },
-        {
-          value: '900',
-          displayName: 'Black',
         },
       ],
     },

--- a/packages/experience-builder-sdk/src/core/definitions/variables.ts
+++ b/packages/experience-builder-sdk/src/core/definitions/variables.ts
@@ -186,11 +186,51 @@ export const optionalBuiltInStyles: Partial<
     defaultValue: '16px',
   },
   cfFontWeight: {
+    validations: {
+      in: [
+        {
+          value: '100',
+          displayName: 'Thin',
+        },
+        {
+          value: '200',
+          displayName: 'Extra Light',
+        },
+        {
+          value: '300',
+          displayName: 'Light',
+        },
+        {
+          value: '400',
+          displayName: 'Normal',
+        },
+        {
+          value: '500',
+          displayName: 'Medium',
+        },
+        {
+          value: '600',
+          displayName: 'Semi Bold',
+        },
+        {
+          value: '700',
+          displayName: 'Bold',
+        },
+        {
+          value: '800',
+          displayName: 'Extra Bold',
+        },
+        {
+          value: '900',
+          displayName: 'Black',
+        },
+      ],
+    },
     displayName: 'Font Weight',
     type: 'Text',
     group: 'style',
     description: 'The font weight of the section',
-    defaultValue: 'normal',
+    defaultValue: '400',
   },
   cfLineHeight: {
     displayName: 'Line Height',


### PR DESCRIPTION
* Updated the font weight style definition to include `validations` values that are used as select options in the UI
* Removed css from `.cf-text` for the Text component to use all built-in typography style controls
