### PR TITLE
feat(components): add new design value to track column wrap [ALT-278]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "lerna": "^8.0.2",
         "lint-staged": "^15.0.1",
         "nx": "16.10.0",
-        "nx-cloud": "*",
+        "nx-cloud": "latest",
         "prettier": "2.8.8"
       }
     },
@@ -2616,6 +2616,7 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {

--- a/packages/core/src/definitions/styles.ts
+++ b/packages/core/src/definitions/styles.ts
@@ -509,7 +509,7 @@ export const columnsBuiltInStyles: Partial<
     type: 'Text',
     group: 'style',
     description: 'The spacing between the elements of the columns',
-    defaultValue: '0 10px',
+    defaultValue: '10px 10px',
   },
   cfBackgroundImageScaling: {
     displayName: 'Image Scaling',
@@ -549,6 +549,11 @@ export const columnsBuiltInStyles: Partial<
   cfWrapColumns: {
     type: 'Text',
     defaultValue: 'false',
+    group: 'style',
+  },
+  cfWrapColumnsCount: {
+    type: 'Text',
+    defaultValue: '2',
     group: 'style',
   },
 };

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -238,6 +238,7 @@ export type StyleProps = {
   cfColumns: string;
   cfColumnSpan: string;
   cfWrapColumns: string;
+  cfWrapColumnsCount: string;
 };
 
 // We might need to replace this with Record<string, string | number> when we want to be React-agnostic


### PR DESCRIPTION
## Purpose
This new `cfWrapColumnsCount` design value allows us to track how many columns there should be before wrapping to a new row for the columns component.

Demo of wrapAfter is available in the related user_interface PR: https://github.com/contentful/user_interface/pull/19524