### PR TITLE
chore: bail rollup and lerna when TS errors []

### DIFF
--- a/packages/components/tsconfig.json
+++ b/packages/components/tsconfig.json
@@ -11,12 +11,13 @@
     "moduleResolution": "node",
     "allowSyntheticDefaultImports": true,
     "forceConsistentCasingInFileNames": true,
+    "noEmitOnError": true,
     "baseUrl": ".",
     "paths": {
       "@components/*": ["./src/components/*"],
-      "@/*": ["./src/*"]
-    }
+      "@/*": ["./src/*"],
+    },
   },
   "include": ["src/**/*", "cypress"],
-  "exclude": ["dist", "node_modules", "src/**/*.test.tsx", "src/**/*.stories.tsx"]
+  "exclude": ["dist", "node_modules", "src/**/*.test.tsx", "src/**/*.stories.tsx"],
 }

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -12,6 +12,7 @@
     "forceConsistentCasingInFileNames": true,
     "baseUrl": ".",
     "noImplicitAny": false,
+    "noEmitOnError": true,
     "paths": {
       "@/*": ["./src/*"]
     }

--- a/packages/create-experience-builder/tsconfig.json
+++ b/packages/create-experience-builder/tsconfig.json
@@ -10,6 +10,7 @@
     "outDir": "dist",
     "forceConsistentCasingInFileNames": true,
     "baseUrl": ".",
+    "noEmitOnError": true,
     "paths": {
       "@/*": ["./src/*"]
     }

--- a/packages/storybook-addon/tsconfig.json
+++ b/packages/storybook-addon/tsconfig.json
@@ -12,6 +12,7 @@
     "noImplicitAny": true,
     "rootDir": "./src",
     "skipLibCheck": true,
+    "noEmitOnError": true,
     "target": "ES2020",
     "paths": {
       "@components/*": ["./src/components/*"],

--- a/packages/test-app/tsconfig.json
+++ b/packages/test-app/tsconfig.json
@@ -12,6 +12,7 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
+    "noEmitOnError": true,
     "jsx": "react-jsx",
 
     /* Linting */

--- a/packages/visual-editor/tsconfig.json
+++ b/packages/visual-editor/tsconfig.json
@@ -13,6 +13,7 @@
     "baseUrl": ".",
     "rootDir": ".",
     "noImplicitAny": false,
+    "noEmitOnError": true,
     "paths": {
       "@components/*": ["./src/components/*"],
       "@/*": ["./src/*"]

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -12,6 +12,7 @@
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "isolatedModules": true,
+    "noEmitOnError": true,
     "noEmit": false,
     "jsx": "react-jsx",
     "outDir": "dist",


### PR DESCRIPTION
Currently, a TS error does not yield an error when building with rollup.
Using the config [noEmitOnError](https://www.npmjs.com/package/@rollup/plugin-typescript#noemitonerror), TS will now return an error that can be consumed by rollup and leads to a subsequent abortion of rollup and lerna.

Video: https://www.loom.com/share/97ba8ed8671f4d5187514b88332bfcd9

Related bug: https://github.com/rollup/rollup-plugin-typescript/issues/43