### PR TITLE
fix(visual-editor): render assembly nodes by passing the required props [ALT-255]

### DIFF
--- a/packages/experience-builder-sdk/src/blocks/preview/CompositionBlock.tsx
+++ b/packages/experience-builder-sdk/src/blocks/preview/CompositionBlock.tsx
@@ -21,10 +21,14 @@ import {
   createDesignComponentRegistration,
   getComponentRegistration,
 } from '../../core/componentRegistry';
-import { buildCfStyles, checkIfDesignComponent } from '@contentful/experience-builder-core';
+import {
+  buildCfStyles,
+  checkIfDesignComponent,
+  transformContentValue,
+} from '@contentful/experience-builder-core';
 import { useStyleTag } from '../../hooks/useStyleTag';
 import { ContentfulContainer } from '@contentful/experience-builder-components';
-import { transformContentValue } from '../../utils/transformers';
+
 import { resolveDesignComponent } from '../../core/preview/designComponentUtils';
 import { DesignComponent } from '../../components/DesignComponent';
 

--- a/packages/visual-editor/src/hooks/useComponent.tsx
+++ b/packages/visual-editor/src/hooks/useComponent.tsx
@@ -60,6 +60,9 @@ export const useComponent = ({ node: rawNode, resolveDesignValue }: ComponentPar
   const { editorMode, renderDropzone, ...componentProps } = props;
   const elementToRender = builtInComponents.includes(node.data.blockId || '') ? (
     <ContentfulContainer {...props} />
+  ) : node.type === DESIGN_COMPONENT_NODE_TYPE ? (
+    // DesignComponent.tsx requires renderDropzone and editorMode as well
+    React.createElement(componentRegistration.component, props)
   ) : (
     React.createElement(componentRegistration.component, componentProps)
   );


### PR DESCRIPTION
Reverts contentful/experience-builder#231

Currently, the rendering of assemblies is broken. To remove this critical bug, we will just revert this fix for now.