### PR TITLE
chore: add catalog info for backstage integration [SPA-1497]

### DIFF
--- a/catalog-info.yml
+++ b/catalog-info.yml
@@ -1,0 +1,24 @@
+apiVersion: backstage.io/v1alpha1
+kind: System
+metadata:
+  name: experience-builder
+  description: A monorepo for all NPM packages related to Experience Builder.
+  annotations:
+    circleci.com/project-slug: github/contentful/experience-builder
+    github.com/project-slug: contentful/experience-builder
+    contentful.com/ci-alert-slack: prd-experience-builder-alerts
+    backstage.io/source-location: url:https://github.com/contentful/experience-builder/
+spec:
+  type: library
+  lifecycle: production
+  owner: group:team-sparks
+
+---
+apiVersion: backstage.io/v1alpha1
+kind: Location
+metadata:
+  name: experience-builder-index
+spec:
+  type: url
+  targets:
+    - ./packages/experience-builder-sdk/catalog-info.yaml

--- a/packages/experience-builder-sdk/catalog-info.yml
+++ b/packages/experience-builder-sdk/catalog-info.yml
@@ -1,0 +1,15 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: experience-builder-sdk
+  description: The official public SDK to integrate applications with the Experience Builder.
+  annotations:
+    circleci.com/project-slug: github/contentful/experience-builder
+    github.com/project-slug: contentful/experience-builder
+    contentful.com/ci-alert-slack: prd-experience-builder-alerts
+    backstage.io/source-location: url:https://github.com/contentful/experience-builder/tree/development/packages/experience-builder-sdk
+spec:
+  type: library
+  lifecycle: production
+  owner: group:team-sparks
+  system: experience-builder


### PR DESCRIPTION
To show this mono repo as well as the SDK in Roadie, we need to provide catalog info configurations. Those are by no mean perfect. I looked at similar repositories to define at least the minimal required attributes.