### PR TITLE
fix: re-fetch entity store on locale change [SPA-1773]

### DIFF
--- a/packages/visual-editor/src/store/editor.ts
+++ b/packages/visual-editor/src/store/editor.ts
@@ -35,7 +35,6 @@ export const useEditorStore = create<EditorStore>((set, get) => ({
   dragItem: '',
   selectedNodeId: null,
   locale: null,
-  entityStore: undefined,
 
   setSelectedNodeId: (id: string) => {
     set({ selectedNodeId: id });
@@ -57,6 +56,7 @@ export const useEditorStore = create<EditorStore>((set, get) => ({
     if (locale === currentLocale) {
       return;
     }
+
     set({ locale });
   },
   initializeEditor({ componentRegistry: initialRegistry, designTokens, initialLocale }) {

--- a/packages/visual-editor/src/store/entityStore.ts
+++ b/packages/visual-editor/src/store/entityStore.ts
@@ -14,7 +14,6 @@ export interface EntityState {
 
 export const useEntityStore = create<EntityState>((set) => ({
   entityStore: new EditorModeEntityStore({ locale: 'en-US', entities: [] }),
-  areEntitesResolvedInParent: false,
   areEntitiesFetched: false,
 
   setEntitiesFetched(fetched) {
@@ -24,6 +23,9 @@ export const useEntityStore = create<EntityState>((set) => ({
     console.debug(
       `[exp-builder.sdk] Resetting entity store because the locale changed to '${locale}'.`
     );
-    set({ entityStore: new EditorModeEntityStore({ locale, entities }) });
+    set({
+      entityStore: new EditorModeEntityStore({ locale, entities }),
+      areEntitiesFetched: false,
+    });
   },
 }));


### PR DESCRIPTION
## Purpose

Changing locale value has to trigger re-fetch of the entity store data. Otherwise, it is stuck with values fetched for previous locale.

## Approach

The state flag, responsible for re-fetch had to be reset once the entity store gets reset

<!--

Three important notes on Pull Requests:
- In general, you should ask yourself whether this code change will improve or worsen the overall code quality. Any new tech debt will probably never be cleaned up.
- Please remember that newly introduced logic should be validated and protected through testing.
- Take a look at PR guides such as Google's [Google’s Code Review Guidelines](https://google.github.io/eng-practices/) and [Blockly - Writing a Good Pull Request](https://developers.google.com/blockly/guides/contribute/get-started/write_a_good_pr)

-->
