### PR TITLE
feat: update editor canvas background so that it's clear to users where the canvas lies [ALT-292]

### DIFF
--- a/packages/core/src/definitions/styles.ts
+++ b/packages/core/src/definitions/styles.ts
@@ -68,7 +68,7 @@ export const builtInStyles: Partial<
     type: 'Text',
     group: 'style',
     description: 'The background color of the section',
-    defaultValue: 'rgba(255, 255, 255, 0)',
+    defaultValue: 'rgba(255, 255, 255, 1)',
   },
   cfWidth: {
     displayName: 'Width',

--- a/packages/create-experience-builder/src/ctflClient.ts
+++ b/packages/create-experience-builder/src/ctflClient.ts
@@ -111,7 +111,7 @@ export class CtflClient {
                       },
                       cfBackgroundColor: {
                         type: 'DesignValue',
-                        valuesByBreakpoint: { desktop: 'rgba(255, 255, 255, 0)' },
+                        valuesByBreakpoint: { desktop: 'rgba(255, 255, 255, 1)' },
                       },
                       cfWidth: {
                         type: 'DesignValue',

--- a/packages/storybook-addon/src/utils/variables.ts
+++ b/packages/storybook-addon/src/utils/variables.ts
@@ -72,7 +72,7 @@ export const builtInStyles: Record<
     type: 'Text',
     group: 'style',
     description: 'The background color of the section',
-    defaultValue: 'rgba(255, 255, 255, 0)',
+    defaultValue: 'rgba(255, 255, 255, 1)',
   },
   cfWidth: {
     displayName: 'Width',


### PR DESCRIPTION
## Purpose
EB PR [https://github.com/contentful/experience-builder/pull/295]
Two parts (User Interface + EB changes) - this is because we need the entire IFrame (which is defined in User Interface) to be background transparent. Then in EB we make the relevant div with id "root" background white which allows us to show the user what part of the canvas is being used or not.
https://www.loom.com/share/c068512d3b8447dd9ca20ffc23dfc06d?sid=576ded82-c454-47f0-911b-9d0eef565055

Images below show the background for desktop, tablet, and mobile
Desktop
<img width="1153" alt="Screenshot 2024-01-26 at 9 17 36 AM" src="https://github.com/contentful/experience-builder/assets/124832189/83b8dbcf-b5e7-47c0-b9fa-8e1bc2c6ead7">
Tablet
<img width="1152" alt="Screenshot 2024-01-26 at 9 17 40 AM" src="https://github.com/contentful/experience-builder/assets/124832189/532d1ed7-62b8-4618-b566-9f385c32be16">
Mobile
<img width="1151" alt="Screenshot 2024-01-26 at 9 17 44 AM" src="https://github.com/contentful/experience-builder/assets/124832189/ee442528-2696-49dc-92a5-0a509ccbcb6b">
