### PR TITLE
Structure component labels are displayed with any background component [ALT-466]

### DIFF
--- a/packages/components/src/components/Columns/Columns.css
+++ b/packages/components/src/components/Columns/Columns.css
@@ -35,4 +35,5 @@
   font-family: var(--exp-builder-font-stack-primary);
   font-size: 12px;
   color: var(--exp-builder-gray400);
+  z-index: 100;
 }

--- a/packages/components/src/components/ContentfulContainer/ContentfulContainer.css
+++ b/packages/components/src/components/ContentfulContainer/ContentfulContainer.css
@@ -31,6 +31,7 @@
   font-family: var(--exp-builder-font-stack-primary);
   font-size: 12px;
   color: var(--exp-builder-gray400);
+  z-index: 100;
 }
 
 /* used by ContentfulSectionAsHyperlink.tsx */


### PR DESCRIPTION
## Purpose
Use zindex to always show the display labels for structural components unless the component has a child

<img width="1172" alt="Screenshot 2024-02-15 at 1 04 45 PM" src="https://github.com/contentful/experience-builder/assets/124832189/5bf650ea-5655-4fc0-a88c-60439a4227ba">
<img width="1401" alt="Screenshot 2024-02-15 at 1 05 54 PM" src="https://github.com/contentful/experience-builder/assets/124832189/fc868619-849b-4493-9f6e-65f70b6a168b">
<img width="1412" alt="Screenshot 2024-02-15 at 1 04 58 PM" src="https://github.com/contentful/experience-builder/assets/124832189/9022e9d5-2cc5-457a-9372-8388f91c9c89">
