### PR TITLE
chore: remove erroneous prepublish script from main package file

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "prepare": "husky install",
     "build": "lerna run build",
     "start": "lerna run --stream start",
-    "prepublish": "lerna run build",
     "prettier:check": "lerna run prettier:check",
     "cm": "git-cz"
   },


### PR DESCRIPTION
There was a prepublish script that called 'lerna run build' that was causing the monorepo to do a build after npm install. This seems unnecessary and is causing the CI pipeline to slow down because there are multiple unneeded builds happening.