### PR TITLE
fix: mobile falls back to tablet style for token-enabled props [SPA-1772]

### DIFF
--- a/packages/core/src/__fixtures__/breakpoints.ts
+++ b/packages/core/src/__fixtures__/breakpoints.ts
@@ -1,0 +1,22 @@
+import { Breakpoint } from '@/types';
+
+export const createBreakpoints = (): Breakpoint[] => [
+  {
+    id: 'desktop',
+    query: '*',
+    displayName: 'All sizes',
+    previewSize: '993px',
+  },
+  {
+    id: 'tablet',
+    query: '<992px',
+    displayName: 'Tablet',
+    previewSize: '820px',
+  },
+  {
+    id: 'mobile',
+    query: '<576px',
+    displayName: 'Mobile',
+    previewSize: '390px',
+  },
+];

--- a/packages/core/src/utils/breakpoint.spec.ts
+++ b/packages/core/src/utils/breakpoint.spec.ts
@@ -1,0 +1,85 @@
+import { createBreakpoints } from '@/__fixtures__/breakpoints';
+import { getValueForBreakpoint } from './breakpoints';
+import { describe, it, expect } from 'vitest';
+
+describe('getValueForBreakpoint', () => {
+  const breakpoints = createBreakpoints();
+  const variableName = 'cfBackgroundColor';
+  const [desktopIndex, tabletIndex, mobileIndex] = [0, 1, 2];
+  const [desktopValue, tabletValue, mobileValue] = ['red', 'orange', 'green'];
+  const valuesByBreakpoint = {
+    desktop: desktopValue,
+    tablet: tabletValue,
+    mobile: mobileValue,
+  };
+  const valuesByBreakpointWithoutMobile = {
+    desktop: desktopValue,
+    tablet: tabletValue,
+  };
+  const valuesByBreakpointWithoutTabletAndMobile = {
+    desktop: desktopValue,
+  };
+
+  describe('when rendering a desktop view', () => {
+    it('renders the desktop-specific value', () => {
+      const value = getValueForBreakpoint(
+        valuesByBreakpoint,
+        breakpoints,
+        desktopIndex,
+        variableName
+      );
+      expect(value).toEqual(desktopValue);
+    });
+  });
+
+  describe('when rendering a tablet view', () => {
+    it('renders the tablet-specific value', () => {
+      const value = getValueForBreakpoint(
+        valuesByBreakpoint,
+        breakpoints,
+        tabletIndex,
+        variableName
+      );
+      expect(value).toEqual(tabletValue);
+    });
+    it('falls back to the desktop-specific value', () => {
+      const value = getValueForBreakpoint(
+        valuesByBreakpointWithoutTabletAndMobile,
+        breakpoints,
+        tabletIndex,
+        variableName
+      );
+      expect(value).toEqual(desktopValue);
+    });
+  });
+
+  describe('when rendering a mobile view', () => {
+    it('renders the mobile-specific value', () => {
+      const value = getValueForBreakpoint(
+        valuesByBreakpoint,
+        breakpoints,
+        mobileIndex,
+        variableName
+      );
+      expect(value).toEqual(mobileValue);
+    });
+    it('falls back to the tablet-specific value', () => {
+      const value = getValueForBreakpoint(
+        valuesByBreakpointWithoutMobile,
+        breakpoints,
+        mobileIndex,
+        variableName
+      );
+      expect(value).toEqual(tabletValue);
+    });
+    it('falls back to the desktop-specific value', () => {
+      const value = getValueForBreakpoint(
+        valuesByBreakpointWithoutTabletAndMobile,
+        breakpoints,
+        mobileIndex,
+        variableName
+      );
+      expect(value).toEqual(desktopValue);
+    });
+  });
+});

--- a/packages/core/src/utils/breakpoints.ts
+++ b/packages/core/src/utils/breakpoints.ts
@@ -1,5 +1,5 @@
 import { getDesignTokenRegistration } from '@/registries';
-import { Breakpoint, ValuesByBreakpoint } from '@/types';
+import { Breakpoint, CompositionVariableValueType, ValuesByBreakpoint } from '@/types';
 
 export const MEDIA_QUERY_REGEXP = /(<|>)(\d{1,})(px|cm|mm|in|pt|pc)$/;
 
@@ -95,25 +95,30 @@ export const getValueForBreakpoint = (
   activeBreakpointIndex: number,
   variableName: string
 ) => {
-  const fallbackBreakpointIndex = getFallbackBreakpointIndex(breakpoints);
-  const fallbackBreakpointId = breakpoints[fallbackBreakpointIndex].id;
+  const eventuallyResolveDesignTokens = (value: CompositionVariableValueType) => {
+    // For some built-in design propertier, we support design tokens
+    if (builtInStylesWithDesignTokens.includes(variableName)) {
+      return getDesignTokenRegistration(value as string, variableName);
+    }
+    // For all other properties, we just return the breakpoint-specific value
+    return value;
+  };
+
   if (valuesByBreakpoint instanceof Object) {
     // Assume that the values are sorted by media query to apply the cascading CSS logic
     for (let index = activeBreakpointIndex; index >= 0; index--) {
       const breakpointId = breakpoints[index].id;
-      if (builtInStylesWithDesignTokens.includes(variableName)) {
-        const breakpointValue =
-          valuesByBreakpoint[breakpointId] || valuesByBreakpoint[fallbackBreakpointId];
-
-        return getDesignTokenRegistration(breakpointValue, variableName);
-      }
       if (valuesByBreakpoint[breakpointId]) {
         // If the value is defined, we use it and stop the breakpoints cascade
-        return valuesByBreakpoint[breakpointId];
+        return eventuallyResolveDesignTokens(valuesByBreakpoint[breakpointId]);
       }
     }
-    return valuesByBreakpoint[fallbackBreakpointId];
+    // If no breakpoint matched, we search and apply the fallback breakpoint
+    const fallbackBreakpointIndex = getFallbackBreakpointIndex(breakpoints);
+    const fallbackBreakpointId = breakpoints[fallbackBreakpointIndex].id;
+    return eventuallyResolveDesignTokens(valuesByBreakpoint[fallbackBreakpointId]);
   } else {
+    // Old design properties did not support breakpoints, keep for backward compatibility
     return valuesByBreakpoint;
   }
 };


### PR DESCRIPTION
## Bug
When setting up a bg color for desktop and tablet but not mobile, the mobile view would show the styles set up for desktop.

<details><summary>Bug Recording</summary>
<p>

https://github.com/contentful/experience-builder/assets/9327071/813b8d24-a8e5-4806-ae84-2f57d8ff65c4
</p>
</details> 

## Solution
The design token logic directly fall back to desktop if mobile was not defined (for token-enabled props). This solution is now adjusted to consider the breakpoint cascading rules.

<details><summary>Solution Recording</summary>
<p>

https://github.com/contentful/experience-builder/assets/9327071/8ac60ba0-495b-48a4-adf6-878d1d378a6b
</p>
</details> 

