### PR TITLE
Container and Section labels [ALT-355]

### DIFF
--- a/packages/components/src/components/ContentfulContainer/ContentfulContainer.css
+++ b/packages/components/src/components/ContentfulContainer/ContentfulContainer.css
@@ -8,6 +8,31 @@
   display: none; /* Safari and Chrome */
 }
 
+.cf-single-column-wrapper {
+  position: relative;
+}
+
+.cf-container-wrapper {
+  position: relative;
+  width: 100%;
+}
+
+.cf-container-label {
+  position: absolute;
+  z-index: -1;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  overflow-x: clip;
+  font-family: var(--exp-builder-font-stack-primary);
+  font-size: 12px;
+  color: var(--exp-builder-gray400);
+}
+
 /* used by ContentfulSectionAsHyperlink.tsx */
 .contentful-container-link,
 .contentful-container-link:active,

--- a/packages/components/src/components/ContentfulContainer/ContentfulContainer.tsx
+++ b/packages/components/src/components/ContentfulContainer/ContentfulContainer.tsx
@@ -5,6 +5,7 @@ import { Flex } from '../Layout/Flex';
 import { ContentfulContainerAsHyperlink } from './ContentfulContainerAsHyperlink';
 import type { ContentfulContainerAsHyperlinkProps } from './ContentfulContainerAsHyperlink';
 import { combineClasses } from '../../utils/combineClasses';
+import { CONTENTFUL_SECTION_ID } from '@contentful/experience-builder-core/constants';
 
 export const ContentfulContainer: React.FC<ContentfulContainerAsHyperlinkProps> = (props) => {
   const { className, editorMode, children, cfHyperlink } = props;
@@ -26,9 +27,26 @@ export const ContentfulContainer: React.FC<ContentfulContainerAsHyperlinkProps> 
   // Extract properties that are only available in editor mode
   const { renderDropzone, node } = props;
 
-  return renderDropzone(node, {
-    ['data-test-id']: 'contentful-container',
-    className: combineClasses(className, 'contentful-container'),
-    WrapperComponent: Flex,
-  });
+  const isEmpty = !node.children.length;
+
+  const renderDropzoneComponent = () => {
+    return renderDropzone(node, {
+      ['data-test-id']: 'contentful-container',
+      id: 'ContentfulContainer',
+      className: combineClasses(className, 'defaultStyles'),
+      WrapperComponent: Flex,
+    });
+  };
+
+  // Perform ternary so that we only render the wrapper div if the container is empty
+  return isEmpty ? (
+    <div className="cf-container-wrapper">
+      <div className="cf-container-label">
+        {node.data.blockId === CONTENTFUL_SECTION_ID ? 'Section' : 'Container'}
+      </div>
+      {renderDropzoneComponent()}
+    </div>
+  ) : (
+    renderDropzoneComponent()
+  );
 };


### PR DESCRIPTION
## Purpose
Adds background label to the Container and Section component.
Also cuts the Container label short on either end if the container itself has too small of a width
Container label no longer shows up when it's non-empty

<img width="1666" alt="Screenshot 2024-02-01 at 2 16 36 PM" src="https://github.com/contentful/experience-builder/assets/124832189/3d037197-66d2-4d82-88ff-136fe11df98d">
<img width="1408" alt="Screenshot 2024-02-01 at 9 50 55 AM" src="https://github.com/contentful/experience-builder/assets/124832189/dc3695fe-04fc-40ce-a970-6296cda19056">
<img width="1416" alt="Screenshot 2024-02-01 at 9 51 05 AM" src="https://github.com/contentful/experience-builder/assets/124832189/1adc4154-55ac-47e4-9bdf-5a85cb606609">
