### PR TITLE
fix: change inside and outside option to dashed, dotted, and solid for border options

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -91,7 +91,7 @@ export interface ComponentDefinitionVariableBase<T extends ComponentDefinitionVa
 }
 
 export type ComponentDefinitionVariable<
-  T extends ComponentDefinitionVariableType = ComponentDefinitionVariableType,
+  T extends ComponentDefinitionVariableType = ComponentDefinitionVariableType
   // K extends ComponentDefinitionVariableArrayItemType = ComponentDefinitionVariableArrayItemType
 > =
   // T extends 'Link'
@@ -101,7 +101,7 @@ export type ComponentDefinitionVariable<
   /*:*/ ComponentDefinitionVariableBase<T>;
 
 export type ComponentDefinition<
-  T extends ComponentDefinitionVariableType = ComponentDefinitionVariableType,
+  T extends ComponentDefinitionVariableType = ComponentDefinitionVariableType
 > = {
   id: string;
   name: string;
@@ -244,7 +244,7 @@ export type DesignTokensDefinition = {
   spacing?: Record<string, string>;
   sizing?: Record<string, string>;
   color?: Record<string, string>;
-  border?: Record<string, { width: string; style: 'inside' | 'outside'; color: string }>;
+  border?: Record<string, { width: string; style: 'solid' | 'dashed' | 'dotted'; color: string }>;
   fontSize?: Record<string, string>;
   lineHeight?: Record<string, string>;
   letterSpacing?: Record<string, string>;
@@ -300,7 +300,7 @@ export interface DeprecatedExperience {
 
 export type ResolveDesignValueType = (
   valuesByBreakpoint: ValuesByBreakpoint,
-  variableName: string,
+  variableName: string
 ) => PrimitiveValue;
 
 // The 'contentful' package only exposes CDA types while we received CMA ones in editor mode

--- a/packages/core/src/utils/transformers.ts
+++ b/packages/core/src/utils/transformers.ts
@@ -26,11 +26,10 @@ export const transformBorderStyle = (value?: string): CSSProperties => {
   // Just accept the passed value
   if (parts.length < 3) return { border: value };
   // Replace the second part always with `solid` and set the box sizing accordingly
-  const [borderSize, borderPlacement, ...borderColorParts] = parts;
+  const [borderSize, borderStyle, ...borderColorParts] = parts;
   const borderColor = borderColorParts.join(' ');
   return {
-    border: `${borderSize} solid ${borderColor}`,
-    boxSizing: borderPlacement === 'inside' ? 'border-box' : 'content-box',
+    border: `${borderSize} ${borderStyle} ${borderColor}`,
   };
 };
 

--- a/packages/storybook-addon/src/components/StyleSectionComponents/BorderInput/useBorderConstituents.ts
+++ b/packages/storybook-addon/src/components/StyleSectionComponents/BorderInput/useBorderConstituents.ts
@@ -6,18 +6,18 @@ export const useBorderConstituents = (borderValue: string) => {
   const [borderWidth, borderStyle, borderColor] = useMemo(() => {
     if (borderValue === '0' || borderValue === 'none') {
       // The ColorPicker doesn't support the alpha channel in hexcodes, so we just leave it out per default
-      return ['0px', 'inside', 'rgba(255, 255, 255, 1)'];
+      return ['0px', 'solid', 'rgba(255, 255, 255, 1)'];
     }
     // To reuse the existing partial regex patterns, we first split it into three substrings
     const constituents = borderValue.split(' ');
     if (constituents.length < 3) {
       // The border value is not valid -> per default set no border
-      return ['0px', 'inside', 'rgba(255, 255, 255, 1)'];
+      return ['0px', 'solid', 'rgba(255, 255, 255, 1)'];
     }
     // We only support setting the same line width and style for all sides
     if (!LengthRegExp.test(constituents[0]) || !BorderStyleRegExp.test(constituents[1])) {
       // If any value is invalid, all parts fall back to the default
-      return ['0px', 'inside', 'rgba(255, 255, 255, 1)'];
+      return ['0px', 'solid', 'rgba(255, 255, 255, 1)'];
     }
     const borderWidth = constituents[0];
     const borderStyle = constituents[1];

--- a/packages/storybook-addon/src/components/StyleSectionComponents/constants.ts
+++ b/packages/storybook-addon/src/components/StyleSectionComponents/constants.ts
@@ -9,5 +9,5 @@ export const OnlyNumberRegexp = /^\d+$/;
 // Note that this explicitly doesn't include percentage values (see <length-percentage>)
 export const LengthRegExp = /^\d{1,}(px|cm|mm|in|pt|pc|em|ex|ch|rem|vw|vh|vmin|vmax)$/;
 
-export const BORDER_STYLE_OPTIONS = ['inside', 'outside'];
+export const BORDER_STYLE_OPTIONS = ['solid', 'dashed', 'dotted'];
 export const BorderStyleRegExp = new RegExp(`^${BORDER_STYLE_OPTIONS.join('|')}$`);


### PR DESCRIPTION
## Purpose
Instead of Inside/Outside, change it to solid, dashed, and dotted options for borders

<img width="1423" alt="Screenshot 2024-02-14 at 12 43 54 PM" src="https://github.com/contentful/user_interface/assets/124832189/2aee6f08-4854-491a-902c-f2833f866a49">
<img width="1428" alt="Screenshot 2024-02-14 at 12 43 50 PM" src="https://github.com/contentful/user_interface/assets/124832189/97125721-36f8-497d-ab0a-778d122de9d1">
<img width="1404" alt="Screenshot 2024-02-14 at 12 43 47 PM" src="https://github.com/contentful/user_interface/assets/124832189/398b9785-1bc6-45f7-b484-1c587fb574ab">
