### PR TITLE
style: move all assembly checks to core utils []

### DIFF
--- a/packages/core/src/utils/utils.ts
+++ b/packages/core/src/utils/utils.ts
@@ -5,7 +5,10 @@ import {
   CompositionDataSource,
   CompositionUnboundValues,
   ExperienceEntry,
+  ComponentDefinition,
 } from '@/types';
+import { Entry } from 'contentful';
+import { ASSEMBLY_DEFAULT_CATEGORY, DESIGN_COMPONENT_DEFAULT_CATEGORY } from '@/constants';
 
 export const getDataFromTree = (
   tree: CompositionTree
@@ -125,7 +128,7 @@ export const generateRandomId = (letterCount: number): string => {
   return times(letterCount, () => ALNUM[random(0, ALNUM.length - 1)]).join('');
 };
 
-export const checkIsAssembly = ({
+export const checkIsAssemblyNode = ({
   componentId,
   usedComponents,
 }: {
@@ -136,3 +139,18 @@ export const checkIsAssembly = ({
 
   return usedComponents.some((usedComponent) => usedComponent.sys.id === componentId);
 };
+
+/** @deprecated use `checkIsAssemblyNode` instead. Will be removed with SDK v5. */
+export const checkIsAssembly = checkIsAssemblyNode;
+
+/**
+ * This check assumes that the entry is already ensured to be an experience, i.e. the
+ * content type of the entry is an experience type with the necessary annotations.
+ * */
+export const checkIsAssemblyEntry = (entry: Entry): boolean => {
+  return Boolean(entry.fields?.componentSettings);
+};
+
+export const checkIsAssemblyDefinition = (component?: ComponentDefinition) =>
+  component?.category === DESIGN_COMPONENT_DEFAULT_CATEGORY ||
+  component?.category === ASSEMBLY_DEFAULT_CATEGORY;

--- a/packages/experience-builder-sdk/src/blocks/preview/CompositionBlock.tsx
+++ b/packages/experience-builder-sdk/src/blocks/preview/CompositionBlock.tsx
@@ -20,7 +20,7 @@ import type {
 import { createAssemblyRegistration, getComponentRegistration } from '../../core/componentRegistry';
 import {
   buildCfStyles,
-  checkIsAssembly,
+  checkIsAssemblyNode,
   transformContentValue,
 } from '@contentful/experience-builder-core';
 import { useStyleTag } from '../../hooks/useStyleTag';
@@ -51,7 +51,7 @@ export const CompositionBlock = ({
   usedComponents,
 }: CompositionBlockProps) => {
   const isAssembly = useMemo(
-    () => checkIsAssembly({ componentId: rawNode.definitionId, usedComponents }),
+    () => checkIsAssemblyNode({ componentId: rawNode.definitionId, usedComponents }),
     [rawNode.definitionId, usedComponents]
   );
 

--- a/packages/experience-builder-sdk/src/core/preview/assemblyUtils.ts
+++ b/packages/experience-builder-sdk/src/core/preview/assemblyUtils.ts
@@ -1,4 +1,4 @@
-import { checkIsAssembly, EntityStore } from '@contentful/experience-builder-core';
+import { checkIsAssemblyNode, EntityStore } from '@contentful/experience-builder-core';
 import type {
   CompositionComponentPropValue,
   CompositionNode,
@@ -56,7 +56,7 @@ export const resolveAssembly = ({
   node: CompositionNode;
   entityStore: EntityStore | undefined;
 }) => {
-  const isAssembly = checkIsAssembly({
+  const isAssembly = checkIsAssemblyNode({
     componentId: node.definitionId,
     usedComponents: entityStore?.usedComponents,
   });

--- a/packages/experience-builder-sdk/src/index.ts
+++ b/packages/experience-builder-sdk/src/index.ts
@@ -3,7 +3,10 @@ export { useExperienceBuilder, useFetchExperience, useFetchById, useFetchBySlug 
 export { defineComponents } from './core/componentRegistry';
 export {
   calculateNodeDefaultHeight,
+  /** @deprecated use `checkIsAssemblyNode` instead. Will be removed with SDK v5. */
   checkIsAssembly,
+  checkIsAssemblyNode,
+  checkIsAssemblyEntry,
   defineDesignTokens,
   supportedModes,
   VisualEditorMode,


### PR DESCRIPTION
Enrich the core and SDK module by putting `checkIsAssemblyNode` and `checkIsAssemblyDefinition` into the utils. Also deprecated `checkIsAssembly` as this naming will be confusing when talking about the different entities around assemblies.