### PR TITLE
fix(core): add design token fallback values based on default values [ALT-200]

### DIFF
--- a/packages/core/src/registries/designTokenRegistry.ts
+++ b/packages/core/src/registries/designTokenRegistry.ts
@@ -1,4 +1,5 @@
 import { DesignTokensDefinition } from '@/types';
+import { builtInStyles, optionalBuiltInStyles } from '../definitions/styles';
 
 export const designTokensRegistry: DesignTokensDefinition = {};
 
@@ -13,22 +14,32 @@ export const defineDesignTokens = (designTokenDefinition: DesignTokensDefinition
 
 const templateStringRegex = /\${(.+?)}/g;
 
-export const getDesignTokenRegistration = (breakpointValue: string) => {
+export const getDesignTokenRegistration = (breakpointValue: string, variableName: string) => {
   if (!breakpointValue) return breakpointValue;
 
   let resolvedValue = '';
   for (const part of breakpointValue.split(' ')) {
-    const tokenValue = templateStringRegex.test(part) ? resolveSimpleDesignToken(part) : part;
+    const tokenValue = templateStringRegex.test(part)
+      ? resolveSimpleDesignToken(part, variableName)
+      : part;
     resolvedValue += `${tokenValue} `;
   }
   // Not trimming would end up with a trailing space that breaks the check in `calculateNodeDefaultHeight`
   return resolvedValue.trim();
 };
 
-const resolveSimpleDesignToken = (templateString: string) => {
+const resolveSimpleDesignToken = (templateString: string, variableName: string) => {
   const nonTemplateValue = templateString.replace(templateStringRegex, '$1');
-  const designKeys = nonTemplateValue.split('.');
-  const spacingValues = designTokensRegistry[designKeys[0]] as DesignTokensDefinition;
-  const resolvedValue = spacingValues[designKeys[1]] as string;
-  return resolvedValue || '0px';
+  const [tokenCategory, tokenName] = nonTemplateValue.split('.');
+  const spacingValues = designTokensRegistry[tokenCategory];
+  if (spacingValues && spacingValues[tokenName]) {
+    return spacingValues[tokenName];
+  }
+  if (builtInStyles[variableName]) {
+    return builtInStyles[variableName].defaultValue;
+  }
+  if (optionalBuiltInStyles[variableName]) {
+    return optionalBuiltInStyles[variableName].defaultValue;
+  }
+  return '0px';
 };

--- a/packages/core/src/utils/breakpoints.ts
+++ b/packages/core/src/utils/breakpoints.ts
@@ -101,7 +101,7 @@ export const getValueForBreakpoint = (
         const breakpointValue =
           valuesByBreakpoint[breakpointId] || valuesByBreakpoint[fallbackBreakpointId];
 
-        return getDesignTokenRegistration(breakpointValue);
+        return getDesignTokenRegistration(breakpointValue, variableName);
       }
       if (valuesByBreakpoint[breakpointId]) {
         // If the value is defined, we use it and stop the breakpoints cascade


### PR DESCRIPTION
Prevent errors like the one below when design tokens are removed after an experience was saved/published with a design token selected.

![](https://github.com/contentful/experience-builder/assets/8539634/77f9ada5-020f-44ff-8f45-4c4bc8441cfb)

I updated `resolveSimpleDesignToken` to use the the default values from `builtInStyles` or `optionalBuiltInStyles` as a fallback value if available, since that would provide a better value to use as the fallback that can vary based on the variable.