### PR TITLE
fix(core): remove lodash dep to get rid of weird reference errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41084,8 +41084,7 @@
       "license": "MIT",
       "dependencies": {
         "@contentful/rich-text-types": "^16.3.0",
-        "@contentful/visual-sdk": "../visual-sdk",
-        "lodash-es": "^4.17.21"
+        "@contentful/visual-sdk": "../visual-sdk"
       },
       "devDependencies": {
         "@rollup/plugin-commonjs": "^25.0.7",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -62,8 +62,7 @@
   },
   "dependencies": {
     "@contentful/rich-text-types": "^16.3.0",
-    "@contentful/visual-sdk": "../visual-sdk",
-    "lodash-es": "^4.17.21"
+    "@contentful/visual-sdk": "../visual-sdk"
   },
   "peerDependencies": {
     "contentful": ">=10.6.0"

--- a/packages/core/src/utils/utils.spec.ts
+++ b/packages/core/src/utils/utils.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { CompositionComponentNode } from '@/types';
-import { getInsertionData } from '@/utils';
+import { generateRandomId, getInsertionData } from '@/utils';
 
 const dropReceiverChildNode: CompositionComponentNode = {
   type: 'block',
@@ -216,6 +216,14 @@ describe('getInsertionData', () => {
         node: dropReceiverNode,
         index: 1, // dropped as the new last child within the dropReceiverNode
       });
+    });
+  });
+
+  describe('generateRandomId', () => {
+    it('should generate a random id with the specified length', () => {
+      const id = generateRandomId(10);
+      console.log(id);
+      expect(id.length).toEqual(10);
     });
   });
 });

--- a/packages/core/src/utils/utils.ts
+++ b/packages/core/src/utils/utils.ts
@@ -1,5 +1,3 @@
-import { times } from 'lodash-es';
-import { random } from 'lodash-es';
 import {
   CompositionTree,
   CompositionComponentNode,
@@ -120,6 +118,9 @@ export const generateRandomId = (letterCount: number): string => {
   const LETTERS = 'abcdefghijklmnopqvwxyzABCDEFGHIJKLMNOPQVWXYZ';
   const NUMS = '0123456789';
   const ALNUM = NUMS + LETTERS;
+
+  const times = (n: number, callback: () => string) => Array.from({ length: n }, callback);
+  const random = (min: number, max: number) => Math.floor(Math.random() * (max - min + 1)) + min;
 
   return times(letterCount, () => ALNUM[random(0, ALNUM.length - 1)]).join('');
 };


### PR DESCRIPTION
We were getting some weird lodash import errors in user interface when the core dep was referenced locally. We were using only two relatively simple methods from lodash (times and random), so I replaced those with custom ones and removed the package. This helped fix the error we were seeing.