### PR TITLE
fix: change default border style color to 0px width []

### DIFF
--- a/packages/core/src/definitions/styles.ts
+++ b/packages/core/src/definitions/styles.ts
@@ -110,7 +110,7 @@ export const builtInStyles: Partial<
     type: 'Text',
     group: 'style',
     description: 'The border of the section',
-    defaultValue: '1px outside rgba(0,0,0,1)',
+    defaultValue: '0px outside rgba(255, 255, 255, 1)',
   },
   cfGap: {
     displayName: 'Gap',

--- a/packages/core/src/registries/designTokenRegistry.ts
+++ b/packages/core/src/registries/designTokenRegistry.ts
@@ -47,5 +47,5 @@ const resolveSimpleDesignToken = (templateString: string, variableName: string) 
   if (optionalBuiltInStyles[variableName]) {
     return optionalBuiltInStyles[variableName].defaultValue;
   }
-  return variableName === 'cfBorder' ? '1px outside rgba(0,0,0,1)' : '0px';
+  return '0px';
 };


### PR DESCRIPTION
Changing the default border style to 0px width and white to align with the default background color.

Without design tokens defined:

![Screenshot 2024-01-10 at 11 08 32 AM](https://github.com/contentful/experience-builder/assets/8539634/672193ed-90a3-4ee0-8cbf-628fd9304412)

With design tokens:

![Screenshot 2024-01-10 at 11 07 31 AM](https://github.com/contentful/experience-builder/assets/8539634/3b0e87d7-056c-4a4c-a59f-5574446b0fc2)
