### PR TITLE
chore: publish packages to github npm registry []

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -2,16 +2,19 @@
   "name": "@contentful/experience-builder-components",
   "version": "0.0.2-alpha.23",
   "description": "A basic set of components to use with Experience Builder",
-  "homepage": "https://github.com/contentful/experience-builder-toolkit/tree/next/packages/components#readme",
+  "homepage": "https://github.com/contentful/experience-builder/tree/next/packages/components#readme",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/contentful/experience-builder-toolkit.git"
+    "url": "git+https://github.com/contentful/experience-builder.git"
   },
   "main": "./dist/index.js",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "style": "./styles.css",
   "type": "module",
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com/"
+  },
   "scripts": {
     "clean": "rimraf dist && rimraf styles.css",
     "predev": "npm run clean",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -8,7 +8,7 @@
   "type": "module",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/contentful/experience-builder-toolkit.git"
+    "url": "git+https://github.com/contentful/experience-builder.git"
   },
   "files": [
     "readme.md",
@@ -18,6 +18,9 @@
   "exports": {
     ".": "./dist/index.js",
     "./constants": "./dist/constants.js"
+  },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com/"
   },
   "typesVersions": {
     "*": {

--- a/packages/create-experience-builder/package.json
+++ b/packages/create-experience-builder/package.json
@@ -2,10 +2,10 @@
   "name": "create-experience-builder",
   "version": "0.0.2-alpha.5",
   "description": "A CLI tool to get up and running with Contentful Experience Builder quickly",
-  "homepage": "https://github.com/contentful/experience-builder-toolkit/tree/next/packages/create-experience-builder#readme",
+  "homepage": "https://github.com/contentful/experience-builder/tree/next/packages/create-experience-builder#readme",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/contentful/experience-builder-toolkit.git"
+    "url": "git+https://github.com/contentful/experience-builder.git"
   },
   "type": "module",
   "main": "./dist/index.js",
@@ -18,6 +18,9 @@
     "bin/**/*.*",
     "templates/**/*.*"
   ],
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com/"
+  },
   "scripts": {
     "dev": "echo noop",
     "_prebuild": "npm uninstall -g && rimraf dist",

--- a/packages/experience-builder-sdk/package.json
+++ b/packages/experience-builder-sdk/package.json
@@ -7,6 +7,9 @@
   "type": "module",
   "author": "Contentful GmbH",
   "license": "MIT",
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com/"
+  },
   "scripts": {
     "clean": "rimraf dist",
     "predev": "npm run clean",
@@ -74,9 +77,6 @@
     "vite": "^4.3.9",
     "vite-plugin-dts": "^3.6.1",
     "vite-plugin-svgr": "^4.1.0"
-  },
-  "relativeDependencies": {
-    "@contentful/experience-builder-components": "../../../experience-builder-toolkit/packages/components"
   },
   "peerDependencies": {
     "contentful": ">=10.6.0",

--- a/packages/storybook-addon/package.json
+++ b/packages/storybook-addon/package.json
@@ -39,6 +39,9 @@
     "*.js",
     "*.d.ts"
   ],
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com/"
+  },
   "scripts": {
     "dev": "echo noop",
     "clean": "rimraf ./dist",
@@ -102,9 +105,6 @@
     "react-dom": {
       "optional": true
     }
-  },
-  "publishConfig": {
-    "access": "public"
   },
   "storybook": {
     "displayName": "Contentful Experience Builder Addon",

--- a/packages/visual-editor/package.json
+++ b/packages/visual-editor/package.json
@@ -10,6 +10,9 @@
     "package.json",
     "dist/**/*.*"
   ],
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com/"
+  },
   "scripts": {
     "bundle": "npx watchify dist/index.cjs -o dist/bundle.js",
     "clean": "rimraf dist",


### PR DESCRIPTION
In the web app, I'm not able to pull any version of `core` that was released in the last week. As we moved all private packages to `npm.pkg.github.com`, it looks like we need to move or public ones as well. According to the [docs](https://docs.npmjs.com/cli/v8/using-npm/registry#description), `.npmrc` does only allow defining a registry per namespace. In the user interface, we point the whole Contentful namespace to `npm.pkg.github.com` which forces us to move experience-builder to this registry as well.

I hope that mirroring works correctly so that customers can still install via the npm registry. We already have a similar config for almost all our customer-facing packages - see [code search](https://github.com/search?type=code&auto_enroll=true&q=org%3Acontentful+publishConfig+language%3AJSON&l=JSON). So I'm confident that this is the way to go.

# Update
Ely and I aligned on this and cleared up all questions. All packages in the `@contentful` scope have to be on `npm.pkg.github.com`. We have a custom script that mirrors releases to npmjs **once per hour**.