### PR TITLE
fix: add dnd cypress stub [SPA-1712]

### DIFF
--- a/packages/visual-editor/src/components/RootRenderer/DNDProvider.tsx
+++ b/packages/visual-editor/src/components/RootRenderer/DNDProvider.tsx
@@ -1,0 +1,74 @@
+import useCanvasInteractions from '@/hooks/useCanvasInteractions';
+import { usePlaceholderStyle } from '@/hooks/usePlaceholderStyle';
+import { useDraggedItemStore } from '@/store/draggedItem';
+import { useEditorStore } from '@/store/editor';
+import { sendMessage } from '@contentful/experience-builder-core';
+import { OUTGOING_EVENTS } from '@contentful/experience-builder-core/constants';
+import { DragDropContext } from '@hello-pangea/dnd';
+import dragState from '@/utils/dragState';
+import React from 'react';
+import type { ReactNode } from 'react';
+
+type Props = {
+  children: ReactNode;
+};
+
+export const DNDProvider = ({ children }: Props) => {
+  const setSelectedNodeId = useEditorStore((state) => state.setSelectedNodeId);
+  const updateItem = useDraggedItemStore((state) => state.updateItem);
+  const { onAddComponent, onMoveComponent } = useCanvasInteractions();
+  const { onDragStartOrUpdate } = usePlaceholderStyle();
+
+  const dragStart = (start) => {
+    onDragStartOrUpdate(start);
+    setSelectedNodeId('');
+    sendMessage(OUTGOING_EVENTS.ComponentSelected, {
+      nodeId: '',
+    });
+  };
+
+  const dragUpdate = (update) => {
+    updateItem(update);
+    onDragStartOrUpdate(update);
+  };
+
+  const dragEnd = (droppedItem) => {
+    updateItem(undefined);
+    dragState.reset();
+
+    sendMessage(OUTGOING_EVENTS.MouseUp);
+
+    // User cancel drag
+    if (!droppedItem.destination) {
+      sendMessage(OUTGOING_EVENTS.ComponentDragCanceled);
+      return;
+    }
+
+    // New component added to canvas
+    if (droppedItem.source.droppableId.startsWith('component-list')) {
+      onAddComponent(droppedItem);
+    } else {
+      onMoveComponent(droppedItem);
+    }
+  };
+
+  const isTestRun =
+    typeof window !== 'undefined' && Object.prototype.hasOwnProperty.call(window, 'Cypress');
+  console.log('isTestRun', isTestRun);
+
+  return (
+    <DragDropContext onDragUpdate={dragUpdate} onBeforeDragStart={dragStart} onDragEnd={dragEnd}>
+      {isTestRun ? (
+        <div
+          data-test-id="dnd-context-substitute"
+          onDragStart={dragStart}
+          onDrag={dragUpdate}
+          onDragEnd={dragEnd}>
+          {children}
+        </div>
+      ) : (
+        children
+      )}
+    </DragDropContext>
+  );
+};

--- a/packages/visual-editor/src/components/RootRenderer/DNDProvider.tsx
+++ b/packages/visual-editor/src/components/RootRenderer/DNDProvider.tsx
@@ -8,6 +8,7 @@ import { DragDropContext } from '@hello-pangea/dnd';
 import dragState from '@/utils/dragState';
 import React from 'react';
 import type { ReactNode } from 'react';
+import { pick } from 'lodash-es';
 
 type Props = {
   children: ReactNode;
@@ -19,7 +20,15 @@ export const DNDProvider = ({ children }: Props) => {
   const { onAddComponent, onMoveComponent } = useCanvasInteractions();
   const { onDragStartOrUpdate } = usePlaceholderStyle();
 
-  const dragStart = (start) => {
+  const isTestRun =
+    typeof window !== 'undefined' && Object.prototype.hasOwnProperty.call(window, 'Cypress');
+  console.log('isTestRun', isTestRun);
+
+  const dragStart = (event) => {
+    const start = isTestRun
+      ? pick(event.nativeEvent, ['mode', 'draggableId', 'type', 'source', 'destination'])
+      : event;
+    console.log('SDK > dragStart', start);
     onDragStartOrUpdate(start);
     setSelectedNodeId('');
     sendMessage(OUTGOING_EVENTS.ComponentSelected, {
@@ -27,12 +36,20 @@ export const DNDProvider = ({ children }: Props) => {
     });
   };
 
-  const dragUpdate = (update) => {
+  const dragUpdate = (event) => {
+    const update = isTestRun
+      ? pick(event.nativeEvent, ['mode', 'draggableId', 'type', 'source', 'destination'])
+      : event;
+    console.log('SDK > dragUpdate', update);
     updateItem(update);
     onDragStartOrUpdate(update);
   };
 
-  const dragEnd = (droppedItem) => {
+  const dragEnd = (event) => {
+    const droppedItem = isTestRun
+      ? pick(event.nativeEvent, ['mode', 'draggableId', 'type', 'source', 'destination'])
+      : event;
+    console.log('SDK > dragEnd', droppedItem);
     updateItem(undefined);
     dragState.reset();
 
@@ -51,10 +68,6 @@ export const DNDProvider = ({ children }: Props) => {
       onMoveComponent(droppedItem);
     }
   };
-
-  const isTestRun =
-    typeof window !== 'undefined' && Object.prototype.hasOwnProperty.call(window, 'Cypress');
-  console.log('isTestRun', isTestRun);
 
   return (
     <DragDropContext onDragUpdate={dragUpdate} onBeforeDragStart={dragStart} onDragEnd={dragEnd}>

--- a/packages/visual-editor/src/components/RootRenderer/DNDProvider.tsx
+++ b/packages/visual-editor/src/components/RootRenderer/DNDProvider.tsx
@@ -22,13 +22,11 @@ export const DNDProvider = ({ children }: Props) => {
 
   const isTestRun =
     typeof window !== 'undefined' && Object.prototype.hasOwnProperty.call(window, 'Cypress');
-  console.log('isTestRun', isTestRun);
 
   const dragStart = (event) => {
     const start = isTestRun
       ? pick(event.nativeEvent, ['mode', 'draggableId', 'type', 'source', 'destination'])
       : event;
-    console.log('SDK > dragStart', start);
     onDragStartOrUpdate(start);
     setSelectedNodeId('');
     sendMessage(OUTGOING_EVENTS.ComponentSelected, {
@@ -40,7 +38,6 @@ export const DNDProvider = ({ children }: Props) => {
     const update = isTestRun
       ? pick(event.nativeEvent, ['mode', 'draggableId', 'type', 'source', 'destination'])
       : event;
-    console.log('SDK > dragUpdate', update);
     updateItem(update);
     onDragStartOrUpdate(update);
   };
@@ -49,7 +46,6 @@ export const DNDProvider = ({ children }: Props) => {
     const droppedItem = isTestRun
       ? pick(event.nativeEvent, ['mode', 'draggableId', 'type', 'source', 'destination'])
       : event;
-    console.log('SDK > dragEnd', droppedItem);
     updateItem(undefined);
     dragState.reset();
 

--- a/packages/visual-editor/src/components/RootRenderer/RootRenderer.tsx
+++ b/packages/visual-editor/src/components/RootRenderer/RootRenderer.tsx
@@ -32,8 +32,6 @@ export const RootRenderer: React.FC<Props> = ({ onChange }) => {
     if (onChange) onChange(tree);
   }, [tree, onChange]);
 
-  console.log(1);
-
   return (
     <DNDProvider>
       {dragItem && <DraggableContainer id={dragItem} />}

--- a/packages/visual-editor/src/components/RootRenderer/RootRenderer.tsx
+++ b/packages/visual-editor/src/components/RootRenderer/RootRenderer.tsx
@@ -1,22 +1,17 @@
 import React from 'react';
 import { useEffect } from 'react';
-import { DragDropContext } from '@hello-pangea/dnd';
 import { Dropzone } from '../Dropzone/Dropzone';
 import DraggableContainer from '../Draggable/DraggableComponentList';
-import { sendMessage } from '@contentful/experience-builder-core';
 import type { CompositionTree } from '@contentful/experience-builder-core/types';
-import { OUTGOING_EVENTS } from '@contentful/experience-builder-core/constants';
-import dragState from '@/utils/dragState';
-import { usePlaceholderStyle } from '@/hooks/usePlaceholderStyle';
+
 import { ROOT_ID } from '@/types/constants';
 import { useTreeStore } from '@/store/tree';
 import { useDraggedItemStore } from '@/store/draggedItem';
-import { useEditorStore } from '@/store/editor';
 import { useZoneStore } from '@/store/zone';
 import styles from './render.module.css';
 import { useBreakpoints } from '@/hooks/useBreakpoints';
 import { useEditorSubscriber } from '@/hooks/useEditorSubscriber';
-import useCanvasInteractions from '@/hooks/useCanvasInteractions';
+import { DNDProvider } from './DNDProvider';
 
 interface Props {
   onChange?: (data: CompositionTree) => void;
@@ -25,9 +20,7 @@ interface Props {
 export const RootRenderer: React.FC<Props> = ({ onChange }) => {
   useEditorSubscriber();
 
-  const setSelectedNodeId = useEditorStore((state) => state.setSelectedNodeId);
   const dragItem = useDraggedItemStore((state) => state.componentId);
-  const updateItem = useDraggedItemStore((state) => state.updateItem);
   const setHoveringSection = useZoneStore((state) => state.setHoveringSection);
   const userIsDragging = !!dragItem;
   const breakpoints = useTreeStore((state) => state.breakpoints);
@@ -35,45 +28,14 @@ export const RootRenderer: React.FC<Props> = ({ onChange }) => {
   const { resolveDesignValue } = useBreakpoints(breakpoints);
   const tree = useTreeStore((state) => state.tree);
 
-  const { onAddComponent, onMoveComponent } = useCanvasInteractions();
   useEffect(() => {
     if (onChange) onChange(tree);
   }, [tree, onChange]);
 
-  const { onDragStartOrUpdate } = usePlaceholderStyle();
+  console.log(1);
 
   return (
-    <DragDropContext
-      onDragUpdate={(update) => {
-        updateItem(update);
-        onDragStartOrUpdate(update);
-      }}
-      onBeforeDragStart={(start) => {
-        onDragStartOrUpdate(start);
-        setSelectedNodeId('');
-        sendMessage(OUTGOING_EVENTS.ComponentSelected, {
-          nodeId: '',
-        });
-      }}
-      onDragEnd={(droppedItem) => {
-        updateItem(undefined);
-        dragState.reset();
-
-        sendMessage(OUTGOING_EVENTS.MouseUp);
-
-        // User cancel drag
-        if (!droppedItem.destination) {
-          sendMessage(OUTGOING_EVENTS.ComponentDragCanceled);
-          return;
-        }
-
-        // New component added to canvas
-        if (droppedItem.source.droppableId.startsWith('component-list')) {
-          onAddComponent(droppedItem);
-        } else {
-          onMoveComponent(droppedItem);
-        }
-      }}>
+    <DNDProvider>
       {dragItem && <DraggableContainer id={dragItem} />}
 
       <div className={styles.container}>
@@ -105,6 +67,6 @@ export const RootRenderer: React.FC<Props> = ({ onChange }) => {
           />
         )}
       </div>
-    </DragDropContext>
+    </DNDProvider>
   );
 };

--- a/packages/visual-editor/src/components/VisualEditorRoot.tsx
+++ b/packages/visual-editor/src/components/VisualEditorRoot.tsx
@@ -55,5 +55,7 @@ export const VisualEditorRoot = () => {
 
   if (!initialized) return null;
 
+  console.log('initialized');
+
   return <RootRenderer />;
 };

--- a/packages/visual-editor/src/components/VisualEditorRoot.tsx
+++ b/packages/visual-editor/src/components/VisualEditorRoot.tsx
@@ -55,7 +55,5 @@ export const VisualEditorRoot = () => {
 
   if (!initialized) return null;
 
-  console.log('initialized');
-
   return <RootRenderer />;
 };


### PR DESCRIPTION
Adding a div with event handlers allowed to skip the "native" dnd and simulate events in cypress.

All that is required is setting the `window.Cypress` property.

You can see the progress on the video below. Sorry for the music - I forgot to disable mic when recording.

https://github.com/contentful/experience-builder/assets/4171202/67f92c5f-e2ce-4eaa-a9c9-06e3210b4c33

