### PR TITLE
chore: ignore cf automation bot as well for publishing [SPA-1497]

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,8 @@ jobs:
         github.ref_name == 'development' ||
         github.ref_name == 'next') &&
       !contains(github.event.head_commit.message, 'skip-release') &&
-      github.actor != 'dependabot[bot]'
+      github.actor != 'dependabot[bot]' &&
+      github.actor != 'contentful-automation[bot]'
     permissions:
       contents: write
     uses: ./.github/workflows/publish.yaml


### PR DESCRIPTION
The dependabot automation is working but it triggers dev prereleases:
https://github.com/contentful/experience-builder/actions/runs/7712599014/job/21020767544

Turns out that we have a different bot name `contentful-automation[bot]` that we need to exclude here as well.