### PR TITLE
fix(components): remove [data-cf-node-*] attributes from components []

### DIFF
--- a/packages/components/src/components/Assembly/Assembly.tsx
+++ b/packages/components/src/components/Assembly/Assembly.tsx
@@ -33,9 +33,6 @@ export const Assembly: React.FC<AssemblyProps> = (props) => {
 
     return props.renderDropzone(node, {
       ['data-test-id']: 'contentful-container',
-      ['data-cf-node-id']: node.data.id,
-      ['data-cf-node-block-id']: node.data.blockId,
-      ['data-cf-node-block-type']: node.type,
       id: 'assembly',
       className: props.className,
       style: assemblyStyle,

--- a/packages/components/src/components/Columns/Columns.tsx
+++ b/packages/components/src/components/Columns/Columns.tsx
@@ -40,9 +40,6 @@ export const Columns: React.FC<ColumnsProps> = (props) => {
 
   return renderDropzone(node, {
     ['data-test-id']: 'contentful-container',
-    ['data-cf-node-id']: node.data.id,
-    ['data-cf-node-block-id']: node.data.blockId,
-    ['data-cf-node-block-type']: node.type,
     id: 'ContentfulContainer',
     className: combineClasses(className, 'defaultStyles'),
     WrapperComponent: ColumnWrapper,

--- a/packages/components/src/components/Columns/SingleColumn.tsx
+++ b/packages/components/src/components/Columns/SingleColumn.tsx
@@ -44,9 +44,6 @@ export const SingleColumn: React.FC<SingleColumnProps> = (props) => {
       {isEmpty && <div className="cf-single-column-label">Column</div>}
       {renderDropzone(node, {
         ['data-test-id']: 'contentful-single-container',
-        ['data-cf-node-id']: node.data.id,
-        ['data-cf-node-block-id']: node.data.blockId,
-        ['data-cf-node-block-type']: node.type,
         id: 'ContentfulSingleColumn',
         className: combineClasses(className, 'defaultStyles'),
         WrapperComponent: Flex,

--- a/packages/components/src/components/ContentfulContainer/ContentfulContainer.tsx
+++ b/packages/components/src/components/ContentfulContainer/ContentfulContainer.tsx
@@ -40,9 +40,6 @@ export const ContentfulContainer: React.FC<ContentfulContainerAsHyperlinkProps> 
 
   return renderDropzone(node, {
     ['data-test-id']: 'contentful-container',
-    ['data-cf-node-id']: node.data.id,
-    ['data-cf-node-block-id']: node.data.blockId,
-    ['data-cf-node-block-type']: node.type,
     id: 'ContentfulContainer',
     className: combineClasses(className, 'defaultStyles'),
     WrapperComponent: Flex,

--- a/packages/components/src/components/ContentfulContainer/ContentfulContainerAsHyperlink.tsx
+++ b/packages/components/src/components/ContentfulContainer/ContentfulContainerAsHyperlink.tsx
@@ -71,9 +71,6 @@ export const ContentfulContainerAsHyperlink: React.FC<ContentfulContainerAsHyper
 
   return renderDropzone(node, {
     ['data-test-id']: 'contentful-container',
-    ['data-cf-node-id']: node.data.id,
-    ['data-cf-node-block-id']: node.data.blockId,
-    ['data-cf-node-block-type']: node.type,
     id: 'ContentfulContainer',
     className: combineClasses(className, 'defaultStyles', 'cf-section-link'),
     zoneId: node.data.id,


### PR DESCRIPTION
## Purpose

In #296 the `[data-cf-node-*]` attributes moved from the `componentProps` to the `wrapperProps`.

This change removes these attributes from some components to prevent them from appearing twice -- on the component and the editor wrapper (draggable) element