### PR TITLE
fix: set default height to fit-content [ALT-448]

### DIFF
--- a/packages/core/src/definitions/styles.ts
+++ b/packages/core/src/definitions/styles.ts
@@ -82,7 +82,7 @@ export const builtInStyles: Partial<
     type: 'Text',
     group: 'style',
     description: 'The height of the section',
-    defaultValue: 'fill',
+    defaultValue: 'fit-content',
   },
   cfMaxWidth: {
     displayName: 'Max width',


### PR DESCRIPTION
## Purpose

This changes **All Components** default Height value to `'fit-content'` instead of `'fill'`. 

I tested all structure and built-in components and this gives the expected result for all our components.

![Screenshot 2024-02-13 at 3 09 33 PM](https://github.com/contentful/experience-builder/assets/8539634/8122e7d1-0e43-4e3a-b0b1-db2eba6a0796)

This change makes it so nested structure components will match the height of their children elements, instead of filling out (or growing) to the height of a parent structure.

![Screenshot 2024-02-13 at 3 20 04 PM](https://github.com/contentful/experience-builder/assets/8539634/252a9c4c-aaef-416e-9123-75963be0c5ae)


