### PR TITLE
fix: refetch when dataSource or design components changed [SPA-1711]

### DIFF
--- a/packages/experience-builder-sdk/src/blocks/editor/VisualEditorBlock.test.tsx
+++ b/packages/experience-builder-sdk/src/blocks/editor/VisualEditorBlock.test.tsx
@@ -95,7 +95,7 @@ describe('VisualEditorBlock', () => {
       <VisualEditorBlock
         node={mockCompositionComponentNode}
         dataSource={{}}
-        areInitialEntitiesFetched={true}
+        areEntitiesFetched={true}
         entityStore={{} as EntityStore}
         unboundValues={mockCompositionComponentNode.data.unboundValues}
         resolveDesignValue={jest.fn()}
@@ -108,7 +108,7 @@ describe('VisualEditorBlock', () => {
       <VisualEditorBlock
         node={mockCompositionComponentNode}
         dataSource={{}}
-        areInitialEntitiesFetched={true}
+        areEntitiesFetched={true}
         entityStore={{} as EntityStore}
         unboundValues={mockCompositionComponentNode.data.unboundValues}
         resolveDesignValue={jest.fn()}
@@ -137,7 +137,7 @@ describe('VisualEditorBlock', () => {
       <VisualEditorBlock
         node={sectionNode}
         dataSource={{}}
-        areInitialEntitiesFetched={true}
+        areEntitiesFetched={true}
         entityStore={{} as EntityStore}
         unboundValues={sectionNode.data.unboundValues}
         resolveDesignValue={jest.fn()}
@@ -165,7 +165,7 @@ describe('VisualEditorBlock', () => {
       <VisualEditorBlock
         node={containerNode}
         dataSource={{}}
-        areInitialEntitiesFetched={true}
+        areEntitiesFetched={true}
         entityStore={{} as EntityStore}
         unboundValues={containerNode.data.unboundValues}
         resolveDesignValue={jest.fn()}
@@ -212,7 +212,7 @@ describe('VisualEditorBlock', () => {
       <VisualEditorBlock
         node={designComponentNode}
         dataSource={{}}
-        areInitialEntitiesFetched={true}
+        areEntitiesFetched={true}
         entityStore={entityStore}
         unboundValues={designComponentNode.data.unboundValues}
         resolveDesignValue={jest.fn()}

--- a/packages/experience-builder-sdk/src/blocks/editor/VisualEditorBlock.tsx
+++ b/packages/experience-builder-sdk/src/blocks/editor/VisualEditorBlock.tsx
@@ -50,7 +50,7 @@ type VisualEditorBlockProps = {
 
   resolveDesignValue: ResolveDesignValueType;
   entityStore: EntityStore;
-  areInitialEntitiesFetched: boolean;
+  areEntitiesFetched: boolean;
 };
 
 export const VisualEditorBlock = ({
@@ -59,10 +59,10 @@ export const VisualEditorBlock = ({
   unboundValues,
   resolveDesignValue,
   entityStore,
-  areInitialEntitiesFetched,
+  areEntitiesFetched,
 }: VisualEditorBlockProps) => {
   const node = useMemo(() => {
-    if (rawNode.type === DESIGN_COMPONENT_NODE_TYPE && areInitialEntitiesFetched) {
+    if (rawNode.type === DESIGN_COMPONENT_NODE_TYPE && areEntitiesFetched) {
       return resolveDesignComponent({
         node: rawNode,
         entityStore,
@@ -70,7 +70,7 @@ export const VisualEditorBlock = ({
     }
 
     return rawNode;
-  }, [areInitialEntitiesFetched, entityStore, rawNode]);
+  }, [areEntitiesFetched, entityStore, rawNode]);
 
   const componentRegistration = useMemo(() => {
     const registration = getComponentRegistration(node.data.blockId as string);
@@ -127,7 +127,7 @@ export const VisualEditorBlock = ({
           const [, uuid, ...path] = variableMapping.path.split('/');
           const binding = dataSource[uuid] as Link<'Entry' | 'Asset'>;
 
-          let boundValue: string | Link<'Asset'> | undefined = areInitialEntitiesFetched
+          let boundValue: string | Link<'Asset'> | undefined = areEntitiesFetched
             ? entityStore.getValue(binding, path.slice(0, -1))
             : undefined;
 
@@ -136,7 +136,7 @@ export const VisualEditorBlock = ({
           // If successful, it means we have identified the linked asset.
 
           if (!boundValue) {
-            const maybeBoundAsset = areInitialEntitiesFetched
+            const maybeBoundAsset = areEntitiesFetched
               ? entityStore.getValue(binding, path.slice(0, -2))
               : undefined;
 
@@ -178,7 +178,7 @@ export const VisualEditorBlock = ({
     node.children,
     resolveDesignValue,
     dataSource,
-    areInitialEntitiesFetched,
+    areEntitiesFetched,
     entityStore,
     unboundValues,
   ]);
@@ -239,7 +239,7 @@ export const VisualEditorBlock = ({
               unboundValues={unboundValues}
               resolveDesignValue={resolveDesignValue}
               entityStore={entityStore}
-              areInitialEntitiesFetched={areInitialEntitiesFetched}
+              areEntitiesFetched={areEntitiesFetched}
             />
           );
         })

--- a/packages/experience-builder-sdk/src/blocks/editor/VisualEditorContext.tsx
+++ b/packages/experience-builder-sdk/src/blocks/editor/VisualEditorContext.tsx
@@ -121,7 +121,7 @@ export function VisualEditorContextProvider({
 
   // Either gets called when dataSource changed or designComponetsRegistry changed (manually)
   const fetchMissingEntities = useCallback(
-    async (newDataSource?: typeof dataSource) => {
+    async (newDataSource?: CompositionDataSource) => {
       const entityLinks = [
         ...Object.values(newDataSource ?? dataSource),
         ...designComponentsRegistry.values(),

--- a/packages/experience-builder-sdk/src/blocks/editor/VisualEditorContext.tsx
+++ b/packages/experience-builder-sdk/src/blocks/editor/VisualEditorContext.tsx
@@ -38,7 +38,7 @@ type VisualEditorContextType = {
   unboundValues: CompositionUnboundValues;
   breakpoints: Breakpoint[];
   entityStore: EditorModeEntityStore;
-  areInitialEntitiesFetched: boolean;
+  areEntitiesFetched: boolean;
 };
 
 export const VisualEditorContext = React.createContext<VisualEditorContextType>({
@@ -53,7 +53,7 @@ export const VisualEditorContext = React.createContext<VisualEditorContextType>(
   locale: null,
   breakpoints: [],
   entityStore: {} as EditorModeEntityStore,
-  areInitialEntitiesFetched: false,
+  areEntitiesFetched: false,
 });
 
 type VisualEditorContextProviderProps = {
@@ -86,7 +86,10 @@ export function VisualEditorContextProvider({
   const [isDragging, setIsDragging] = useState(false);
   const selectedNodeId = useRef<string>('');
   const [locale, setLocale] = useState<string>(initialLocale);
-  const [areInitialEntitiesFetched, setInitialEntitiesFetched] = useState(false);
+  // Set to true when entities were fetched from the parent app.
+  // Reset to false when we receive a tree update and need to validate
+  // again whether all necessary entities are fetched.
+  const [areEntitiesFetched, setEntitiesFetched] = useState(false);
   const [isFetchingEntities, setFetchingEntities] = useState(false);
 
   const [entityStore, setEntityStore] = useState<EditorModeEntityStore>(
@@ -113,40 +116,47 @@ export function VisualEditorContextProvider({
         locale: locale,
       })
     );
+    setEntitiesFetched(false);
   }, [entityStore, locale]);
 
   // Either gets called when dataSource changed or designComponetsRegistry changed (manually)
-  const fetchMissingEntities = useCallback(async () => {
-    const entityLinks = [...Object.values(dataSource), ...designComponentsRegistry.values()];
-    const { missingAssetIds, missingEntryIds } = entityStore.getMissingEntityIds(entityLinks);
-    // Only continue and trigger rerendering when we need to fetch something and we're not fetching yet
-    if (!missingAssetIds.length && !missingEntryIds.length) {
-      setInitialEntitiesFetched(true);
-      return;
-    }
-    setInitialEntitiesFetched(false);
-    setFetchingEntities(true);
-    try {
-      // Await until the fetching is done to update the state variable at the right moment
-      await entityStore.fetchEntities({ missingAssetIds, missingEntryIds });
-      console.debug('[exp-builder.sdk] Finished fetching entities', { entityStore, entityLinks });
-    } catch (error) {
-      console.error('[exp-builder.sdk] Failed fetching entities');
-      console.error(error);
-    } finally {
-      // Important to set this as it is the only state variable that triggers a rerendering
-      // of the components (changes inside the entityStore are not part of the state)
-      setInitialEntitiesFetched(true);
-      setFetchingEntities(false);
-    }
-  }, [dataSource, entityStore]);
+  const fetchMissingEntities = useCallback(
+    async (newDataSource?: typeof dataSource) => {
+      const entityLinks = [
+        ...Object.values(newDataSource ?? dataSource),
+        ...designComponentsRegistry.values(),
+      ];
+      const { missingAssetIds, missingEntryIds } = entityStore.getMissingEntityIds(entityLinks);
+      // Only continue and trigger rerendering when we need to fetch something and we're not fetching yet
+      if (!missingAssetIds.length && !missingEntryIds.length) {
+        setEntitiesFetched(true);
+        return;
+      }
+      setEntitiesFetched(false);
+      setFetchingEntities(true);
+      try {
+        // Await until the fetching is done to update the state variable at the right moment
+        await entityStore.fetchEntities({ missingAssetIds, missingEntryIds });
+        console.debug('[exp-builder.sdk] Finished fetching entities', { entityStore, entityLinks });
+      } catch (error) {
+        console.error('[exp-builder.sdk] Failed fetching entities');
+        console.error(error);
+      } finally {
+        // Important to set this as it is the only state variable that triggers a rerendering
+        // of the components (changes inside the entityStore are not part of the state)
+        setEntitiesFetched(true);
+        setFetchingEntities(false);
+      }
+    },
+    [dataSource, entityStore]
+  );
 
   // When the tree was updated, we store the dataSource and
   // afterward, this effect fetches the respective entities.
   useEffect(() => {
-    if (areInitialEntitiesFetched || isFetchingEntities) return;
+    if (areEntitiesFetched || isFetchingEntities) return;
     fetchMissingEntities();
-  }, [areInitialEntitiesFetched, fetchMissingEntities, isFetchingEntities]);
+  }, [areEntitiesFetched, fetchMissingEntities, isFetchingEntities]);
 
   const reloadApp = () => {
     sendMessage(OUTGOING_EVENTS.CanvasReload, {});
@@ -245,12 +255,9 @@ export function VisualEditorContextProvider({
           // Make sure to first store the design components before setting the tree and thus triggering a rerender
           if (designComponents) {
             setDesignComponents(designComponents);
-            // Since design components are stored outside of the React state, we need to manually update the entity store
-            // TODO: Move designComponentsRegistry into React to avoid these async issues and manual tweaks
-            await fetchMissingEntities();
+            // If the designComponentEntry is not yet fetched, this will be done below by
+            // the imperative calls to fetchMissingEntities.
           }
-          setTree(tree);
-          setLocale(locale);
 
           if (changedNode) {
             /**
@@ -260,18 +267,26 @@ export function VisualEditorContextProvider({
              *
              * We still update the tree here so we don't have a stale "tree"
              */
-            changedValueType === 'BoundValue' &&
-              setDataSource((dataSource) => ({ ...dataSource, ...changedNode.data.dataSource }));
-            changedValueType === 'UnboundValue' &&
+            if (changedValueType === 'BoundValue') {
+              const newDataSource = { ...dataSource, ...changedNode.data.dataSource };
+              setDataSource(newDataSource);
+              await fetchMissingEntities(newDataSource);
+            } else if (changedValueType === 'UnboundValue') {
               setUnboundValues((unboundValues) => ({
                 ...unboundValues,
                 ...changedNode.data.unboundValues,
               }));
+            }
           } else {
             const { dataSource, unboundValues } = getDataFromTree(tree);
             setDataSource(dataSource);
             setUnboundValues(unboundValues);
+            await fetchMissingEntities(dataSource);
           }
+
+          // Update the tree when all necessary data is fetched and ready for rendering.
+          setTree(tree);
+          setLocale(locale);
           break;
         }
         case INCOMING_EVENTS.DesignComponentsAdded: {
@@ -337,7 +352,7 @@ export function VisualEditorContextProvider({
     return () => {
       window.removeEventListener('message', onMessage);
     };
-  }, [fetchMissingEntities, entityStore, mode]);
+  }, [fetchMissingEntities, entityStore, mode, dataSource]);
 
   /*
    * Handles on scroll business
@@ -397,7 +412,7 @@ export function VisualEditorContextProvider({
         locale,
         breakpoints: tree?.root.data.breakpoints ?? [],
         entityStore,
-        areInitialEntitiesFetched,
+        areEntitiesFetched,
       }}>
       {children}
     </VisualEditorContext.Provider>

--- a/packages/experience-builder-sdk/src/blocks/editor/VisualEditorRoot.tsx
+++ b/packages/experience-builder-sdk/src/blocks/editor/VisualEditorRoot.tsx
@@ -40,7 +40,7 @@ const VisualEditorRootComponents = () => {
     unboundValues,
     breakpoints,
     entityStore,
-    areInitialEntitiesFetched,
+    areEntitiesFetched,
   } = useEditorContext();
 
   // We call it here instead of on block-level to avoid registering too many even listeners for media queries
@@ -70,7 +70,7 @@ const VisualEditorRootComponents = () => {
           unboundValues={unboundValues}
           resolveDesignValue={resolveDesignValue}
           entityStore={entityStore}
-          areInitialEntitiesFetched={areInitialEntitiesFetched}
+          areEntitiesFetched={areEntitiesFetched}
         />
       ))}
     </div>

--- a/packages/experience-builder-sdk/src/core/editor/designComponentUtils.ts
+++ b/packages/experience-builder-sdk/src/core/editor/designComponentUtils.ts
@@ -122,6 +122,12 @@ export const resolveDesignComponent = ({
     return node;
   }
 
+  if (!componentFields.componentTree?.children) {
+    console.warn(`Component tree for design component with ID '${componentId}' not found`, {
+      componentFields,
+    });
+  }
+
   const deserializedNode = deserializeDesignComponentNode({
     node: {
       definitionId: node.data.blockId || '',


### PR DESCRIPTION
With my previous PR, the SDK did only fetch once which caused rendering issues as nto all entities might have been requested yet.

Now, we're checking the entityStore and update it everytime the data source or design components change (via componentTreeUpdated)