### PR TITLE
fix(visual-editor): rich text binding should work [SPA-1758]

### DIFF
--- a/packages/visual-editor/src/hooks/useComponentProps.tsx
+++ b/packages/visual-editor/src/hooks/useComponentProps.tsx
@@ -104,7 +104,7 @@ export const useComponentProps = ({
 
           if (
             typeof boundValue === 'object' &&
-            (boundValue as Link<'Entry' | 'Asset'>).sys.linkType === 'Asset'
+            (boundValue as Link<'Entry' | 'Asset'>)?.sys?.linkType === 'Asset'
           ) {
             boundValue = entityStore?.getValue(boundValue, ['fields', 'file']);
           }


### PR DESCRIPTION
When binding to rich text, `boundValue` can be an object but will not have a `sys` object  or `linkType`. So added optional operator. 
This should fix the binding to rich text field. 