### PR TITLE
feat(components): ability to lock a column span for columns component

### DIFF
--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -77,7 +77,7 @@ export const CONTENTFUL_COMPONENTS = {
   },
   singleColumn: {
     id: 'contentful-single-column',
-    name: 'Single Column',
+    name: 'Column',
   },
   button: {
     id: 'button',

--- a/packages/core/src/definitions/styles.ts
+++ b/packages/core/src/definitions/styles.ts
@@ -450,7 +450,12 @@ export const singleColumnBuiltInStyles: Partial<
     type: 'Text',
     defaultValue: '6',
     group: 'style',
-  } as ComponentDefinitionVariable<'Text'>,
+  },
+  cfColumnSpanLock: {
+    type: 'Text',
+    defaultValue: 'false',
+    group: 'style',
+  },
 };
 
 export const columnsBuiltInStyles: Partial<
@@ -543,7 +548,7 @@ export const columnsBuiltInStyles: Partial<
   },
   cfColumns: {
     type: 'Text',
-    defaultValue: '[6, 6]',
+    defaultValue: '[6,6]',
     group: 'style',
   },
   cfWrapColumns: {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -237,6 +237,7 @@ export type StyleProps = {
   cfTextUnderline: boolean;
   cfColumns: string;
   cfColumnSpan: string;
+  cfColumnSpanLock: string;
   cfWrapColumns: string;
   cfWrapColumnsCount: string;
 };


### PR DESCRIPTION
## Purpose

This new variable allows us to lock a column span so that during column resizing, a locked column keeps it's span value instead of dynamically changing.

user_interface PR: https://github.com/contentful/user_interface/pull/19566

Also updated label from `Single Column` to `Column` per Travis' request
