### PR TITLE
chore(experience-builder-sdk): update readme [ALT-250]

### DIFF
--- a/packages/experience-builder-sdk/README.md
+++ b/packages/experience-builder-sdk/README.md
@@ -33,7 +33,13 @@ function MyButton({ buttonTitle, buttonUrl, ...props }) {
 Please find more setup examples [on a dedicated Wiki page](https://github.com/contentful/experience-builder/wiki/Setup-examples)
 
 ```tsx
-import { useFetchBySlug, ExperienceRoot, defineComponents } from '@contentful/experience-builder';
+import {
+  defineComponents,
+  defineDesignTokens,
+  ExperienceRoot,
+  useFetchBySlug,
+} from '@contentful/experience-builder';
+
 import { createClient } from 'contentful';
 
 // component example can be found at the top of this document
@@ -46,7 +52,7 @@ const client = createClient({
   accessToken: 'YOUR_PREVIEW_OR_DELIVERY_TOKEN', // needs to be preview token if host = 'preview.contentful.com' and delivery token if 'cdn.contentful.com'
 });
 
-// 1. Define components outside of React (or within React - see 2.5)
+// 1. Define components outside of React
 defineComponents([
   {
     component: MyButton, // example component defined above in this file
@@ -64,6 +70,12 @@ defineComponents([
   },
 ]);
 
+// 2. Define design tokens
+defineDesignTokens({
+  spacing: { XS: '4px', S: '16px', M: '32px', L: '64px', XL: '128px' },
+  color: { Slate: '#94a3b8', Azure: 'azure', Orange: '#fdba74' },
+});
+
 const Home = () => {
 
   // You could pull these values from your router, state, etc...
@@ -72,7 +84,7 @@ const Home = () => {
   const mode = 'delivery'; // 'delivery' or 'preview'
   const experienceTypeId = 'layout'; // the content id of the experience to fetch
 
-  // 2. Fetch the experience
+  // 3. Fetch the experience
   const { experience, error, isLoading } = useFetchBySlug({
     client,
     slug,
@@ -81,17 +93,17 @@ const Home = () => {
     localeCode,
   });
 
-  // 3. Handle loading state
+  // 4. Handle loading state
   if(isLoading) {
     return <div>Loading...</div>
   }
 
-  // 4. Handle errors
+  // 5. Handle errors
   if (error) {
     return <div>{error.message}</div>;
   }
 
-  // 5. Render the experience
+  // 6. Render the experience
   return (
     <ExperienceRoot
       experience={experience}
@@ -101,40 +113,3 @@ const Home = () => {
   );
 };
 ```
-
-
-## Registering Design Tokens
-
-In order to define your design tokens import the `defineDesignTokens` hook.
-```
-import { defineDesignTokens } from '@contentful/experience-builder'
-```
-
-There are several key terms that are specifically tied to the Design sidebar in Experience Builder, namely `spacing`, `sizing`, `colors`, and `borders`. You are also free to define your own custom key-value pairings however you like, just keep in mind that the key terms listed are specifically reserved to affect the Design sidebar.
-
-Here's a quick example of a DesignTokenDefinition.
-```
-const DesignTokensDefinition = {
-  spacing: { XS: '4px', S: '16px', M: '32px', L: '64px', XL: '128px' },
-  sizing: { XS: '16px', S: '100px', M: '300px', L: '600px', XL: '1024px' },
-  colors: {
-    "Slate": "#94a3b8",
-    "Azure": "azure",
-    "Orange": "#fdba74",
-    "Blue": "#0000Ff",
-
-  },
-  border: {
-    "Azure": { width: '20px', style: 'outside', color: Colors.Azure },
-    "Hero": { width: '20px', style: 'outside', color: "#ffaabb" },
-    "Card": { width: '10px', style: 'inside', color: "#ffccbb" },
-    "Carousel": { width: '15px', style: 'outside', color: 'rgba(30, 25, 25, 0.75)', },
-  }
-}
-defineDesignTokens(DesignTokensDefinition)
-```
-
-Notice that for `spacing`, `sizing`, and `colors` that it's just a simple key-value object. `border` however, is a more complex object where its values have three parts rather than just a single string value.
-
-## Design Token Documentation
-Please refer to our [our Wiki page](https://github.com/contentful/experience-builder/wiki#design-token-documentation) for Design Token Documentation

--- a/packages/experience-builder-sdk/README.md
+++ b/packages/experience-builder-sdk/README.md
@@ -70,7 +70,7 @@ defineComponents([
   },
 ]);
 
-// 2. Define design tokens
+// 2. Define design tokens (optional)
 defineDesignTokens({
   spacing: { XS: '4px', S: '16px', M: '32px', L: '64px', XL: '128px' },
   color: { Slate: '#94a3b8', Azure: 'azure', Orange: '#fdba74' },


### PR DESCRIPTION
Readme revisions for design tokens.

Design Tokens are introduced at the bottom of the Wiki Home page:
* https://github.com/contentful/experience-builder/wiki#registering-design-tokens

Design Token Definitions are more thoroughly described in the Design Tokens dedicated Wiki page:
* https://github.com/contentful/experience-builder/wiki/Design-Tokens#design-tokens-definition