### PR TITLE
fix: handle colliding unbound value keys correctly in entity store [SPA-1836]

### DIFF
--- a/packages/core/src/entity/EntityStore.ts
+++ b/packages/core/src/entity/EntityStore.ts
@@ -53,16 +53,24 @@ export class EntityStore extends EntityStoreBase {
     return this._experienceEntry?.usedComponents ?? [];
   }
 
-  public updateUnboundValues(unboundValues: CompositionUnboundValues) {
-    this._unboundValues = { ...(this._unboundValues ?? {}), ...unboundValues };
+  /**
+   * Extend the existing set of unbound values with the ones from the assembly definition.
+   * When creating a new assembly out of a container, the unbound value keys are copied and
+   * thus the existing and the added ones have colliding keys. In the case of overlapping value
+   * keys, the ones from the experience overrule the ones from the assembly definition as
+   * the latter one is certainly just a default value while the other one is from the actual instance.
+   * @param unboundValues set of unbound values defined in the assembly definition
+   */
+  public addAssemblyUnboundValues(unboundValues: CompositionUnboundValues) {
+    this._unboundValues = { ...unboundValues, ...(this._unboundValues ?? {}) };
   }
 
   public getValue(
     entityLinkOrEntity: UnresolvedLink<'Entry' | 'Asset'> | Entry | Asset,
-    path: string[]
+    path: string[],
   ): string | undefined {
     const isLink = (
-      entity: typeof entityLinkOrEntity
+      entity: typeof entityLinkOrEntity,
     ): entity is UnresolvedLink<'Entry' | 'Asset'> => entityLinkOrEntity.sys.type === 'Link';
 
     let entity: Entry | Asset;
@@ -74,7 +82,7 @@ export class EntityStore extends EntityStoreBase {
 
       if (!resolvedEntity || resolvedEntity.sys.type !== entityLinkOrEntity.sys.linkType) {
         console.warn(
-          `Experience references unresolved entity: ${JSON.stringify(entityLinkOrEntity)}`
+          `Experience references unresolved entity: ${JSON.stringify(entityLinkOrEntity)}`,
         );
         return;
       }

--- a/packages/experience-builder-sdk/src/blocks/preview/CompositionBlock.spec.tsx
+++ b/packages/experience-builder-sdk/src/blocks/preview/CompositionBlock.spec.tsx
@@ -21,6 +21,13 @@ const TestComponent: React.FC<{ text: string }> = (props) => {
 };
 
 describe('CompositionBlock', () => {
+  const emptyEntityStore = {
+    breakpoints: [],
+    dataSource: {},
+    unboundValues: {},
+    usedComponents: [],
+  } as unknown as EntityStore;
+
   beforeEach(() => {
     defineComponents([
       {
@@ -57,15 +64,16 @@ describe('CompositionBlock', () => {
     render(
       <CompositionBlock
         node={mockCompositionComponentNode}
-        dataSource={{}}
         locale="en-US"
-        breakpoints={[]}
-        entityStore={undefined}
-        usedComponents={[]}
-        unboundValues={{
-          value1: { value: 'unboundValue1' },
-          value2: { value: 1 },
-        }}
+        entityStore={
+          {
+            ...emptyEntityStore,
+            unboundValues: {
+              value1: { value: 'unboundValue1' },
+              value2: { value: 1 },
+            },
+          } as unknown as EntityStore
+        }
         resolveDesignValue={jest.fn()}
       />,
     );
@@ -81,12 +89,8 @@ describe('CompositionBlock', () => {
     const { getByTestId } = render(
       <CompositionBlock
         node={sectionNode}
-        dataSource={{}}
         locale="en-US"
-        breakpoints={[]}
-        entityStore={undefined}
-        usedComponents={[]}
-        unboundValues={{}}
+        entityStore={emptyEntityStore}
         resolveDesignValue={jest.fn()}
       />,
     );
@@ -104,12 +108,8 @@ describe('CompositionBlock', () => {
     const { getByTestId } = render(
       <CompositionBlock
         node={containerNode}
-        dataSource={{}}
         locale="en-US"
-        breakpoints={[]}
-        entityStore={undefined}
-        usedComponents={[]}
-        unboundValues={{}}
+        entityStore={emptyEntityStore}
         resolveDesignValue={jest.fn()}
       />,
     );
@@ -153,12 +153,8 @@ describe('CompositionBlock', () => {
     const { getByTestId, getByText } = render(
       <CompositionBlock
         node={assemblyNode}
-        dataSource={{}}
         locale="en-US"
-        breakpoints={[]}
         entityStore={entityStore}
-        usedComponents={[assemblyEntry] as ExperienceEntry[]}
-        unboundValues={experienceEntry.fields.unboundValues}
         resolveDesignValue={jest.fn()}
       />,
     );

--- a/packages/experience-builder-sdk/src/blocks/preview/DeprecatedPreviewDeliveryRoot.tsx
+++ b/packages/experience-builder-sdk/src/blocks/preview/DeprecatedPreviewDeliveryRoot.tsx
@@ -80,11 +80,7 @@ export const DeprecatedPreviewDeliveryRoot = ({
           node={childNode}
           locale={locale}
           entityStore={entityStore}
-          dataSource={entityStore.dataSource}
-          unboundValues={entityStore.unboundValues}
-          breakpoints={entityStore.breakpoints}
           resolveDesignValue={resolveDesignValue}
-          usedComponents={entityStore.usedComponents}
         />
       ))}
     </>

--- a/packages/experience-builder-sdk/src/blocks/preview/PreviewDeliveryRoot.tsx
+++ b/packages/experience-builder-sdk/src/blocks/preview/PreviewDeliveryRoot.tsx
@@ -34,10 +34,6 @@ export const PreviewDeliveryRoot = ({ locale, experience }: DeliveryRootProps) =
           node={childNode}
           locale={locale}
           entityStore={entityStore}
-          dataSource={entityStore.dataSource}
-          unboundValues={entityStore.unboundValues}
-          breakpoints={entityStore.breakpoints}
-          usedComponents={entityStore.usedComponents}
           resolveDesignValue={resolveDesignValue}
         />
       ))}

--- a/packages/experience-builder-sdk/src/core/preview/assemblyUtils.spec.ts
+++ b/packages/experience-builder-sdk/src/core/preview/assemblyUtils.spec.ts
@@ -32,7 +32,7 @@ describe('resolveAssembly', () => {
       children: [],
     };
 
-    const entityStore = undefined;
+    const entityStore = {} as unknown as EntityStore;
 
     const result = resolveAssembly({ node: containerNode, entityStore });
 

--- a/packages/experience-builder-sdk/src/core/preview/assemblyUtils.ts
+++ b/packages/experience-builder-sdk/src/core/preview/assemblyUtils.ts
@@ -54,11 +54,11 @@ export const resolveAssembly = ({
   entityStore,
 }: {
   node: CompositionNode;
-  entityStore: EntityStore | undefined;
+  entityStore: EntityStore;
 }) => {
   const isAssembly = checkIsAssemblyNode({
     componentId: node.definitionId,
-    usedComponents: entityStore?.usedComponents,
+    usedComponents: entityStore.usedComponents,
   });
 
   if (!isAssembly) {
@@ -66,7 +66,7 @@ export const resolveAssembly = ({
   }
 
   const componentId = node.definitionId as string;
-  const assembly = entityStore?.experienceEntryFields?.usedComponents?.find(
+  const assembly = entityStore.experienceEntryFields?.usedComponents?.find(
     (component) => component.sys.id === componentId,
   );
 
@@ -85,7 +85,7 @@ export const resolveAssembly = ({
     componentInstanceVariables: node.variables,
   });
 
-  entityStore?.addAssemblyUnboundValues(componentFields.unboundValues);
+  entityStore.addAssemblyUnboundValues(componentFields.unboundValues);
 
   return deserializedNode;
 };

--- a/packages/experience-builder-sdk/src/core/preview/assemblyUtils.ts
+++ b/packages/experience-builder-sdk/src/core/preview/assemblyUtils.ts
@@ -85,7 +85,7 @@ export const resolveAssembly = ({
     componentInstanceVariables: node.variables,
   });
 
-  entityStore?.updateUnboundValues(componentFields.unboundValues);
+  entityStore?.addAssemblyUnboundValues(componentFields.unboundValues);
 
   return deserializedNode;
 };


### PR DESCRIPTION
## Purpose

When creating a new pattern out of a container, the custom unbound values would be persisted correctly and rendered in the editor. However, in preview mode, it would only render the default value.

This as our logic puts all unbound values from experience and assembly definitions in a single entity store. If the keys are the same, the assembly ones override the experience ones. As the former one contains only default values while the latter ones contains actual instance values, I changed the order in which we merge both maps. I added a comment to it as well in case, future us is wondering why.

## Approach

Also, I realized that we have some fallbacks like `entityStore?.unboundValues ?? unboundValues` which were not necessary. This is a leftover from the merged preview/ editor rendering. Now we only support preview mode and know that the entity store is always defined. `entityStore?.unboundValues` and `unboundValues` are the exact same object. The same holds for `breakpoints`, `usedComponents`, and `dataSource`. As we only pass the `entityStore`, I removed all the unnecessary additional props.