### PR TITLE
fix: duplicate assembly rendering [SPA-1783]

### DIFF
--- a/packages/visual-editor/src/utils/treeHelpers.ts
+++ b/packages/visual-editor/src/utils/treeHelpers.ts
@@ -159,15 +159,3 @@ export function reorderChildNode(
     reorderChildNode(oldIndex, newIndex, parentNodeId, childNode)
   );
 }
-
-export function countNodes(node: CompositionComponentNode): number {
-  // Count the current node
-  let count = 1;
-
-  // Recursively count the children
-  node.children.forEach((child) => {
-    count += countNodes(child);
-  });
-
-  return count;
-}


### PR DESCRIPTION
When detaching an assembly node, the tree-diffing logic did not recognize that this was technically a "replacement". Based on the total node count in the tree it always figured that a node was "added" and thus didn't remove the previous assembly node but just added the new detached container.

I tested multiple ways of adding, removing, re-ordering, and replacing nodes to ensure that this had no side-effects on other rendering scenarios.