### PR TITLE
fix: properly remove event listener on scroll [ALT-395] [SPA-1817]

### DIFF
--- a/packages/visual-editor/src/hooks/useEditorSubscriber.ts
+++ b/packages/visual-editor/src/hooks/useEditorSubscriber.ts
@@ -361,7 +361,7 @@ export function useEditorSubscriber() {
     window.addEventListener('scroll', onScroll, { capture: true, passive: true });
 
     return () => {
-      window.removeEventListener('scroll', onScroll);
+      window.removeEventListener('scroll', onScroll, { capture: true });
       clearTimeout(timeoutId);
     };
   }, [selectedNodeId]);


### PR DESCRIPTION
## Purpose
 Properly remove event listener on scroll

## Approach
We had the capture option true when adding the event listener, but never specified on remove that the event listener to be removed is registered as a capturing event listener.

Before PR

https://github.com/contentful/experience-builder/assets/30434146/4abf57e1-916b-470e-9653-f81781ae6eba

After PR

https://github.com/contentful/experience-builder/assets/30434146/c8ae529c-96b9-4e26-b89c-1d0797d934b8


