### PR TITLE
fix(visual-editor): change component outlines and dropzone backgrounds [ALT-273] [ALT-275]

### DIFF
--- a/packages/visual-editor/src/components/Dropzone/styles.module.css
+++ b/packages/visual-editor/src/components/Dropzone/styles.module.css
@@ -3,8 +3,8 @@
   margin-right: auto;
   position: relative;
   height: 100%;
-  outline-offset: -1px;
-  outline: 1px solid transparent;
+  outline-offset: -2px;
+  outline: 2px solid transparent;
   width: 100%;
   transition: outline 0.2s;
   min-height: 120px;
@@ -39,11 +39,11 @@
 }
 
 .isDragging {
-  outline: 1px dashed var(--exp-builder-blue500);
+  outline: 2px dashed var(--exp-builder-blue500);
 }
 
 .isHovering {
-  /* outline: 1px solid var(--exp-builder-gray800); */
+  /* outline: 2px solid var(--exp-builder-gray800); */
 }
 
 .isHovering > .overlay {
@@ -54,6 +54,6 @@
 }
 
 .isDestination:not(.isRoot) {
-  outline: 1px dashed var(--exp-builder-blue500);
-  background-color: var(--exp-builder-blue100);
+  outline: 2px dashed var(--exp-builder-blue500);
+  background-color: rgba(var(--exp-builder-blue100-rgb), 0.5);
 }

--- a/packages/visual-editor/src/components/EmptyContainer/EmptyContainer.module.css
+++ b/packages/visual-editor/src/components/EmptyContainer/EmptyContainer.module.css
@@ -10,16 +10,20 @@
   color: var(--exp-builder-gray400);
   font-size: var(--exp-builder-font-size-l);
   font-family: var(--exp-builder-font-stack-primary);
-  outline: 1px dashed var(--exp-builder-gray500);
-  outline-offset: -1px;
+  outline: 2px dashed var(--exp-builder-gray400);
+  outline-offset: -2px;
 }
 
 .highlight:hover {
-  outline: 1px dashed var(--exp-builder-blue500);
-  background-color: var(--exp-builder-blue100);
+  outline: 2px dashed var(--exp-builder-blue500);
+  background-color: rgba(var(--exp-builder-blue100-rgb), 0.5);
   cursor: grabbing;
 }
 
-.icon {
+.icon rect {
+  fill: var(--exp-builder-gray400);
+}
+
+.label {
   margin-left: var(--exp-builder-spacing-s);
 }

--- a/packages/visual-editor/src/components/EmptyContainer/EmptyContainer.tsx
+++ b/packages/visual-editor/src/components/EmptyContainer/EmptyContainer.tsx
@@ -15,13 +15,17 @@ export const EmptyEditorContainer = ({ isDragging }: EmptyContainerProps) => {
         [styles.highlight]: isDragging,
       })}
       data-type="empty-container">
-      <svg xmlns="http://www.w3.org/2000/svg" width="37" height="36" fill="none">
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="37"
+        height="36"
+        fill="none"
+        className={styles.icon}>
         <rect
           width="11.676"
           height="11.676"
           x="18.512"
           y=".153"
-          fill="#CFD9E0"
           rx="1.621"
           transform="rotate(45 18.512 .153)"
         />
@@ -30,7 +34,6 @@ export const EmptyEditorContainer = ({ isDragging }: EmptyContainerProps) => {
           height="11.676"
           x="9.254"
           y="9.139"
-          fill="#CFD9E0"
           rx="1.621"
           transform="rotate(45 9.254 9.139)"
         />
@@ -39,7 +42,6 @@ export const EmptyEditorContainer = ({ isDragging }: EmptyContainerProps) => {
           height="11.676"
           x="18.011"
           y="18.625"
-          fill="#CFD9E0"
           rx="1.621"
           transform="rotate(45 18.01 18.625)"
         />
@@ -48,7 +50,6 @@ export const EmptyEditorContainer = ({ isDragging }: EmptyContainerProps) => {
           height="11.676"
           x="30.557"
           y="10.131"
-          fill="#CFD9E0"
           rx="1.621"
           transform="rotate(60 30.557 10.13)"
         />
@@ -60,7 +61,7 @@ export const EmptyEditorContainer = ({ isDragging }: EmptyContainerProps) => {
         />
       </svg>
 
-      <span className={styles.icon}>Add components to begin</span>
+      <span className={styles.label}>Add elements to begin</span>
     </div>
   );
 };

--- a/packages/visual-editor/src/global.css
+++ b/packages/visual-editor/src/global.css
@@ -14,7 +14,7 @@ body {
 
 :root {
   /* Color tokens from Forma 36: https://f36.contentful.com/tokens/color-system */
-  --exp-builder-blue100: #e8f5ff;
+  --exp-builder-blue100: #e8f5ff; 
   --exp-builder-blue200: #ceecff;
   --exp-builder-blue300: #98cbff;
   --exp-builder-blue400: #40a0ff;
@@ -36,6 +36,10 @@ body {
   --exp-builder-red800: #7f0010;
   --exp-builder-color-white: #ffffff;
   --exp-builder-glow-primary: 0px 0px 0px 3px #e8f5ff;
+
+  /* RGB colors for applying opacity */
+  --exp-builder-blue100-rgb: 232, 245, 255;
+  --exp-builder-blue300-rgb: 152, 203, 255;
 
   /* Spacing tokens from Forma 36: https://f36.contentful.com/tokens/spacing */
   --exp-builder-spacing-s: 0.75rem;

--- a/packages/visual-editor/src/global.css
+++ b/packages/visual-editor/src/global.css
@@ -14,7 +14,7 @@ body {
 
 :root {
   /* Color tokens from Forma 36: https://f36.contentful.com/tokens/color-system */
-  --exp-builder-blue100: #e8f5ff; 
+  --exp-builder-blue100: #e8f5ff;
   --exp-builder-blue200: #ceecff;
   --exp-builder-blue300: #98cbff;
   --exp-builder-blue400: #40a0ff;

--- a/packages/visual-editor/src/hooks/usePlaceholderStyle.ts
+++ b/packages/visual-editor/src/hooks/usePlaceholderStyle.ts
@@ -135,10 +135,9 @@ export const usePlaceholderStyle = () => {
         height: direction === 'horizontal' ? '100%' : clientHeight,
         width: direction === 'horizontal' ? clientWidth : '100%',
         zIndex: 0,
-        opacity: 0.4,
-        backgroundColor: 'var(--exp-builder-blue200)',
-        outline: '1px dashed var(--exp-builder-blue600)',
-        outlineOffset: -1,
+        backgroundColor: 'rgba(var(--exp-builder-blue300-rgb), 0.5)',
+        outline: '2px dashed var(--exp-builder-blue600)',
+        outlineOffset: '-2px',
       });
     },
     [zones, updateStyle]


### PR DESCRIPTION
Changes
* For [ALT-273](https://contentful.atlassian.net/browse/ALT-273): outline width increased from 1px to 2px
* For [ALT-275](https://contentful.atlassian.net/browse/ALT-275): updated colors of some component outlines and dropzone backgrounds (changes made in coordination with Travis on Zoom)

![Screenshot 2024-01-12 at 3 34 44 PM](https://github.com/contentful/experience-builder/assets/8539634/07b01f62-da49-4fd5-8c13-9d4ba0b06bff)
![Screenshot 2024-01-12 at 3 35 23 PM](https://github.com/contentful/experience-builder/assets/8539634/509c2f78-8104-4c65-9e56-0ef3301cdf55)
![Screenshot 2024-01-12 at 3 36 07 PM](https://github.com/contentful/experience-builder/assets/8539634/14cf6fa1-bce7-42fb-92ca-559b7ea93fec)
![Screenshot 2024-01-12 at 3 36 20 PM](https://github.com/contentful/experience-builder/assets/8539634/c311ccf2-8575-451b-bb93-787ea15b6190)
![Screenshot 2024-01-12 at 3 36 16 PM](https://github.com/contentful/experience-builder/assets/8539634/794ca1bb-88d8-4d75-9a1d-8cfcc9a411f4)
![Screenshot 2024-01-12 at 3 45 48 PM](https://github.com/contentful/experience-builder/assets/8539634/24a78d3e-7b28-4a65-952f-ad29bac88655)
![Screenshot 2024-01-12 at 3 46 00 PM](https://github.com/contentful/experience-builder/assets/8539634/d92a8950-cae5-4668-99ff-25751e1a41fe)

[ALT-273]: https://contentful.atlassian.net/browse/ALT-273?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ALT-275]: https://contentful.atlassian.net/browse/ALT-275?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ