### PR TITLE
fix(experience-builder-sdk): support ssr in nextjs pages router

### DIFF
--- a/packages/core/src/fetchers/createExperience.ts
+++ b/packages/core/src/fetchers/createExperience.ts
@@ -12,23 +12,33 @@ type createExperienceArgs = {
   mode?: ExternalSDKMode;
 };
 
-export const createExperience = ({
-  experienceEntry,
-  referencedAssets,
-  referencedEntries,
-  locale,
-}: createExperienceArgs): Experience<EntityStore> => {
-  if (!isExperienceEntry(experienceEntry)) {
-    throw new Error('Provided entry is not experience entry');
+/**
+ * Create an experience instance
+ * @param {string} json - JSON representation of the experience
+ */
+export function createExperience(json: string): Experience<EntityStore>;
+export function createExperience(args: createExperienceArgs): Experience<EntityStore>;
+
+export function createExperience(options: string | createExperienceArgs): Experience<EntityStore> {
+  if (typeof options === 'string') {
+    const entityStore = new EntityStore(options);
+    return {
+      entityStore,
+    };
+  } else {
+    const { experienceEntry, referencedAssets, referencedEntries, locale } = options;
+    if (!isExperienceEntry(experienceEntry)) {
+      throw new Error('Provided entry is not experience entry');
+    }
+
+    const entityStore = new EntityStore({
+      experienceEntry,
+      entities: [...referencedEntries, ...referencedAssets],
+      locale,
+    });
+
+    return {
+      entityStore,
+    };
   }
-
-  const entityStore = new EntityStore({
-    experienceEntry,
-    entities: [...referencedEntries, ...referencedAssets],
-    locale,
-  });
-
-  return {
-    entityStore,
-  };
-};
+}

--- a/packages/core/src/fetchers/index.ts
+++ b/packages/core/src/fetchers/index.ts
@@ -1,2 +1,3 @@
 export * from './fetchBySlug';
 export * from './fetchById';
+export * from './createExperience';

--- a/packages/core/src/utils/transformers.ts
+++ b/packages/core/src/utils/transformers.ts
@@ -36,7 +36,7 @@ export const transformBorderStyle = (value?: string): CSSProperties => {
 export const transformAlignment = (
   cfHorizontalAlignment?: string,
   cfVerticalAlignment?: string,
-  cfFlexDirection = 'column'
+  cfFlexDirection = 'column',
 ): CSSProperties =>
   cfFlexDirection === 'row'
     ? {
@@ -72,10 +72,10 @@ interface CSSPropertiesForBackground extends CSSProperties {
 export const transformBackgroundImage = (
   cfBackgroundImageUrl: string | null | undefined,
   cfBackgroundImageScaling?: StyleProps['cfBackgroundImageScaling'],
-  cfBackgroundImageAlignment?: StyleProps['cfBackgroundImageAlignment']
+  cfBackgroundImageAlignment?: StyleProps['cfBackgroundImageAlignment'],
 ): CSSPropertiesForBackground | undefined => {
   const matchBackgroundSize = (
-    backgroundImageScaling?: StyleProps['cfBackgroundImageScaling']
+    backgroundImageScaling?: StyleProps['cfBackgroundImageScaling'],
   ): 'cover' | 'contain' | undefined => {
     if ('fill' === backgroundImageScaling) return 'cover';
     if ('fit' === backgroundImageScaling) return 'contain';
@@ -83,7 +83,7 @@ export const transformBackgroundImage = (
   };
 
   const matchBackgroundPosition = (
-    cfBackgroundImageAlignment?: StyleProps['cfBackgroundImageAlignment']
+    cfBackgroundImageAlignment?: StyleProps['cfBackgroundImageAlignment'],
   ): CSSPropertiesForBackground['backgroundPosition'] | undefined => {
     if (!cfBackgroundImageAlignment) {
       return undefined;
@@ -148,7 +148,7 @@ export const transformBackgroundImage = (
 
 export const transformContentValue = (
   value: CompositionVariableValueType,
-  variableDefinition: ComponentDefinitionVariable
+  variableDefinition: ComponentDefinitionVariable,
 ) => {
   if (variableDefinition.type === 'RichText') {
     return transformRichText(value);
@@ -157,7 +157,7 @@ export const transformContentValue = (
 };
 
 export const transformRichText = (
-  value: CompositionVariableValueType
+  value: CompositionVariableValueType,
 ): RichTextDocument | undefined => {
   if (typeof value === 'string') {
     return {
@@ -208,7 +208,7 @@ export const transformWidthSizing = ({
    * The value may instead be a string such as `min-content` or `max-content`. In
    * that case we don't want to use calc and instead return the raw value.
    */
-  if (CSS.supports('width', calcValue)) {
+  if (typeof window !== 'undefined' && CSS.supports('width', calcValue)) {
     return calcValue;
   }
 

--- a/packages/experience-builder-sdk/src/hooks/useFetchById.ts
+++ b/packages/experience-builder-sdk/src/hooks/useFetchById.ts
@@ -15,7 +15,7 @@ export type UseFetchByIdArgs = {
 };
 
 export const useFetchById = ({ id, localeCode, client, experienceTypeId }: UseFetchByIdArgs) => {
-  const isEditorMode = useDetectEditorMode();
+  const isEditorMode = useDetectEditorMode({ isClientSide: typeof window !== 'undefined' });
 
   const fetchMethod = useCallback(() => {
     return fetchById({ id, localeCode, client, experienceTypeId });

--- a/packages/experience-builder-sdk/src/hooks/useFetchBySlug.ts
+++ b/packages/experience-builder-sdk/src/hooks/useFetchBySlug.ts
@@ -20,7 +20,7 @@ export const useFetchBySlug = ({
   client,
   experienceTypeId,
 }: UseFetchBySlugArgs) => {
-  const isEditorMode = useDetectEditorMode();
+  const isEditorMode = useDetectEditorMode({ isClientSide: typeof window !== 'undefined' });
 
   const fetchMethod = useCallback(() => {
     return fetchBySlug({ slug, localeCode, client, experienceTypeId });

--- a/packages/experience-builder-sdk/src/index.ts
+++ b/packages/experience-builder-sdk/src/index.ts
@@ -14,6 +14,7 @@ export {
   VisualEditorMode,
   fetchById,
   fetchBySlug,
+  createExperience,
 } from '@contentful/experience-builder-core';
 export {
   /** @deprecated use `CONTENTFUL_COMPONENTS.section.id` instead. This will be removed in version 4. */


### PR DESCRIPTION
This PR fixes some issues and introduces a workaround to get SSR working in NextJS projects that use the pages router (app router is still not supported in SSR).

There were a couple of issues to tackle here.

1) The Experience that gets returned from the fetchBy{slug/id} methods returned an EntityStore object that cannot be serialized by NextJS in `getServerSideProps` due to their strict JSON serialization rules (see [here](https://github.com/vercel/next.js/issues/11993)). In order to get around this, we need to serialize the experience ourselves in getServerSideProps and then reconstruct the object back into a proper class in the component. To do the later, I reintroduced the `createExperience` function back into userland. It now takes an overloaded parameter of a json package, and if thats passed in, we recreate the experience based on the existing json object.

2) Defaulting the mode to editorMode by default when in an iframe was causing a hydration issue when in the editor. 
This as due to the server thinking it was not in editorMode (because there is no window object to check if you are in an iFrame), and the client thinking it was.

To get around this, We now default editorMode to false on first render. This will send an initial pageload of the page (via ssr) in non editor mode, and the client will initially think its not an editor mode as well. But then will quickly get updated to editor mode on the client after it mounts.