### PR TITLE
fix: replace node completely with new assembly node [SPA-1775]

### DIFF
--- a/packages/components/src/components/ContentfulContainer/ContentfulContainerAsHyperlink.tsx
+++ b/packages/components/src/components/ContentfulContainer/ContentfulContainerAsHyperlink.tsx
@@ -11,7 +11,7 @@ import type {
 import { EntityStore } from '@contentful/visual-sdk';
 import { combineClasses } from '../../utils/combineClasses';
 
-export type ContentfulContainerProps<EditorMode = boolean> = EditorMode extends true
+export type ContentfulContainerAsHyperlinkProps<EditorMode = boolean> = EditorMode extends true
   ? {
       children?: React.ReactNode;
       className?: string;
@@ -37,7 +37,9 @@ export type ContentfulContainerProps<EditorMode = boolean> = EditorMode extends 
       children?: React.ReactNode;
     };
 
-export const ContentfulContainerAsHyperlink: React.FC<ContentfulContainerProps> = (props) => {
+export const ContentfulContainerAsHyperlink: React.FC<ContentfulContainerAsHyperlinkProps> = (
+  props
+) => {
   const { cfHyperlink, cfOpenInNewTab, editorMode, className, children } = props;
 
   let anchorTagProps = {};

--- a/packages/experience-builder-sdk/src/components/ContentfulContainerAsHyperlink.tsx
+++ b/packages/experience-builder-sdk/src/components/ContentfulContainerAsHyperlink.tsx
@@ -8,7 +8,7 @@ import type {
   StyleProps,
 } from '@contentful/experience-builder-core/types';
 
-export type ContentfulContainerProps<EditorMode = boolean> = EditorMode extends true
+export type ContentfulContainerAsHyperlinkProps<EditorMode = boolean> = EditorMode extends true
   ? {
       onMouseDown: MouseEventHandler<HTMLElement>;
       children?: React.ReactNode;
@@ -26,7 +26,7 @@ export type ContentfulContainerProps<EditorMode = boolean> = EditorMode extends 
       editorMode: EditorMode;
     };
 
-export const ContentfulContainerAsHyperlink = (props: ContentfulContainerProps) => {
+export const ContentfulContainerAsHyperlink = (props: ContentfulContainerAsHyperlinkProps) => {
   const { cfHyperlink, cfOpenInNewTab, children, editorMode, className } = props;
 
   let anchorTagProps = {};

--- a/packages/visual-editor/src/hooks/useComponent.tsx
+++ b/packages/visual-editor/src/hooks/useComponent.tsx
@@ -68,7 +68,7 @@ export const useComponent = ({ node: rawNode, resolveDesignValue }: ComponentPar
   // Only pass editor props to built-in components
   const { editorMode, renderDropzone, ...componentProps } = props;
   const elementToRender = builtInComponents.includes(node.data.blockId || '') ? (
-    <ContentfulContainer {...props} />
+    <ContentfulContainer {...(props as any)} />
   ) : node.type === DESIGN_COMPONENT_NODE_TYPE || node.type === ASSEMBLY_NODE_TYPE ? (
     // Assembly.tsx requires renderDropzone and editorMode as well
     React.createElement(componentRegistration.component, props)

--- a/packages/visual-editor/src/hooks/useEditorSubscriber.ts
+++ b/packages/visual-editor/src/hooks/useEditorSubscriber.ts
@@ -221,10 +221,6 @@ export function useEditorSubscriber() {
             });
           }
 
-          //HACK: The node that is dropped doesn't identify as a designComponent,
-          //so we need to force a rerender to get a new tree, which correctly identifies the node as a designComponent
-          sendMessage(OUTGOING_EVENTS.RequestComponentTreeUpdate);
-
           break;
         }
         case INCOMING_EVENTS.CanvasResized: {

--- a/packages/visual-editor/src/store/tree.ts
+++ b/packages/visual-editor/src/store/tree.ts
@@ -75,7 +75,7 @@ export const useTreeStore = create<TreeStore>((set, get) => ({
               addChildNode(diff.indexToAdd, diff.parentNodeId, diff.nodeToAdd, state.tree.root);
               break;
             case TreeAction.REPLACE_NODE:
-              replaceNode(diff.originalId, diff.node, state.tree.root);
+              replaceNode(diff.indexToReplace, diff.node, state.tree.root);
               break;
             case TreeAction.UPDATE_NODE:
               updateNode(diff.nodeId, diff.node, state.tree.root);

--- a/packages/visual-editor/src/types/treeActions.ts
+++ b/packages/visual-editor/src/types/treeActions.ts
@@ -22,6 +22,7 @@ export interface ReplaceNode extends DiffBase {
   type: TreeAction.REPLACE_NODE;
   originalId: string;
   node: CompositionComponentNode;
+  indexToReplace: number;
 }
 
 export interface UpdateNode extends DiffBase {

--- a/packages/visual-editor/src/utils/getTreeDiff.ts
+++ b/packages/visual-editor/src/utils/getTreeDiff.ts
@@ -46,6 +46,7 @@ function missingNodeAction({
   return {
     type: TreeAction.REPLACE_NODE,
     originalId: currentNode.children[index].data.id,
+    indexToReplace: index,
     node: child,
   };
 }
@@ -94,6 +95,8 @@ function compareNodes({
   originalTree,
   differences = [],
 }: CompareNodeParams): Array<TreeDiff | null> {
+  // In the end, this map contains the list of nodes that are not present
+  // in the updated tree and must be removed
   const map = new Map<string, number>();
 
   if (!currentNode || !updatedNode) {
@@ -133,6 +136,10 @@ function compareNodes({
         tree: originalTree,
         currentNode,
       });
+      if (diff?.type === TreeAction.REPLACE_NODE) {
+        // Remove it from the deletion map to avoid adding another REMOVE_NODE action
+        map.delete(diff.originalId);
+      }
       return differences.push(diff);
     }
 

--- a/packages/visual-editor/src/utils/treeHelpers.ts
+++ b/packages/visual-editor/src/utils/treeHelpers.ts
@@ -14,19 +14,20 @@ export function updateNode(
   node.children.forEach((childNode) => updateNode(nodeId, updatedNode, childNode));
 }
 export function replaceNode(
-  nodeId: string,
+  indexToReplace: number,
   updatedNode: CompositionComponentNode,
   node: CompositionComponentNode
 ) {
-  if (node.data.id === nodeId) {
-    node.data = updatedNode.data;
-    node.type = updatedNode.type;
-    node.parentId = updatedNode.parentId;
-    node.children = updatedNode.children;
+  if (node.data.id === updatedNode.parentId) {
+    node.children = [
+      ...node.children.slice(0, indexToReplace),
+      updatedNode,
+      ...node.children.slice(indexToReplace + 1),
+    ];
     return;
   }
 
-  node.children.forEach((childNode) => updateNode(nodeId, updatedNode, childNode));
+  node.children.forEach((childNode) => replaceNode(indexToReplace, updatedNode, childNode));
 }
 
 export function reorderChildrenNodes(


### PR DESCRIPTION
When creating a new assembly out of an existing container, the tree diff logic was making two mistakes:
- It detected not only the "replace" action but also the "remove" action which led to not rendering the new node at all
- The replace action itself did not replace the node fully which caused a weird mix of the original block node and new assembly node with warning logs and missing designs for the container inside the new assembly node.

I addressed the first problem by explicitly handling this case. The second one I could resolve by capturing the index of the node that should be replaced. I could then replace the node as a whole via its parent and the index.

## Screenshot of the adjusted tree diff action
![Screenshot 2024-01-17 at 15 07 23](https://github.com/contentful/experience-builder/assets/9327071/e8f816ac-47e9-4d5f-ae9d-4ad9cf81b6b1)
