### PR TITLE
fix: show outline when hovering over readonly assembly blocks [ALT-260]

### DIFF
--- a/packages/visual-editor/src/components/Draggable/DraggableComponent.tsx
+++ b/packages/visual-editor/src/components/Draggable/DraggableComponent.tsx
@@ -8,6 +8,7 @@ export const DraggableComponent = ({
   children,
   id,
   index,
+  isAssemblyBlock = false,
   isSelected = false,
   onClick = () => null,
   onMouseDown = () => null,
@@ -26,6 +27,7 @@ export const DraggableComponent = ({
   children: ReactNode;
   id: string;
   index: number;
+  isAssemblyBlock?: boolean;
   isSelected?: boolean;
   onClick?: (e: SyntheticEvent) => void;
   onMouseDown?: (e: SyntheticEvent) => void;
@@ -45,6 +47,7 @@ export const DraggableComponent = ({
           {...provided.dragHandleProps}
           {...rest}
           className={classNames(styles.DraggableComponent, className, {
+            [styles.isAssemblyBlock]: isAssemblyBlock,
             [styles.isDragging]: snapshot.isDragging,
             [styles.isSelected]: isSelected,
             [styles.userIsDragging]: userIsDragging,
@@ -58,7 +61,14 @@ export const DraggableComponent = ({
           onMouseDown={onMouseDown}
           onMouseUp={onMouseUp}
           onClick={onClick}>
-          {!isSelected ? <div className={styles.overlay}>{label}</div> : null}
+          {!isSelected ? (
+            <div
+              className={classNames(styles.overlay, {
+                [styles.overlayAssembly]: isAssemblyBlock,
+              })}>
+              {label}
+            </div>
+          ) : null}
 
           {children}
         </div>

--- a/packages/visual-editor/src/components/Draggable/styles.module.css
+++ b/packages/visual-editor/src/components/Draggable/styles.module.css
@@ -26,21 +26,20 @@
   position: absolute;
   top: 0;
   left: 0;
-  color: var(--exp-builder-color-white);
-  padding: 4px 8px;
-  transition: all 0.2s;
-  /* opacity: 0; */
-  font-family: var(--exp-builder-font-stack-primary);
   z-index: 1;
-  top: 0;
+  font-family: var(--exp-builder-font-stack-primary);
   font-size: 14px;
+  font-weight: 500;
   background-color: var(--exp-builder-gray500);
-  padding: 2px 6px 2px 5px;
-  color: white;
+  color: var(--exp-builder-color-white);
   border-radius: 0 0 2px 0;
+  padding: 2px 6px 2px 5px;
   transition: opacity 0.2s;
   opacity: 0;
-  font-weight: 500;
+}
+
+.overlayAssembly {
+  background-color: var(--exp-builder-purple600);
 }
 
 /* .DraggableComponent:hover .overlay {
@@ -55,15 +54,25 @@
   outline: 2px solid transparent !important;
 }
 
+.DraggableComponent:hover:not(:has(div[data-rfd-draggable-id]:hover)) > .overlay {
+  opacity: 1;
+}
+
 .DraggableComponent:hover,
 .DraggableComponent:hover div[data-rfd-draggable-id] {
   outline: 2px dashed var(--exp-builder-gray500);
 }
 
-.DraggableComponent:hover:not(:has(div[data-rfd-draggable-id]:hover)) > .overlay {
-  opacity: 1;
-}
-
 .DraggableComponent:hover:not(:has(div[data-rfd-draggable-id]:hover)) {
   outline: 2px solid var(--exp-builder-gray500);
+}
+
+.isAssemblyBlock:hover,
+.isAssemblyBlock:hover div[data-rfd-draggable-id],
+.DraggableComponent:hover div[data-rfd-draggable-id][data-cf-node-block-type^="assembly"] {
+  outline: 2px dashed var(--exp-builder-purple600) !important;
+}
+
+.isAssemblyBlock:hover:not(:has(div[data-rfd-draggable-id]:hover)) {
+  outline: 2px solid var(--exp-builder-purple600) !important;
 }

--- a/packages/visual-editor/src/components/Dropzone/EditorBlock.tsx
+++ b/packages/visual-editor/src/components/Dropzone/EditorBlock.tsx
@@ -59,8 +59,9 @@ const EditorBlock: React.FC<VisualEditorBlockProps> = ({
       label={label || 'No Label Specified'}
       id={`draggable-${componentId}`}
       index={index}
-      isSelected={selectedNodeId === componentId}
+      isAssemblyBlock={isAssemblyBlock}
       isDragDisabled={isAssemblyBlock}
+      isSelected={selectedNodeId === componentId}
       userIsDragging={userIsDragging}
       className={classNames({
         [styles.fullWidth]: isContainer && !wrapperProps.isFixedWidth,
@@ -70,10 +71,9 @@ const EditorBlock: React.FC<VisualEditorBlockProps> = ({
         e.stopPropagation();
 
         if (isAssemblyBlock && !containsZone) {
-          // Readonly components within assembly blocks cannot be selected
+          // Readonly components in an assembly cannot be selected
           return;
         }
-
         const nodeId = isAssemblyBlock ? parentSectionId : componentId;
         setSelectedNodeId(nodeId);
         sendMessage(OUTGOING_EVENTS.ComponentSelected, {

--- a/packages/visual-editor/src/components/Dropzone/EditorBlock.tsx
+++ b/packages/visual-editor/src/components/Dropzone/EditorBlock.tsx
@@ -54,18 +54,13 @@ const EditorBlock: React.FC<VisualEditorBlockProps> = ({
 
   const isAssemblyBlock = node.type === ASSEMBLY_BLOCK_NODE_TYPE;
 
-  // Currently, assembly blocks are not editable (readonly) so
-  // we simply render that underlying component instead of making it draggable
-  if (isAssemblyBlock) {
-    return elementToRender;
-  }
-
   return (
     <DraggableComponent
       label={label || 'No Label Specified'}
       id={`draggable-${componentId}`}
       index={index}
       isSelected={selectedNodeId === componentId}
+      isDragDisabled={isAssemblyBlock}
       userIsDragging={userIsDragging}
       className={classNames({
         [styles.fullWidth]: isContainer && !wrapperProps.isFixedWidth,
@@ -73,9 +68,16 @@ const EditorBlock: React.FC<VisualEditorBlockProps> = ({
       })}
       onClick={(e) => {
         e.stopPropagation();
-        setSelectedNodeId(componentId);
+
+        if (isAssemblyBlock && !containsZone) {
+          // Readonly components within assembly blocks cannot be selected
+          return;
+        }
+
+        const nodeId = isAssemblyBlock ? parentSectionId : componentId;
+        setSelectedNodeId(nodeId);
         sendMessage(OUTGOING_EVENTS.ComponentSelected, {
-          nodeId: componentId,
+          nodeId,
         });
       }}
       onMouseOver={(e) => {

--- a/packages/visual-editor/src/global.css
+++ b/packages/visual-editor/src/global.css
@@ -32,6 +32,7 @@ body {
   --exp-builder-gray700: #414d63;
   --exp-builder-gray800: #1b273a;
   --exp-builder-gray900: #111b2b;
+  --exp-builder-purple600: #6c3ecf;
   --exp-builder-red200: #ffe0e0;
   --exp-builder-red800: #7f0010;
   --exp-builder-color-white: #ffffff;


### PR DESCRIPTION
https://contentful.atlassian.net/browse/ALT-260

https://github.com/contentful/experience-builder/assets/8539634/d5580dc8-2ffd-4d18-a6fc-68b73df024dc

