### PR TITLE
fix(components): line breaks for text built-ins [ALT-307]

### DIFF
--- a/packages/components/src/components/Heading/Heading.css
+++ b/packages/components/src/components/Heading/Heading.css
@@ -1,0 +1,3 @@
+.cf-heading {
+  white-space: pre-line;
+}

--- a/packages/components/src/components/Heading/Heading.tsx
+++ b/packages/components/src/components/Heading/Heading.tsx
@@ -1,6 +1,6 @@
 import { combineClasses } from '@/utils/combineClasses';
 import React from 'react';
-
+import './Heading.css';
 export interface HeadingProps extends React.HTMLAttributes<HTMLHeadingElement> {
   /**
    * The text to display in the heading. If not provided, children will be used instead.

--- a/packages/components/src/components/RichText/RichText.css
+++ b/packages/components/src/components/RichText/RichText.css
@@ -1,0 +1,3 @@
+.cf-richtext {
+  white-space: pre-line;
+}

--- a/packages/components/src/components/RichText/RichText.tsx
+++ b/packages/components/src/components/RichText/RichText.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { documentToReactComponents } from '@contentful/rich-text-react-renderer';
 import { Document, BLOCKS } from '@contentful/rich-text-types';
 import { combineClasses } from '@/utils/combineClasses';
-
+import './RichText.css';
 export interface RichTextProps extends Omit<React.HTMLAttributes<HTMLElement>, 'value'> {
   /**
    * Renders the text in a specific HTML tag.

--- a/packages/components/src/components/Text/Text.css
+++ b/packages/components/src/components/Text/Text.css
@@ -1,0 +1,3 @@
+.cf-text {
+  white-space: pre-line;
+}

--- a/packages/components/src/components/Text/Text.tsx
+++ b/packages/components/src/components/Text/Text.tsx
@@ -1,6 +1,6 @@
 import { combineClasses } from '@/utils/combineClasses';
 import React from 'react';
-
+import './Text.css';
 export interface TextProps extends React.HTMLAttributes<HTMLElement> {
   /**
    * The URL to navigate to when the text is clicked. When provided, the text will be wrapped in an anchor tag.

--- a/packages/components/src/components/Text/Text.tsx
+++ b/packages/components/src/components/Text/Text.tsx
@@ -93,6 +93,7 @@ export const Text: React.FC<TextProps> = ({
 
   const Tag = as;
 
+  console.log('text', value, children);
   const textAsTag = (
     <Tag
       className={combineClasses('cf-text', className)}

--- a/packages/components/src/components/Text/Text.tsx
+++ b/packages/components/src/components/Text/Text.tsx
@@ -93,7 +93,6 @@ export const Text: React.FC<TextProps> = ({
 
   const Tag = as;
 
-  console.log('text', value, children);
   const textAsTag = (
     <Tag
       className={combineClasses('cf-text', className)}

--- a/packages/components/src/styles.ts
+++ b/packages/components/src/styles.ts
@@ -1,5 +1,2 @@
 import './components/variables.css';
 import './components/Image/Image.css';
-import './components/Text/Text.css';
-import './components/Heading/Heading.css';
-import './components/RichText/RichText.css';

--- a/packages/components/src/styles.ts
+++ b/packages/components/src/styles.ts
@@ -1,2 +1,5 @@
 import './components/variables.css';
 import './components/Image/Image.css';
+import './components/Text/Text.css';
+import './components/Heading/Heading.css';
+import './components/RichText/RichText.css';


### PR DESCRIPTION
## Purpose
Add css properties so text components respect line breaks

<img width="1220" alt="Screenshot 2024-02-13 at 2 32 15 PM" src="https://github.com/contentful/experience-builder/assets/23040747/a09b580d-bb2f-48be-b119-e12ad182e1fa">
