### PR TITLE
chore: introduce dependabot without release automation [SPA-1497]

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,28 @@
+version: 2
+registries:
+  npm-registry-registry-npmjs-org:
+    type: npm-registry
+    url: https://registry.npmjs.org
+    token: '${{secrets.NPM_REGISTRY_REGISTRY_NPMJS_ORG_TOKEN}}'
+  npm-github:
+    type: npm-registry
+    url: https://npm.pkg.github.com
+    token: ${{secrets.NPM_REGISTRY_REGISTRY_GH_ORG_TOKEN}}
+
+updates:
+  - package-ecosystem: npm
+    directory: '/'
+    schedule:
+      interval: weekly
+      time: '00:00'
+      timezone: Etc/UCT
+    open-pull-requests-limit: 10
+    target-branch: development
+    labels:
+      - dependencies
+      - dependabot
+    commit-message:
+      prefix: chore
+    registries:
+      - npm-registry-registry-npmjs-org
+      - npm-github

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,15 @@
+name: 'dependabot approve-and-request-merge'
+
+on: pull_request_target
+
+jobs:
+  worker:
+    permissions:
+      contents: write
+      id-token: write
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - uses: contentful/github-auto-merge@v1
+        with:
+          VAULT_URL: ${{ secrets.VAULT_URL }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,12 @@ jobs:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
   publish:
     needs: [install-build, check]
-    if: (github.ref_name == 'main' || github.ref_name == 'development' || github.ref_name == 'next') && !contains(github.event.head_commit.message, 'skip-release')
+    if: >-
+      (github.ref_name == 'main' ||
+        github.ref_name == 'development' ||
+        github.ref_name == 'next') &&
+      !contains(github.event.head_commit.message, 'skip-release') &&
+      github.actor != 'dependabot[bot]'
     permissions:
       contents: write
     uses: ./.github/workflows/publish.yaml


### PR DESCRIPTION
## Purpose

For security purposes, we should not use old outdated versions of packages. To get recent security patches and bugfixes, we add dependabot to this mono repo.

## Approach

I added a simple config that supports the npm and github registry. It will execute every week and auto-merge releases into the `development` branch. Those commits don't trigger an automatic version release, so we can ensure to not break the SDK.
