### PR TITLE
chore: add dev scripts for local development

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,6 +1,7 @@
 module.exports = {
   env: {
     browser: true,
+    node: true,
     es2021: true,
   },
   extends: [

--- a/README.md
+++ b/README.md
@@ -10,6 +10,16 @@ Please refer to our [our Wiki page](https://github.com/contentful/experience-bui
 
 - [@contentful/experience-builder](https://github.com/contentful/experience-builder/tree/main/packages/experience-builder-sdk) - the SDK
 
+## Local Development
+
+Each package has a 'dev' script that will build the application and watch for changes.
+
+Run the following command in the directory of the package to start the dev script:
+
+```bash
+npm run dev 
+```
+
 ## Troubleshooting
 
 > [!WARNING]

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -13,8 +13,11 @@
   "style": "./styles.css",
   "type": "module",
   "scripts": {
-    "prebuild": "rimraf dist && rimraf styles.css",
-    "build": "rollup -c rollup.config.mjs",
+    "clean": "rimraf dist && rimraf styles.css",
+    "predev": "npm run clean",
+    "dev": "rollup -c ./rollup.config.mjs --watch --environment DEV",
+    "prebuild": "npm run clean",
+    "build": "rollup -c ./rollup.config.mjs",
     "lint": "eslint src --ext '.ts,.tsx,.js,.jsx' --max-warnings 0 --ignore-path ../../.eslintignore",
     "lint:fix": "eslint src --ext '.ts,.tsx,.js,.jsx' --fix",
     "test:component": "npx cypress run --component",

--- a/packages/components/rollup.config.mjs
+++ b/packages/components/rollup.config.mjs
@@ -26,7 +26,7 @@ export default [
       }),
       resolve(),
       commonjs(),
-      typescript({ tsconfig: './tsconfig.json' }),
+      typescript({ tsconfig: './tsconfig.json', noEmitOnError: process.env.DEV ? false : true }),
     ],
     external: [/node_modules\/(?!tslib.*)/],
   },
@@ -46,7 +46,7 @@ export default [
   {
     input: 'src/index.ts',
     output: [{ file: 'dist/index.d.ts', format: 'es' }],
-    plugins: [dts()],
+    plugins: [dts({ compilerOptions: { noEmitOnError: process.env.DEV ? false : true } })],
     external: [/.css/],
   },
 ];

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -34,7 +34,7 @@
     "prebuild": "npm run clean",
     "build": "rollup -c ./rollup.config.mjs",
     "predev": "npm run clean",
-    "dev": "rollup -c ./rollup.dev.config.mjs --watch",
+    "dev": "rollup -c ./rollup.config.mjs --watch --environment DEV",
     "lint": "eslint src --ext '.ts,.tsx,.js,.jsx' --max-warnings 0 --ignore-path ../../.eslintignore",
     "lint:fix": "eslint src --ext '.ts,.tsx,.js,.jsx' --fix",
     "test": "vitest",

--- a/packages/core/rollup.config.mjs
+++ b/packages/core/rollup.config.mjs
@@ -1,6 +1,7 @@
 import { nodeResolve } from '@rollup/plugin-node-resolve';
 import typescript from '@rollup/plugin-typescript';
 import dts from 'rollup-plugin-dts';
+
 export default [
   {
     input: 'src/index.ts',
@@ -11,7 +12,10 @@ export default [
         sourcemap: true,
       },
     ],
-    plugins: [nodeResolve(), typescript({ tsconfig: './tsconfig.json' })],
+    plugins: [
+      nodeResolve(),
+      typescript({ tsconfig: './tsconfig.json', noEmitOnError: process.env.DEV ? false : true }),
+    ],
     external: [/node_modules\/(?!tslib.*)/],
   },
   //specific exports in package.json
@@ -25,20 +29,33 @@ export default [
         preserveModules: true,
       },
     ],
-    plugins: [nodeResolve(), typescript({ tsconfig: './tsconfig.json' })],
+    plugins: [
+      nodeResolve(),
+      typescript({ tsconfig: './tsconfig.json', noEmitOnError: process.env.DEV ? false : true }),
+    ],
     external: [/node_modules\/(?!tslib.*)/],
   },
   //typings
   {
     input: 'src/index.ts',
     output: [{ dir: 'dist', format: 'esm', preserveModules: true }],
-    plugins: [dts({ tsconfig: './tsconfig.json' })],
+    plugins: [
+      dts({
+        tsconfig: './tsconfig.json',
+        compilerOptions: { noEmitOnError: process.env.DEV ? false : true },
+      }),
+    ],
     external: [/.css/],
   },
   {
     input: 'src/exports.ts',
     output: [{ dir: 'dist', format: 'esm', preserveModules: true }],
-    plugins: [dts({ tsconfig: './tsconfig.json' })],
+    plugins: [
+      dts({
+        tsconfig: './tsconfig.json',
+        compilerOptions: { noEmitOnError: process.env.DEV ? false : true },
+      }),
+    ],
     external: [/.css/],
   },
 ];

--- a/packages/create-experience-builder/package.json
+++ b/packages/create-experience-builder/package.json
@@ -19,7 +19,7 @@
     "templates/**/*.*"
   ],
   "scripts": {
-    "dev:": "echo noop",
+    "dev": "echo noop",
     "_prebuild": "npm uninstall -g && rimraf dist",
     "_build": "tsc",
     "lint": "eslint src --ext '.ts,.tsx,.js,.jsx' --max-warnings 0 --ignore-path ../../.eslintignore",

--- a/packages/create-experience-builder/package.json
+++ b/packages/create-experience-builder/package.json
@@ -19,7 +19,7 @@
     "templates/**/*.*"
   ],
   "scripts": {
-    "dev": "tsc -w",
+    "dev:": "echo noop",
     "_prebuild": "npm uninstall -g && rimraf dist",
     "_build": "tsc",
     "lint": "eslint src --ext '.ts,.tsx,.js,.jsx' --max-warnings 0 --ignore-path ../../.eslintignore",

--- a/packages/experience-builder-sdk/package.json
+++ b/packages/experience-builder-sdk/package.json
@@ -8,9 +8,11 @@
   "author": "Contentful GmbH",
   "license": "MIT",
   "scripts": {
-    "dev": "vite",
+    "clean": "rimraf dist",
+    "predev": "npm run clean",
+    "dev": "rollup -c ./rollup.config.mjs --watch --environment DEV",
     "prepare": "node ./bin/injectSDKVersion.cjs",
-    "prebuild": "rimraf dist && node ./bin/injectSDKVersion.cjs",
+    "prebuild": "npm run clean && node ./bin/injectSDKVersion.cjs",
     "build": "rollup -c rollup.config.mjs",
     "watch": "vite build --watch",
     "test": "NODE_ENV=test jest",

--- a/packages/experience-builder-sdk/rollup.config.mjs
+++ b/packages/experience-builder-sdk/rollup.config.mjs
@@ -24,13 +24,13 @@ export default [
       }),
       resolve(),
       commonjs(),
-      typescript({ tsconfig: './tsconfig.json' }),
+      typescript({ tsconfig: './tsconfig.json', noEmitOnError: process.env.DEV ? false : true }),
     ],
     external: [/node_modules/],
   },
   {
     input: 'src/index.ts',
     output: [{ file: 'dist/index.d.ts', format: 'es' }],
-    plugins: [dts()],
+    plugins: [dts({ compilerOptions: { noEmitOnError: process.env.DEV ? false : true } })],
   },
 ];

--- a/packages/storybook-addon/package.json
+++ b/packages/storybook-addon/package.json
@@ -40,7 +40,7 @@
     "*.d.ts"
   ],
   "scripts": {
-    "dev:": "echo noop",
+    "dev": "echo noop",
     "clean": "rimraf ./dist",
     "prebuild": "npm run clean",
     "build": "tsup",

--- a/packages/storybook-addon/package.json
+++ b/packages/storybook-addon/package.json
@@ -40,6 +40,7 @@
     "*.d.ts"
   ],
   "scripts": {
+    "dev:": "echo noop",
     "clean": "rimraf ./dist",
     "prebuild": "npm run clean",
     "build": "tsup",

--- a/packages/test-app/package.json
+++ b/packages/test-app/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.1-pre-20231216T233830.0",
   "type": "module",
   "scripts": {
-    "dev": "vite",
+    "dev": "vite --force",
     "start": "vite",
     "prebuild": "rimraf dist",
     "build": "tsc && vite build",

--- a/packages/visual-editor/package.json
+++ b/packages/visual-editor/package.json
@@ -11,12 +11,12 @@
     "dist/**/*.*"
   ],
   "scripts": {
+    "bundle": "npx watchify dist/index.cjs -o dist/bundle.js",
     "clean": "rimraf dist",
     "prebuild": "npm run clean",
     "build": "rollup -c ./rollup.config.mjs",
     "predev": "npm run clean",
-    "bundle": "npx watchify dist/index.cjs -o dist/bundle.js",
-    "dev": "rollup -c ./rollup.dev.config.mjs --watch",
+    "dev": "rollup -c ./rollup.config.mjs --watch --environment DEV",
     "lint": "eslint src --ext '.ts,.tsx,.js,.jsx' --max-warnings 0 --ignore-path ../../.eslintignore",
     "lint:fix": "eslint src --ext '.ts,.tsx,.js,.jsx' --fix",
     "test": "vitest",

--- a/packages/visual-editor/rollup.config.mjs
+++ b/packages/visual-editor/rollup.config.mjs
@@ -27,6 +27,7 @@ export default [
       commonjs(),
       typescript({
         tsconfig: './tsconfig.json',
+        noEmitOnError: process.env.DEV ? false : true,
         exclude: [
           'dist',
           'node_modules',
@@ -42,7 +43,7 @@ export default [
   {
     input: 'src/index.tsx',
     output: [{ file: 'dist/index.d.ts', format: 'es' }],
-    plugins: [dts()],
+    plugins: [dts({ compilerOptions: { noEmitOnError: process.env.DEV ? false : true } })],
     external: [/.css/],
   },
   {
@@ -66,7 +67,7 @@ export default [
       injectProcessEnv({
         NODE_ENV: 'production',
       }),
-      typescript({ tsconfig: './tsconfig.json' }),
+      typescript({ tsconfig: './tsconfig.json', noEmitOnError: process.env.DEV ? false : true }),
     ],
     external: [],
   },


### PR DESCRIPTION
## Purpose

A recent change to add the tsconfig 'noEmitOnError' config value caused the rollup watch server to hault when there was any type of compilation error.

This PR adds new "dev" scripts to each of main EB packages to fire up the rollup watch server with a dev mode argument, which will disable the 'noEmitOnError' option, allowing the process to still report the error but continue running. 

When building the application (npm run build), the 'noEmitOnError' option will still be used and will error out if there is a compilation error.

To use the new scripts, go into the packages folder, and run 'npm run dev', which will build the application and then continually watch for file changes, which will retrigger a build.
