### PR TITLE
fix(core): enable design tokens for text color style [ALT-249]

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -279,11 +279,12 @@ export type RecursiveDesignTokenDefinition = {
 export type DesignTokensDefinition = {
   spacing?: Record<string, string>;
   sizing?: Record<string, string>;
-  colors?: Record<string, string>;
-  borders?: Record<string, { width: string; style: 'inside' | 'outside'; color: string }>;
+  color?: Record<string, string>;
+  border?: Record<string, { width: string; style: 'inside' | 'outside'; color: string }>;
   fontSize?: Record<string, string>;
   lineHeight?: Record<string, string>;
   letterSpacing?: Record<string, string>;
+  textColor?: Record<string, string>;
 } & RecursiveDesignTokenDefinition;
 
 export type ExperienceEntry = {

--- a/packages/core/src/utils/breakpoints.ts
+++ b/packages/core/src/utils/breakpoints.ts
@@ -86,6 +86,7 @@ const builtInStylesWithDesignTokens = [
   'cfFontSize',
   'cfLineHeight',
   'cfLetterSpacing',
+  'cfTextColor',
 ];
 
 export const getValueForBreakpoint = (


### PR DESCRIPTION
Changes

* Enable design tokens for text color styling
* Rename `border` and `color` tokens to singular for consistency