### PR TITLE
fix: adjust auto to Auto so that the design tab is consistent throughout

### DIFF
--- a/packages/core/src/definitions/styles.ts
+++ b/packages/core/src/definitions/styles.ts
@@ -315,7 +315,7 @@ export const containerBuiltInStyles: Partial<
     type: 'Text',
     group: 'style',
     description: 'The margin of the container',
-    defaultValue: '0 auto 0 auto',
+    defaultValue: '0 Auto 0 Auto',
   },
 };
 
@@ -466,7 +466,7 @@ export const columnsBuiltInStyles: Partial<
     type: 'Text',
     group: 'style',
     description: 'The margin of the columns',
-    defaultValue: '0 auto 0 auto',
+    defaultValue: '0 Auto 0 Auto',
   },
   cfWidth: {
     displayName: 'Width',

--- a/packages/storybook-addon/src/utils/variables.ts
+++ b/packages/storybook-addon/src/utils/variables.ts
@@ -183,6 +183,6 @@ export const containerBuiltInStyles = {
     type: 'Text',
     group: 'style',
     description: 'The height of the section',
-    defaultValue: 'auto',
+    defaultValue: 'Auto',
   } as ComponentDefinitionVariable<'Text'>,
 };


### PR DESCRIPTION
## Purpose
For the margin to change to Auto instead of auto with the container component
<img width="260" alt="Screenshot 2024-02-12 at 11 11 44 AM" src="https://github.com/contentful/user_interface/assets/124832189/137303a1-13d3-4529-b7ba-f00f080d470e">
