### PR TITLE
fix: improve initial fetching mechanism [SPA-1711]

### DIFF
--- a/packages/experience-builder-sdk/package.json
+++ b/packages/experience-builder-sdk/package.json
@@ -28,7 +28,7 @@
     "@contentful/experience-builder-components": "^0.0.1-alpha.11",
     "@contentful/experience-builder-types": "^2.0.2",
     "@contentful/rich-text-types": "^16.2.1",
-    "@contentful/visual-sdk": "^1.0.0-alpha.26",
+    "@contentful/visual-sdk": "^1.0.0-alpha.38",
     "classnames": "^2.3.2",
     "contentful": "^10.6.10",
     "csstype": "^3.1.2",

--- a/packages/experience-builder-sdk/src/ExperienceRoot.tsx
+++ b/packages/experience-builder-sdk/src/ExperienceRoot.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useState } from 'react';
 
 import { isDeprecatedExperience } from '@contentful/experience-builder-types';
 import { EntityStore } from './core/preview/EntityStore';
@@ -37,15 +37,10 @@ export const ExperienceRoot = ({ locale, experience, slug }: ExperienceRootProps
     );
   });
 
-  useEffect(() => {
-    if (supportedModes.includes(mode)) {
-      setMode(mode);
-    }
-  }, [mode]);
-
   const switchToEditorMode = useCallback(() => {
+    console.debug(`[exp-builder.sdk] Switching from ${mode} to editor mode.`);
     setMode('editor');
-  }, []);
+  }, [mode]);
 
   validateExperienceBuilderConfig({
     locale,

--- a/packages/experience-builder-sdk/src/blocks/editor/VisualEditorBlock.test.tsx
+++ b/packages/experience-builder-sdk/src/blocks/editor/VisualEditorBlock.test.tsx
@@ -95,7 +95,7 @@ describe('VisualEditorBlock', () => {
       <VisualEditorBlock
         node={mockCompositionComponentNode}
         dataSource={{}}
-        areEntitiesFetched={true}
+        areInitialEntitiesFetched={true}
         entityStore={{} as EntityStore}
         unboundValues={mockCompositionComponentNode.data.unboundValues}
         resolveDesignValue={jest.fn()}
@@ -108,7 +108,7 @@ describe('VisualEditorBlock', () => {
       <VisualEditorBlock
         node={mockCompositionComponentNode}
         dataSource={{}}
-        areEntitiesFetched={true}
+        areInitialEntitiesFetched={true}
         entityStore={{} as EntityStore}
         unboundValues={mockCompositionComponentNode.data.unboundValues}
         resolveDesignValue={jest.fn()}
@@ -137,7 +137,7 @@ describe('VisualEditorBlock', () => {
       <VisualEditorBlock
         node={sectionNode}
         dataSource={{}}
-        areEntitiesFetched={true}
+        areInitialEntitiesFetched={true}
         entityStore={{} as EntityStore}
         unboundValues={sectionNode.data.unboundValues}
         resolveDesignValue={jest.fn()}
@@ -165,7 +165,7 @@ describe('VisualEditorBlock', () => {
       <VisualEditorBlock
         node={containerNode}
         dataSource={{}}
-        areEntitiesFetched={true}
+        areInitialEntitiesFetched={true}
         entityStore={{} as EntityStore}
         unboundValues={containerNode.data.unboundValues}
         resolveDesignValue={jest.fn()}
@@ -212,7 +212,7 @@ describe('VisualEditorBlock', () => {
       <VisualEditorBlock
         node={designComponentNode}
         dataSource={{}}
-        areEntitiesFetched={true}
+        areInitialEntitiesFetched={true}
         entityStore={entityStore}
         unboundValues={designComponentNode.data.unboundValues}
         resolveDesignValue={jest.fn()}

--- a/packages/experience-builder-sdk/src/blocks/editor/VisualEditorBlock.tsx
+++ b/packages/experience-builder-sdk/src/blocks/editor/VisualEditorBlock.tsx
@@ -50,7 +50,7 @@ type VisualEditorBlockProps = {
 
   resolveDesignValue: ResolveDesignValueType;
   entityStore: EntityStore;
-  areEntitiesFetched: boolean;
+  areInitialEntitiesFetched: boolean;
 };
 
 export const VisualEditorBlock = ({
@@ -59,10 +59,10 @@ export const VisualEditorBlock = ({
   unboundValues,
   resolveDesignValue,
   entityStore,
-  areEntitiesFetched,
+  areInitialEntitiesFetched,
 }: VisualEditorBlockProps) => {
   const node = useMemo(() => {
-    if (rawNode.type === DESIGN_COMPONENT_NODE_TYPE && areEntitiesFetched) {
+    if (rawNode.type === DESIGN_COMPONENT_NODE_TYPE && areInitialEntitiesFetched) {
       return resolveDesignComponent({
         node: rawNode,
         entityStore,
@@ -70,7 +70,7 @@ export const VisualEditorBlock = ({
     }
 
     return rawNode;
-  }, [areEntitiesFetched, entityStore, rawNode]);
+  }, [areInitialEntitiesFetched, entityStore, rawNode]);
 
   const componentRegistration = useMemo(() => {
     const registration = getComponentRegistration(node.data.blockId as string);
@@ -127,7 +127,7 @@ export const VisualEditorBlock = ({
           const [, uuid, ...path] = variableMapping.path.split('/');
           const binding = dataSource[uuid] as Link<'Entry' | 'Asset'>;
 
-          let boundValue: string | Link<'Asset'> | undefined = areEntitiesFetched
+          let boundValue: string | Link<'Asset'> | undefined = areInitialEntitiesFetched
             ? entityStore.getValue(binding, path.slice(0, -1))
             : undefined;
 
@@ -136,7 +136,7 @@ export const VisualEditorBlock = ({
           // If successful, it means we have identified the linked asset.
 
           if (!boundValue) {
-            const maybeBoundAsset = areEntitiesFetched
+            const maybeBoundAsset = areInitialEntitiesFetched
               ? entityStore.getValue(binding, path.slice(0, -2))
               : undefined;
 
@@ -178,7 +178,7 @@ export const VisualEditorBlock = ({
     node.children,
     resolveDesignValue,
     dataSource,
-    areEntitiesFetched,
+    areInitialEntitiesFetched,
     entityStore,
     unboundValues,
   ]);
@@ -239,7 +239,7 @@ export const VisualEditorBlock = ({
               unboundValues={unboundValues}
               resolveDesignValue={resolveDesignValue}
               entityStore={entityStore}
-              areEntitiesFetched={areEntitiesFetched}
+              areInitialEntitiesFetched={areInitialEntitiesFetched}
             />
           );
         })

--- a/packages/experience-builder-sdk/src/blocks/editor/VisualEditorBlock.tsx
+++ b/packages/experience-builder-sdk/src/blocks/editor/VisualEditorBlock.tsx
@@ -79,6 +79,8 @@ export const VisualEditorBlock = ({
         definitionId: node.data.blockId as string,
         component: DesignComponent,
       });
+    } else if (!registration) {
+      console.warn(`[exp-builder.sdk] Component registration not found for ${node.data.blockId}`);
     }
     return registration;
   }, [node]);

--- a/packages/experience-builder-sdk/src/blocks/editor/VisualEditorContext.tsx
+++ b/packages/experience-builder-sdk/src/blocks/editor/VisualEditorContext.tsx
@@ -120,7 +120,10 @@ export function VisualEditorContextProvider({
     const entityLinks = [...Object.values(dataSource), ...designComponentsRegistry.values()];
     const { missingAssetIds, missingEntryIds } = entityStore.getMissingEntityIds(entityLinks);
     // Only continue and trigger rerendering when we need to fetch something and we're not fetching yet
-    if (!missingAssetIds.length && !missingEntryIds.length) return;
+    if (!missingAssetIds.length && !missingEntryIds.length) {
+      setInitialEntitiesFetched(true);
+      return;
+    }
     setInitialEntitiesFetched(false);
     setFetchingEntities(true);
     try {

--- a/packages/experience-builder-sdk/src/blocks/editor/VisualEditorRoot.tsx
+++ b/packages/experience-builder-sdk/src/blocks/editor/VisualEditorRoot.tsx
@@ -40,7 +40,7 @@ const VisualEditorRootComponents = () => {
     unboundValues,
     breakpoints,
     entityStore,
-    areEntitiesFetched,
+    areInitialEntitiesFetched,
   } = useEditorContext();
 
   // We call it here instead of on block-level to avoid registering too many even listeners for media queries
@@ -70,7 +70,7 @@ const VisualEditorRootComponents = () => {
           unboundValues={unboundValues}
           resolveDesignValue={resolveDesignValue}
           entityStore={entityStore}
-          areEntitiesFetched={areEntitiesFetched}
+          areInitialEntitiesFetched={areInitialEntitiesFetched}
         />
       ))}
     </div>

--- a/packages/experience-builder-sdk/src/core/editor/EditorModeEntityStore.ts
+++ b/packages/experience-builder-sdk/src/core/editor/EditorModeEntityStore.ts
@@ -15,7 +15,7 @@ export class EditorModeEntityStore extends EditorEntityStore {
       { entities }
     );
     const subscribe = (method: unknown, cb: (payload: RequestedEntitiesMessage) => void) => {
-      const listeners = (event: MessageEvent) => {
+      const handleMessage = (event: MessageEvent) => {
         const data: {
           source: 'composability-app';
           eventType: string;
@@ -30,12 +30,12 @@ export class EditorModeEntityStore extends EditorEntityStore {
       };
 
       if (typeof window !== 'undefined') {
-        window.addEventListener('message', listeners);
+        window.addEventListener('message', handleMessage);
       }
 
       return () => {
         if (typeof window !== 'undefined') {
-          window.removeEventListener('message', listeners);
+          window.removeEventListener('message', handleMessage);
         }
       };
     };
@@ -51,7 +51,18 @@ export class EditorModeEntityStore extends EditorEntityStore {
    * @param entityLinks
    * @returns false if no async fetching is happening, otherwise a promise that resolves when all entities are fetched
    */
-  fetchEntities(entityLinks: UnresolvedLink<'Entry' | 'Asset'>[]): false | Promise<void> {
+  async fetchEntities({
+    missingEntryIds,
+    missingAssetIds,
+  }: {
+    missingEntryIds: string[];
+    missingAssetIds: string[];
+  }) {
+    // Entries and assets will be stored in entryMap and assetMap
+    await Promise.all([this.fetchEntries(missingEntryIds), this.fetchAssets(missingAssetIds)]);
+  }
+
+  getMissingEntityIds(entityLinks: UnresolvedLink<'Entry' | 'Asset'>[]) {
     const entryLinks = entityLinks.filter((link) => link.sys?.linkType === 'Entry');
     const assetLinks = entityLinks.filter((link) => link.sys?.linkType === 'Asset');
 
@@ -61,13 +72,7 @@ export class EditorModeEntityStore extends EditorEntityStore {
     const { missing: missingEntryIds } = this.getEntitiesFromMap('Entry', uniqueEntryIds);
     const { missing: missingAssetIds } = this.getEntitiesFromMap('Asset', uniqueAssetIds);
 
-    // Return false to indicate that no async fetching is happening
-    if (!missingAssetIds.length && !missingEntryIds.length) return false;
-
-    // Entries and assets will be stored in entryMap and assetMap
-    return Promise.all([this.fetchEntries(uniqueEntryIds), this.fetchAssets(uniqueAssetIds)]).then(
-      () => Promise.resolve()
-    );
+    return { missingEntryIds, missingAssetIds };
   }
 
   getValue(

--- a/packages/experience-builder-types/package.json
+++ b/packages/experience-builder-types/package.json
@@ -17,7 +17,7 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@contentful/visual-sdk": "^1.0.0-alpha.26",
+    "@contentful/visual-sdk": "^1.0.0-alpha.38",
     "contentful": "^10.6.10"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -516,6 +516,11 @@
   resolved "https://registry.yarnpkg.com/@contentful/visual-sdk/-/visual-sdk-1.0.0-alpha.34.tgz#c193aaca5b64ecb34c62903594423b9be36de35c"
   integrity sha512-umPTFWfh3gNNmruyIRD5jgcQQN3KIzSd/6DaoTxPpz+ud3O+g4zYItytJoD0iZaEz1+V9ciVFw+C5+Xe57RvMg==
 
+"@contentful/visual-sdk@^1.0.0-alpha.38":
+  version "1.0.0-alpha.38"
+  resolved "https://registry.yarnpkg.com/@contentful/visual-sdk/-/visual-sdk-1.0.0-alpha.38.tgz#a0f7be8f3873023cf89d31fca687ad64b4c6619b"
+  integrity sha512-x+DFtTULEIUEYVEpOYyfh5SFG0GmcslLpMjhl9Yyen6eNCiOXG0mnAzPATPT/Nj9oeJNSIf/ZuYP3avOcckPVg==
+
 "@esbuild/android-arm64@0.18.20":
   version "0.18.20"
   resolved "https://registry.yarnpkg.com/@esbuild/android-arm64/-/android-arm64-0.18.20.tgz#984b4f9c8d0377443cc2dfcef266d02244593622"

--- a/yarn.lock
+++ b/yarn.lock
@@ -511,11 +511,6 @@
   resolved "https://registry.yarnpkg.com/@contentful/rich-text-types/-/rich-text-types-16.3.0.tgz#d44145a43b32d61eb4d6a82d3001cdfddbbda42e"
   integrity sha512-OfQmAu5bxE0CgQA3WlUleVej+ifFG/iXmB2DmUl4EyWyFue1aiIvfjxQhcDRSH4n1jUNMJ6L1wInZL8uV5m3TQ==
 
-"@contentful/visual-sdk@^1.0.0-alpha.26":
-  version "1.0.0-alpha.34"
-  resolved "https://registry.yarnpkg.com/@contentful/visual-sdk/-/visual-sdk-1.0.0-alpha.34.tgz#c193aaca5b64ecb34c62903594423b9be36de35c"
-  integrity sha512-umPTFWfh3gNNmruyIRD5jgcQQN3KIzSd/6DaoTxPpz+ud3O+g4zYItytJoD0iZaEz1+V9ciVFw+C5+Xe57RvMg==
-
 "@contentful/visual-sdk@^1.0.0-alpha.38":
   version "1.0.0-alpha.38"
   resolved "https://registry.yarnpkg.com/@contentful/visual-sdk/-/visual-sdk-1.0.0-alpha.38.tgz#a0f7be8f3873023cf89d31fca687ad64b4c6619b"


### PR DESCRIPTION
The current fetching logic for initial entities (data source and design components) was sometimes not fetching entities correctly and failed thereby to render. While we identified the root cause of the user interface being too slow for the initial fetching, this PR is adding more transparency to this process by adding debug, warning, and error logs in unexpected cases.

The biggest logical change in this PR is the function `fetchMissingEntities` which is basically the previous effect but in a new callback. This function is now also imperatively called when we receive the design components. I added this as design components are not part of the React state and thus won't cause a re-rendering solely through this change. To avoid possible race conditions related to this, we're explicitly trying to fetch again when we're in this situation. 

~Also, I'm checking again the entities cache just before the JSX block as again we can't memoize data that is not in the React state (yes, I'm looking at you, `deisgnComponentsRegistry`!). Doing so, we can rely more on the true state of `areEntitiesFetched`.~

Update: To avoid infinite loops when entities are missing completely, I removed the manual map lookup and went back to fetch only once initially. I renamed the respective state variable, so it's clearer that this is about the initial fetch and is not intended to fetch automatically when something changed in the dataSource. As @SofiaMargariti pointed out, the new boolean `areEntitesResolvedInParent` (currently in the `development` branch) will make sure that our check runs once but also when the user interface is ready to handle it.

**Notes for the future:**
- I think that this boolean `areEntitiesFetched` is not the best approach. Every time we fetch something, we don't render any bindings on the canvas for a short moment which leads to a blinking in the UI. However, right now we need to do this as only through this boolean variable we force the child components to re-render and load the entities from the entitiy store. If we had some *more sophisticated state machine with selectors*, the components would be able to re-render as soon as the needed entities are in the store. By that, we could drop this boolean variable and don't have this blinking UI.
- The `designComponentsRegistry` should be moved to the React state. The current tweaks are not nice maintainable code. Alternatively, we could use `zustand` and use a selector which would ensure a re-rendering in React. Probably not a nice solution as we're trying to keep the SDK as lightweight as possible (though zustand is very lightweight).