### PR TITLE
chore: use exact version for deps when resolving local path deps []

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,8 @@ jobs:
       - vault/configure-lerna
       - run: echo '//registry.npmjs.org/:_authToken=${NPM_TOKEN}' > ~/.npmrc
       - run: yarn build # This should not be needed, but without it it will not contain any files
-      - run: yarn lerna version --no-private --conventional-commits --conventional-prerelease --preid next --create-release github --yes
+      # Use the exact dependency version for local path specifiers. e.g. this avoids resolving `^0.0.2-alpha.15` to `0.0.2-dev-20240114T223125.0`
+      - run: yarn lerna version --exact --no-private --conventional-commits --conventional-prerelease --preid next --create-release github --yes
       - run: yarn lerna publish from-git --pre-dist-tag next --yes
 
 workflows:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -41,9 +41,9 @@ jobs:
           git config user.email "${{ github.actor}}@users.noreply.github.com"
 
           if [ ${{ github.ref_name }} = development ]; then
-            npx lerna publish prerelease --conventional-commits --conventional-prerelease --preid dev-$(date +%Y%m%dT%H%M%S) --no-changelog --no-git-tag-version --dist-tag dev --no-push --yes
+            npx lerna publish prerelease --exact --conventional-commits --conventional-prerelease --preid dev-$(date +%Y%m%dT%H%M%S) --no-changelog --no-git-tag-version --dist-tag dev --no-push --yes
           elif [ ${{ github.ref_name }} = next ]; then
-            npx lerna publish prerelease --conventional-commits --conventional-prerelease --preid alpha --yes --no-private --dist-tag latest
+            npx lerna publish prerelease --exact --conventional-commits --conventional-prerelease --preid alpha --yes --no-private --dist-tag latest
           else
             npx lerna publish --conventional-commits --conventional-graduate --yes --no-private --create-release github --dist-tag latest
           fi


### PR DESCRIPTION
In our colorful coin demo project, I observer the following issue:
We updated to the latest alpha version of the SDK but under the hood it resolves a deeper dependency from a month ago. This is since the range defined by the prefix `^` doesn't function as expected for alpha releases. In the example below it resolved `^0.0.2-alpha.15` to `0.0.2-dev-20240114T223125.0` which contains an outdated set of `INCOMING_EVENTS` and thus logged warnings and caused errors in the application.

<img width="1085" alt="Screenshot 2024-01-16 at 13 35 14" src="https://github.com/contentful/experience-builder/assets/9327071/37b187d5-d6ae-4629-b902-494e3d851e57">

![Screenshot 2024-01-16 at 13 38 19](https://github.com/contentful/experience-builder/assets/9327071/e5ea6254-0585-41af-a2c2-b2d025bb4b05)

https://github.com/lerna/lerna/tree/main/libs/commands/version#--exact