### PR TITLE
fix: update dropzone to consider children margins [ALT-282]

### DIFF
--- a/packages/visual-editor/src/hooks/usePlaceholderStyle.ts
+++ b/packages/visual-editor/src/hooks/usePlaceholderStyle.ts
@@ -48,15 +48,23 @@ export const usePlaceholderStyle = () => {
 
       if (destinationIndex > 0 && direction === 'vertical' && isRoot) {
         const childrenAbove = children.slice(0, destinationIndex);
-        clientY = childrenAbove.reduce(
-          (total, item) =>
+        clientY = childrenAbove.reduce((total, item) => {
+          const childrenMarginY = Array.from(item.children).reduce(
+            (childrenTotal, child) =>
+              childrenTotal +
+              parseInt(window.getComputedStyle(child).marginTop.replace('px', '')) +
+              parseInt(window.getComputedStyle(child).marginBottom.replace('px', '')),
+            0
+          );
+
+          return (
             total +
             item.clientHeight +
             parseInt(window.getComputedStyle(item).marginTop.replace('px', '')) +
-            parseInt(window.getComputedStyle(item).marginBottom.replace('px', '')),
-
-          0
-        );
+            parseInt(window.getComputedStyle(item).marginBottom.replace('px', '')) +
+            childrenMarginY
+          );
+        }, 0);
       }
 
       if (direction === 'vertical' && !isRoot) {


### PR DESCRIPTION
Fixes: https://contentful.atlassian.net/browse/ALT-282

The white gap between containers is a 50px margin-top set on the green container.  With these changes, this 50px margin-top is included in the `clientY` computation so the dropzone renders in the correct place.

![](https://github.com/contentful/experience-builder/assets/8539634/a87d97c2-b0ca-4f05-8a20-5e948e75cca9)
