### PR TITLE
fix: allows re-parenting of components, however does not allow for new containers to be created while dragging across parents

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2616,6 +2616,7 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
Main light bulb idea was to treat existing components on the canvas more like dragging components from the component-list.

This PR allows all components to be dragged across parents however it lacks one feature (which might even be debatable if we want this or not).

The feature it lacks is the ability to create new containers as you're dragging the component.