### PR TITLE
feat: updates rich text component definition to hold default stylings rather than using css modules [ALT-311]

### DIFF
--- a/packages/components/src/components/RichText/RichText.css
+++ b/packages/components/src/components/RichText/RichText.css
@@ -1,5 +1,0 @@
-
-.cf-richtext {
-  color: var(--cf-text-color);
-  font-family: var(--cf-font-family-sans);
-}

--- a/packages/components/src/components/RichText/index.ts
+++ b/packages/components/src/components/RichText/index.ts
@@ -7,9 +7,47 @@ export const RichTextComponentDefinition: ComponentDefinition = {
   id: 'richText',
   name: 'RichText',
   category: 'Contentful',
-  builtInStyles: ['cfMargin', 'cfPadding'],
+  builtInStyles: [
+    'cfMargin',
+    'cfPadding',
+    'cfFontWeight',
+    'cfLetterSpacing',
+    'cfTextTransform',
+    'cfMaxWidth',
+    'cfBackgroundColor',
+    'cfBorder',
+  ],
   thumbnailUrl: constants.thumbnails.richText,
   variables: {
+    // Built-in style variables with default values changed
+    cfLineHeight: {
+      displayName: 'Line Height',
+      type: 'Text',
+      group: 'style',
+      description: 'The line height of the heading.',
+      defaultValue: '24px',
+    },
+    cfTextAlign: {
+      displayName: 'Text Align',
+      type: 'Text',
+      group: 'style',
+      description: 'The text alignment of the heading.',
+      defaultValue: 'center',
+    },
+    cfWidth: {
+      displayName: 'Width',
+      type: 'Text',
+      group: 'style',
+      description: 'The width of the button.',
+      defaultValue: 'fit-content',
+    },
+    cfHeight: {
+      displayName: 'Height',
+      type: 'Text',
+      group: 'style',
+      description: 'The height of the button.',
+      defaultValue: 'fit-content',
+    },
     value: {
       displayName: 'Value',
       description: 'The text to display.',
@@ -24,8 +62,7 @@ export const RichTextComponentDefinition: ComponentDefinition = {
             content: [
               {
                 nodeType: 'text',
-                value:
-                  'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.',
+                value: 'Rich text',
                 marks: [],
                 data: {},
               },
@@ -33,13 +70,6 @@ export const RichTextComponentDefinition: ComponentDefinition = {
           },
         ],
       },
-    },
-    classes: {
-      displayName: 'Classes',
-      description: 'Additional CSS classes to apply to the component.',
-      type: 'Text',
-      defaultValue: 'cf-richtext',
-      group: 'style',
     },
   },
 };

--- a/packages/components/src/styles.ts
+++ b/packages/components/src/styles.ts
@@ -1,5 +1,4 @@
 import './components/variables.css';
 import './components/Button/Button.css';
 import './components/Image/Image.css';
-import './components/RichText/RichText.css';
 import './components/Text/Text.css';

--- a/packages/experience-builder-sdk/src/core/componentRegistry.ts
+++ b/packages/experience-builder-sdk/src/core/componentRegistry.ts
@@ -105,6 +105,9 @@ const DEFAULT_COMPONENT_REGISTRATIONS = {
   richText: enrichComponentDefinition({
     component: Components.RichText,
     definition: Components.RichTextComponentDefinition,
+    options: {
+      wrapComponent: false,
+    },
   }),
   text: enrichComponentDefinition({
     component: Components.Text,


### PR DESCRIPTION
## Purpose
Rich Text now has the following design options as shown in the screenshots

<img width="1411" alt="Screenshot 2024-01-30 at 1 33 28 PM" src="https://github.com/contentful/experience-builder/assets/124832189/b3786d18-b95c-4063-a414-4ddf78e54a2b">
