### PR TITLE
chore: dont bundle core into sdk

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38781,6 +38781,18 @@
         "sourcemap-codec": "^1.4.8"
       }
     },
+    "node_modules/rollup-plugin-node-externals": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-node-externals/-/rollup-plugin-node-externals-7.0.1.tgz",
+      "integrity": "sha512-NIGBhcuhyKn8slRsIt2mCHmxj5zRjXfkYjJ5FPjmg1Q3/rHvvMhOzj07kg0qVX/X6SEP2iubswIc0sL+CbXruA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 21 || ^20.6.0 || ^18.19.0"
+      },
+      "peerDependencies": {
+        "rollup": "^3.0.0 || ^4.0.0"
+      }
+    },
     "node_modules/rollup-plugin-peer-deps-external": {
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/rollup-plugin-peer-deps-external/-/rollup-plugin-peer-deps-external-2.2.4.tgz",
@@ -45830,6 +45842,7 @@
         "react-dom": "^18.2.0",
         "relative-deps": "^1.0.7",
         "rollup-plugin-dts": "^6.1.0",
+        "rollup-plugin-node-externals": "^7.0.1",
         "rollup-plugin-peer-deps-external": "^2.2.4",
         "rollup-plugin-postcss": "^4.0.2",
         "semantic-release": "23.0.2",

--- a/packages/experience-builder-sdk/package.json
+++ b/packages/experience-builder-sdk/package.json
@@ -69,6 +69,7 @@
     "react-dom": "^18.2.0",
     "relative-deps": "^1.0.7",
     "rollup-plugin-dts": "^6.1.0",
+    "rollup-plugin-node-externals": "^7.0.1",
     "rollup-plugin-peer-deps-external": "^2.2.4",
     "rollup-plugin-postcss": "^4.0.2",
     "semantic-release": "23.0.2",

--- a/packages/experience-builder-sdk/rollup.config.mjs
+++ b/packages/experience-builder-sdk/rollup.config.mjs
@@ -4,6 +4,7 @@ import typescript from '@rollup/plugin-typescript';
 import dts from 'rollup-plugin-dts';
 import postcss from 'rollup-plugin-postcss';
 import postcssImport from 'postcss-import';
+import nodeExternals from 'rollup-plugin-node-externals';
 
 export default [
   {
@@ -16,6 +17,7 @@ export default [
       },
     ],
     plugins: [
+      nodeExternals(),
       postcss({
         plugins: [postcssImport()],
         inject(cssVariableName) {
@@ -26,7 +28,6 @@ export default [
       commonjs(),
       typescript({ tsconfig: './tsconfig.json', noEmitOnError: process.env.DEV ? false : true }),
     ],
-    external: [/node_modules/],
   },
   {
     input: 'src/index.ts',


### PR DESCRIPTION
I noticed that core was being bundled into the SDK package, which is causing the SDK to be bigger than necessary and the core dep to be not used. This fix uses a package that automatically excludes any packages in dependencies, peer dependencies, and node apis from being packaged into the bundle.
