### PR TITLE
fix: use https protocol for component thumnails []

### DIFF
--- a/packages/components/src/utils/constants.ts
+++ b/packages/components/src/utils/constants.ts
@@ -3,18 +3,18 @@ const constants = {
     'https://images.ctfassets.net/tofsejyzyo24/5owPX1vp6cXDZr7QOabwzT/d5580f5b4dbad3f74c87ce2f03efa581/Image_container.png',
   thumbnails: {
     button:
-      'http://images.ctfassets.net/tofsejyzyo24/7nSWHngZyMLp1kwp3uaIsL/d3b647f41e20f510644677dedd587cbb/button.png',
+      'https://images.ctfassets.net/tofsejyzyo24/7nSWHngZyMLp1kwp3uaIsL/d3b647f41e20f510644677dedd587cbb/button.png',
     heading:
-      'http://images.ctfassets.net/tofsejyzyo24/3Q9azSMiVYtDD9Ra58HWv1/929cdcb67c10238f41ed7c97f9dfe101/heading.png',
+      'https://images.ctfassets.net/tofsejyzyo24/3Q9azSMiVYtDD9Ra58HWv1/929cdcb67c10238f41ed7c97f9dfe101/heading.png',
     image:
-      'http://images.ctfassets.net/tofsejyzyo24/3Svf1pYdVrhfYqKc8JT0Eb/055214f105b00658ccb3e3a17ca71656/image.png',
-    text: 'http://images.ctfassets.net/tofsejyzyo24/2k8kqqPRaLGX7a1Vo97mPb/8a5c1b5b4770e3ca49d6b808b563a305/text.png',
+      'https://images.ctfassets.net/tofsejyzyo24/3Svf1pYdVrhfYqKc8JT0Eb/055214f105b00658ccb3e3a17ca71656/image.png',
+    text: 'https://images.ctfassets.net/tofsejyzyo24/2k8kqqPRaLGX7a1Vo97mPb/8a5c1b5b4770e3ca49d6b808b563a305/text.png',
     richText:
-      'http://images.ctfassets.net/tofsejyzyo24/7HIFYGzHZDN0CwQnz9EmzW/629d0d4580517395f1d1f8237d136e43/rich_text.png',
+      'https://images.ctfassets.net/tofsejyzyo24/7HIFYGzHZDN0CwQnz9EmzW/629d0d4580517395f1d1f8237d136e43/rich_text.png',
     infoBlock:
-      'http://images.ctfassets.net/tofsejyzyo24/6DRBAjZUN4L2hwIkV4uM50/81e0a3a27fbada0c20f3420031ca85e5/info_block.png',
+      'https://images.ctfassets.net/tofsejyzyo24/6DRBAjZUN4L2hwIkV4uM50/81e0a3a27fbada0c20f3420031ca85e5/info_block.png',
     duplex:
-      'http://images.ctfassets.net/tofsejyzyo24/7cOHx0p0J1gUCFMPcoXnFg/73144735e3db345b101509bf707a56b1/Duplex.png',
+      'https://images.ctfassets.net/tofsejyzyo24/7cOHx0p0J1gUCFMPcoXnFg/73144735e3db345b101509bf707a56b1/Duplex.png',
   },
 };
 


### PR DESCRIPTION
## Purpose

We're seeing security warnings and suspect the thumbnail URLs which use an insecure protocol.