### PR TITLE
fix: update hover labels to be more like onclick labels

### DIFF
--- a/packages/visual-editor/src/components/Draggable/canvasToolsUtils.ts
+++ b/packages/visual-editor/src/components/Draggable/canvasToolsUtils.ts
@@ -64,7 +64,7 @@ export const getTooltipPositions = ({
     }
   }
 
-  const tooltipHeight = 18;
+  const tooltipHeight = tooltipRect.height === 0 ? 32 : tooltipRect.height;
 
   /**
    * For elements with small heights, we don't want the tooltip covering the content in the element,
@@ -76,7 +76,7 @@ export const getTooltipPositions = ({
      * else we show the tooltip at the bottom.
      */
     if (tooltipHeight < coordinates.top) {
-      newTooltipStyles['bottom'] = tooltipHeight;
+      newTooltipStyles['bottom'] = coordinates.height;
     } else {
       newTooltipStyles['top'] = coordinates.height;
     }

--- a/packages/visual-editor/src/components/Draggable/styles.module.css
+++ b/packages/visual-editor/src/components/Draggable/styles.module.css
@@ -23,17 +23,18 @@
 
 .overlay {
   position: absolute;
+  display: flex;
+  align-items: center;
   min-width: max-content;
-  min-height: 10px;
-  max-height: 10px;
+  height: 24px;
   z-index: 1;
   font-family: var(--exp-builder-font-stack-primary);
-  font-size: 10px;
+  font-size: 14px;
   font-weight: 500;
   background-color: var(--exp-builder-gray500);
   color: var(--exp-builder-color-white);
   border-radius: 0 0 2px 0;
-  padding: 2px 2px 2px 2px;
+  padding: 4px 12px 4px 12px;
   transition: opacity 0.2s;
   opacity: 0;
   text-wrap: nowrap;


### PR DESCRIPTION
## Purpose
Make the hover labels match more closely with the active labels in terms of height and width. Kept the gray500 color because the color scheming will be handled during the dark mode ticket.

<img width="1055" alt="Screenshot 2024-01-26 at 8 52 59 AM" src="https://github.com/contentful/experience-builder/assets/124832189/12f7ad0c-0953-4226-89d2-5fe78cd92333">
<img width="871" alt="Screenshot 2024-01-26 at 8 52 53 AM" src="https://github.com/contentful/experience-builder/assets/124832189/09e03084-191e-4e6e-bef7-b57324b1103e">
