### PR TITLE
fix(experience-builder): rendering breakpoint-specific design values [SPA-1772]

### DIFF
--- a/packages/core/src/utils/breakpoints.ts
+++ b/packages/core/src/utils/breakpoints.ts
@@ -58,7 +58,7 @@ export const getActiveBreakpointIndex = (
     id,
     index,
     // The fallback breakpoint with wildcard query will always match
-    isMatch: mediaQueryMatches[id] ?? true,
+    isMatch: mediaQueryMatches[id] ?? index === fallbackBreakpointIndex,
   }));
 
   // Find the last breakpoint in the list that matches (desktop-first: the narrowest one)

--- a/packages/visual-editor/src/hooks/useBreakpoints.ts
+++ b/packages/visual-editor/src/hooks/useBreakpoints.ts
@@ -22,21 +22,22 @@ import { useCallback, useEffect, useState } from 'react';
  * and then decending by screen width. For mobile-first designs, the order would be ascending
  */
 export const useBreakpoints = (breakpoints: Breakpoint[]) => {
-  const [mediaQueryMatchers, initialMediaQueryMatches] = mediaQueryMatcher(breakpoints);
-
-  const [mediaQueryMatches, setMediaQueryMatches] =
-    useState<Record<string, boolean>>(initialMediaQueryMatches);
+  const [mediaQueryMatches, setMediaQueryMatches] = useState<Record<string, boolean>>({});
 
   const fallbackBreakpointIndex = getFallbackBreakpointIndex(breakpoints);
 
   // Register event listeners to update the media query states
   useEffect(() => {
+    const [mediaQueryMatchers, initialMediaQueryMatches] = mediaQueryMatcher(breakpoints);
+    // Store the media query state in the beginning to initialise the state
+    setMediaQueryMatches(initialMediaQueryMatches);
     const eventListeners = mediaQueryMatchers.map(({ id, signal }) => {
       const onChange = () =>
         setMediaQueryMatches((prev) => ({
           ...prev,
           [id]: signal.matches,
         }));
+
       signal.addEventListener('change', onChange);
       return onChange;
     });
@@ -46,7 +47,9 @@ export const useBreakpoints = (breakpoints: Breakpoint[]) => {
         mediaQueryMatchers[index].signal.removeEventListener('change', eventListener);
       });
     };
-  }, [mediaQueryMatchers]);
+    // Only re-setup all listeners when the breakpoint definition changed
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [breakpoints]);
 
   const activeBreakpointIndex = getActiveBreakpointIndex(
     breakpoints,


### PR DESCRIPTION
## Purpose
There were at least two bugs when having breakpoint-specific styles:

## Bug 1
When opening the experience builder, we used to render the mobile value first. There were two problems related to that:

#### Fix 1
The "matches" state variable is an empty object initially. It is a state variable that receives the `initialMediaQueryMatches` only once. Though, on the first run the breakpoint definitions are not yet defined, so the initial value becomes `{}`.
**Solution**: Fill the state variable ones in the effect and trigger the effect only when the breakpoint definitions changed.

#### Fix 2
Now when the "matches" variable is `{}`, the util function just assumes `true` for every breakpoint. Due to the specificity priority for desktop-first, we ended up assuming we're on mobile.
**Solution:** We only assume `true` for the fallback breakpoint but otherwise `false`.

## Bug 2
When switching from "desktop" to "mobile" (or vice versa), it didn't end up in the right breakpoint state.

#### Fix
The signal callbacks for "tablet" and "mobile" get called separately for each change. So in this scenario, we have two callback invocations. However, the first one did already change the state which retriggered the effect. Before rerunning the effect, it removed all signal listeners before the second one could alter the state.
**Solution**: The effect reruns and initializes the signal listeners only when the breakpoint definition changes. This works but we need to be aware later on that we might not have the latest reference to the state variable. Currently, we don't need we change the state via `set((prev) => ...)`.

## Screen recording
I added logs to show the proper state change and callback invocations.

https://github.com/contentful/experience-builder/assets/9327071/6e0c4da0-4ef9-455b-8797-b82c22a821fc


