### PR TITLE
fix: handle missing linkType property [SPA-1762]

### DIFF
--- a/packages/core/src/entity/EditorModeEntityStore.ts
+++ b/packages/core/src/entity/EditorModeEntityStore.ts
@@ -80,7 +80,7 @@ export class EditorModeEntityStore extends EditorEntityStore {
     entityLink: UnresolvedLink<'Entry' | 'Asset'> | undefined,
     path: string[]
   ): string | undefined {
-    if (!entityLink) return;
+    if (!entityLink || !entityLink.sys) return;
 
     const fieldValue = super.getValue(entityLink, path);
 

--- a/packages/visual-editor/src/hooks/useComponentProps.tsx
+++ b/packages/visual-editor/src/hooks/useComponentProps.tsx
@@ -102,10 +102,7 @@ export const useComponentProps = ({
             }
           }
 
-          if (
-            typeof boundValue === 'object' &&
-            (boundValue as Link<'Entry' | 'Asset'>).sys.linkType === 'Asset'
-          ) {
+          if (typeof boundValue === 'object' && boundValue.sys?.linkType === 'Asset') {
             boundValue = entityStore?.getValue(boundValue, ['fields', 'file']);
           }
 


### PR DESCRIPTION
When selecting an asset with a newly added file, the SDK sometimes has some kind of hick-up - not sure why exactly. As a result, it throws an error that it is unable to read property `linkType` of undefined. To avoid these unexpected issues, I added some safety checks if `sys` is even existing in the related places.

### Reproducing the error
https://github.com/contentful/experience-builder/assets/9327071/37fadf02-6705-4683-8af1-2140190bdc2a

### The error
<img width="825" alt="Screenshot 2024-01-10 at 16 31 16" src="https://github.com/contentful/experience-builder/assets/9327071/7b6dbc6a-70b7-4ab5-a9f1-859a3ac4d49c">

### The sent over entity
<img width="773" alt="Screenshot 2024-01-10 at 16 32 17" src="https://github.com/contentful/experience-builder/assets/9327071/ee3b563f-2da6-4034-9072-38262851218c">
