### PR TITLE
chore: dont auto merge major version upgrades [SPA-1496]

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -10,6 +10,14 @@ jobs:
     runs-on: ubuntu-latest
     if: github.actor == 'dependabot[bot]'
     steps:
-      - uses: contentful/github-auto-merge@v1
+      - name: Fetch Dependabot metadata
+        id: dependabot-metadata
+        uses: dependabot/fetch-metadata@v1
+        with:
+          github-token: '${{ secrets.GITHUB_TOKEN }}'
+      - name: Auto-merge
+        # Don't auto-merge major version upgrades
+        if: ${{steps.dependabot-metadata.outputs.update-type != 'version-update:semver-major'}}
+        uses: contentful/github-auto-merge@v1
         with:
           VAULT_URL: ${{ secrets.VAULT_URL }}


### PR DESCRIPTION
## Purpose

Major version upgrades could introduce breaking changes or bring unwanted features that should be reviewed manually by a dev before merging those.