### PR TITLE
fix: export individual types for each property value type []

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -35,6 +35,10 @@ export {
   ValuesByBreakpoint,
   Breakpoint,
   SchemaVersions,
+  DesignValue,
+  UnboundValue,
+  BoundValue,
+  ComponentValue,
 } from '@contentful/experiences-validators';
 
 type ScrollStateKey = keyof typeof SCROLL_STATES;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -15,7 +15,7 @@ import type {
   ExperienceComponentTree,
 } from '@contentful/experiences-validators';
 // TODO: Remove references to 'Composition'
-export {
+export type {
   /** @deprecated the old type name will be replaced by ExperienceDataSource as of v5 */
   ExperienceDataSource as CompositionDataSource,
   ExperienceDataSource,

--- a/packages/validators/package.json
+++ b/packages/validators/package.json
@@ -23,7 +23,9 @@
     "dist/**/*.*"
   ],
   "exports": {
-    "*": {
+    ".": {
+      "import": "./dist/index.js",
+      "require": "./dist/index.js",
       "types": [
         "./dist/index.d.ts"
       ]

--- a/packages/validators/src/schemas/v2023_09_28/experience.ts
+++ b/packages/validators/src/schemas/v2023_09_28/experience.ts
@@ -36,23 +36,28 @@ export const ComponentDefinitionPropertyTypeSchema = z.enum([
 
 const ValuesByBreakpointSchema = z.record(z.lazy(() => PrimitiveValueSchema));
 
+const DesignValueSchema = z.object({
+  type: z.literal('DesignValue'),
+  valuesByBreakpoint: ValuesByBreakpointSchema,
+});
+const BoundValueSchema = z.object({
+  type: z.literal('BoundValue'),
+  path: z.string(),
+});
+const UnboundValueSchema = z.object({
+  type: z.literal('UnboundValue'),
+  key: z.string(),
+});
+const ComponentValueSchema = z.object({
+  type: z.literal('ComponentValue'),
+  key: z.string(),
+});
+
 const ComponentPropertyValueSchema = z.union([
-  z.object({
-    type: z.literal('DesignValue'),
-    valuesByBreakpoint: ValuesByBreakpointSchema,
-  }),
-  z.object({
-    type: z.literal('BoundValue'),
-    path: z.string(),
-  }),
-  z.object({
-    type: z.literal('UnboundValue'),
-    key: z.string(),
-  }),
-  z.object({
-    type: z.literal('ComponentValue'),
-    key: z.string(),
-  }),
+  DesignValueSchema,
+  BoundValueSchema,
+  UnboundValueSchema,
+  ComponentValueSchema,
 ]);
 
 export type ComponentPropertyValue = z.infer<typeof ComponentPropertyValueSchema>;
@@ -183,3 +188,7 @@ export type ExperienceComponentTree = z.infer<typeof ComponentTreeSchema>;
 export type ValuesByBreakpoint = z.infer<typeof ValuesByBreakpointSchema>;
 export type Breakpoint = z.infer<typeof BreakpointSchema>;
 export type PrimitiveValue = z.infer<typeof PrimitiveValueSchema>;
+export type DesignValue = z.infer<typeof DesignValueSchema>;
+export type BoundValue = z.infer<typeof BoundValueSchema>;
+export type UnboundValue = z.infer<typeof UnboundValueSchema>;
+export type ComponentValue = z.infer<typeof ComponentValueSchema>;

--- a/packages/validators/src/schemas/v2023_09_28/experience.ts
+++ b/packages/validators/src/schemas/v2023_09_28/experience.ts
@@ -92,12 +92,25 @@ const ComponentSettingsSchema = z.object({
   variableDefinitions: z.record(
     z.string().regex(/^[a-zA-Z0-9-_]{1,54}$/), // Here the key is <variableName>_<nanoidId> so we need to allow for a longer length
     z.object({
-      displayName: z.string(),
+      displayName: z.string().optional(),
       type: ComponentDefinitionPropertyTypeSchema,
-      defaultValue: ComponentPropertyValueSchema.optional(),
+      defaultValue: PrimitiveValueSchema.or(ComponentPropertyValueSchema).optional(),
       description: z.string().optional(),
       group: z.string().optional(),
-      validations: z.record(z.string()).optional(),
+      validations: z
+        .object({
+          required: z.boolean().optional(),
+          format: z.literal('URL').optional(),
+          in: z
+            .array(
+              z.object({
+                value: z.union([z.string(), z.number()]),
+                displayName: z.string().optional(),
+              }),
+            )
+            .optional(),
+        })
+        .optional(),
     }),
   ),
 });

--- a/packages/validators/src/types.ts
+++ b/packages/validators/src/types.ts
@@ -10,5 +10,9 @@ export type {
   ComponentPropertyValue,
   ComponentTreeNode,
   PrimitiveValue,
+  DesignValue,
+  UnboundValue,
+  BoundValue,
+  ComponentValue,
 } from './schemas/latest';
 export type { SchemaVersions } from './schemas/schemaVersions';

--- a/packages/validators/test/v2023_09_28/componentSettings.spec.ts
+++ b/packages/validators/test/v2023_09_28/componentSettings.spec.ts
@@ -84,32 +84,6 @@ describe('componentSettings', () => {
     expect(result.error.issues[0]).toEqual(expect.objectContaining(expectedError));
   });
 
-  it('fails if variable definition is missing a displayName', () => {
-    const updatedPattern = {
-      ...experiencePattern,
-      fields: {
-        ...experience.fields,
-        componentSettings: {
-          [locale]: { variableDefinitions: { var1: { type: 'Text', defaultValue: '' } } },
-        },
-      },
-    };
-    const result = validateExperienceFields(updatedPattern, schemaVersion) as SafeParseError<
-      typeof updatedPattern
-    >;
-
-    const expectedError = {
-      received: 'undefined',
-      code: 'invalid_type',
-      expected: 'string',
-      path: ['componentSettings', 'en-US', 'variableDefinitions', 'var1', 'displayName'],
-      message: 'Required',
-    };
-
-    expect(result.success).toBe(false);
-    expect(result.error.issues[0]).toEqual(expect.objectContaining(expectedError));
-  });
-
   it('fails if componentSettings is used in conjuction with usedComponents', () => {
     const updatedPattern = {
       ...experiencePattern,


### PR DESCRIPTION
## Purpose

* Export individual types for each property value type in order to avoid using generic type.
* Align ExperienceComponentSettings['variableDefinitions'] with `ComponentDefinitionVariable` types

## Approach

<!--

Three important notes on Pull Requests:
- In general, you should ask yourself whether this code change will improve or worsen the overall code quality. Any new tech debt will probably never be cleaned up.
- Please remember that newly introduced logic should be validated and protected through testing.
- Take a look at PR guides such as Google's [Google’s Code Review Guidelines](https://google.github.io/eng-practices/) and [Blockly - Writing a Good Pull Request](https://developers.google.com/blockly/guides/contribute/get-started/write_a_good_pr)

-->
