### PR TITLE
fix(experience-builder): only accept new assembly event [SPA-1730]

### DIFF
--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -36,9 +36,15 @@ export const INCOMING_EVENTS = {
   SelectComponent: 'selectComponent',
   HoverComponent: 'hoverComponent',
   UpdatedEntity: 'updatedEntity',
-  /** @deprecated use `AssembliesAdded` instead. This will be removed in version 5. */
+  /**
+   * @deprecated use `AssembliesAdded` instead. This will be removed in version 5.
+   * In the meanwhile, the experience builder will send the old and the new event to support multiple SDK versions.
+   */
   DesignComponentsAdded: 'designComponentsAdded',
-  /** @deprecated use `AssembliesRegistered` instead. This will be removed in version 5. */
+  /**
+   * @deprecated use `AssembliesRegistered` instead. This will be removed in version 5.
+   * In the meanwhile, the experience builder will send the old and the new event to support multiple SDK versions.
+   */
   DesignComponentsRegistered: 'designComponentsRegistered',
   AssembliesAdded: 'assembliesAdded',
   AssembliesRegistered: 'assembliesRegistered',

--- a/packages/visual-editor/src/hooks/useEditorSubscriber.ts
+++ b/packages/visual-editor/src/hooks/useEditorSubscriber.ts
@@ -182,6 +182,9 @@ export function useEditorSubscriber() {
           setLocale(locale);
           break;
         }
+        case INCOMING_EVENTS.DesignComponentsRegistered:
+          // Event was deprecated and support will be discontinued with version 5
+          break;
         case INCOMING_EVENTS.AssembliesRegistered: {
           const { assemblies }: { assemblies: ComponentRegistration['definition'][] } = payload;
 
@@ -193,6 +196,9 @@ export function useEditorSubscriber() {
           });
           break;
         }
+        case INCOMING_EVENTS.DesignComponentsAdded:
+          // Event was deprecated and support will be discontinued with version 5
+          break;
         case INCOMING_EVENTS.AssembliesAdded: {
           const {
             assembly,

--- a/packages/visual-editor/src/hooks/useEditorSubscriber.ts
+++ b/packages/visual-editor/src/hooks/useEditorSubscriber.ts
@@ -182,7 +182,6 @@ export function useEditorSubscriber() {
           setLocale(locale);
           break;
         }
-        case INCOMING_EVENTS.DesignComponentsRegistered:
         case INCOMING_EVENTS.AssembliesRegistered: {
           const { assemblies }: { assemblies: ComponentRegistration['definition'][] } = payload;
 
@@ -194,7 +193,6 @@ export function useEditorSubscriber() {
           });
           break;
         }
-        case INCOMING_EVENTS.DesignComponentsAdded:
         case INCOMING_EVENTS.AssembliesAdded: {
           const {
             assembly,


### PR DESCRIPTION
We figured out that changing the payload of the iframe message can't just be addressed by a renaming with supporting old and new event type. The previous renaming leads to breaking changes for the SDK which we want to avoid.

For a smoother SDK migration time, we should instead use only the new event shape in the newer SDK and only support the older event shape in the older SDK (<=4.0.0-alpha.10).

To support both ways, the web app will send old and new events through the message channel until we drop the support for the deprecated functions.

TLDR; how the migration will work:
- Old SDK accepts only designComponentsAdded/ designComponentsRegistered (with param `designComponents`)
- New SDK accepts only assembliesAdded/ assembliesRegistered (with param `assemblies`)
- Experience Builder will send both events at once until we discontinue support for the old versions (starting with major version 5)