### PR TITLE
Release@next

### DIFF
--- a/packages/components/src/components/Columns/Columns.css
+++ b/packages/components/src/components/Columns/Columns.css
@@ -35,4 +35,5 @@
   font-family: var(--exp-builder-font-stack-primary);
   font-size: 12px;
   color: var(--exp-builder-gray400);
+  z-index: 100;
 }

--- a/packages/components/src/components/ContentfulContainer/ContentfulContainer.css
+++ b/packages/components/src/components/ContentfulContainer/ContentfulContainer.css
@@ -31,6 +31,7 @@
   font-family: var(--exp-builder-font-stack-primary);
   font-size: 12px;
   color: var(--exp-builder-gray400);
+  z-index: 100;
 }
 
 /* used by ContentfulSectionAsHyperlink.tsx */

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -91,7 +91,7 @@ export interface ComponentDefinitionVariableBase<T extends ComponentDefinitionVa
 }
 
 export type ComponentDefinitionVariable<
-  T extends ComponentDefinitionVariableType = ComponentDefinitionVariableType,
+  T extends ComponentDefinitionVariableType = ComponentDefinitionVariableType
   // K extends ComponentDefinitionVariableArrayItemType = ComponentDefinitionVariableArrayItemType
 > =
   // T extends 'Link'
@@ -101,7 +101,7 @@ export type ComponentDefinitionVariable<
   /*:*/ ComponentDefinitionVariableBase<T>;
 
 export type ComponentDefinition<
-  T extends ComponentDefinitionVariableType = ComponentDefinitionVariableType,
+  T extends ComponentDefinitionVariableType = ComponentDefinitionVariableType
 > = {
   id: string;
   name: string;
@@ -244,7 +244,7 @@ export type DesignTokensDefinition = {
   spacing?: Record<string, string>;
   sizing?: Record<string, string>;
   color?: Record<string, string>;
-  border?: Record<string, { width: string; style: 'inside' | 'outside'; color: string }>;
+  border?: Record<string, { width: string; style: 'solid' | 'dashed' | 'dotted'; color: string }>;
   fontSize?: Record<string, string>;
   lineHeight?: Record<string, string>;
   letterSpacing?: Record<string, string>;
@@ -300,7 +300,7 @@ export interface DeprecatedExperience {
 
 export type ResolveDesignValueType = (
   valuesByBreakpoint: ValuesByBreakpoint,
-  variableName: string,
+  variableName: string
 ) => PrimitiveValue;
 
 // The 'contentful' package only exposes CDA types while we received CMA ones in editor mode

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -15,7 +15,7 @@ import type {
   ExperienceComponentTree,
 } from '@contentful/experiences-validators';
 // TODO: Remove references to 'Composition'
-export {
+export type {
   /** @deprecated the old type name will be replaced by ExperienceDataSource as of v5 */
   ExperienceDataSource as CompositionDataSource,
   ExperienceDataSource,
@@ -35,6 +35,10 @@ export {
   ValuesByBreakpoint,
   Breakpoint,
   SchemaVersions,
+  DesignValue,
+  UnboundValue,
+  BoundValue,
+  ComponentValue,
 } from '@contentful/experiences-validators';
 
 type ScrollStateKey = keyof typeof SCROLL_STATES;

--- a/packages/core/src/utils/transformers.ts
+++ b/packages/core/src/utils/transformers.ts
@@ -26,11 +26,10 @@ export const transformBorderStyle = (value?: string): CSSProperties => {
   // Just accept the passed value
   if (parts.length < 3) return { border: value };
   // Replace the second part always with `solid` and set the box sizing accordingly
-  const [borderSize, borderPlacement, ...borderColorParts] = parts;
+  const [borderSize, borderStyle, ...borderColorParts] = parts;
   const borderColor = borderColorParts.join(' ');
   return {
-    border: `${borderSize} solid ${borderColor}`,
-    boxSizing: borderPlacement === 'inside' ? 'border-box' : 'content-box',
+    border: `${borderSize} ${borderStyle} ${borderColor}`,
   };
 };
 

--- a/packages/storybook-addon/src/components/StyleSectionComponents/BorderInput/useBorderConstituents.ts
+++ b/packages/storybook-addon/src/components/StyleSectionComponents/BorderInput/useBorderConstituents.ts
@@ -6,18 +6,18 @@ export const useBorderConstituents = (borderValue: string) => {
   const [borderWidth, borderStyle, borderColor] = useMemo(() => {
     if (borderValue === '0' || borderValue === 'none') {
       // The ColorPicker doesn't support the alpha channel in hexcodes, so we just leave it out per default
-      return ['0px', 'inside', 'rgba(255, 255, 255, 1)'];
+      return ['0px', 'solid', 'rgba(255, 255, 255, 1)'];
     }
     // To reuse the existing partial regex patterns, we first split it into three substrings
     const constituents = borderValue.split(' ');
     if (constituents.length < 3) {
       // The border value is not valid -> per default set no border
-      return ['0px', 'inside', 'rgba(255, 255, 255, 1)'];
+      return ['0px', 'solid', 'rgba(255, 255, 255, 1)'];
     }
     // We only support setting the same line width and style for all sides
     if (!LengthRegExp.test(constituents[0]) || !BorderStyleRegExp.test(constituents[1])) {
       // If any value is invalid, all parts fall back to the default
-      return ['0px', 'inside', 'rgba(255, 255, 255, 1)'];
+      return ['0px', 'solid', 'rgba(255, 255, 255, 1)'];
     }
     const borderWidth = constituents[0];
     const borderStyle = constituents[1];

--- a/packages/storybook-addon/src/components/StyleSectionComponents/constants.ts
+++ b/packages/storybook-addon/src/components/StyleSectionComponents/constants.ts
@@ -9,5 +9,5 @@ export const OnlyNumberRegexp = /^\d+$/;
 // Note that this explicitly doesn't include percentage values (see <length-percentage>)
 export const LengthRegExp = /^\d{1,}(px|cm|mm|in|pt|pc|em|ex|ch|rem|vw|vh|vmin|vmax)$/;
 
-export const BORDER_STYLE_OPTIONS = ['inside', 'outside'];
+export const BORDER_STYLE_OPTIONS = ['solid', 'dashed', 'dotted'];
 export const BorderStyleRegExp = new RegExp(`^${BORDER_STYLE_OPTIONS.join('|')}$`);

--- a/packages/validators/package.json
+++ b/packages/validators/package.json
@@ -23,7 +23,9 @@
     "dist/**/*.*"
   ],
   "exports": {
-    "*": {
+    ".": {
+      "import": "./dist/index.js",
+      "require": "./dist/index.js",
       "types": [
         "./dist/index.d.ts"
       ]

--- a/packages/validators/src/index.ts
+++ b/packages/validators/src/index.ts
@@ -1,2 +1,3 @@
 export * from './schemas';
 export * from './types';
+export * from './validators';

--- a/packages/validators/src/schemas/v2023_09_28/experience.ts
+++ b/packages/validators/src/schemas/v2023_09_28/experience.ts
@@ -36,23 +36,28 @@ export const ComponentDefinitionPropertyTypeSchema = z.enum([
 
 const ValuesByBreakpointSchema = z.record(z.lazy(() => PrimitiveValueSchema));
 
+const DesignValueSchema = z.object({
+  type: z.literal('DesignValue'),
+  valuesByBreakpoint: ValuesByBreakpointSchema,
+});
+const BoundValueSchema = z.object({
+  type: z.literal('BoundValue'),
+  path: z.string(),
+});
+const UnboundValueSchema = z.object({
+  type: z.literal('UnboundValue'),
+  key: z.string(),
+});
+const ComponentValueSchema = z.object({
+  type: z.literal('ComponentValue'),
+  key: z.string(),
+});
+
 const ComponentPropertyValueSchema = z.union([
-  z.object({
-    type: z.literal('DesignValue'),
-    valuesByBreakpoint: ValuesByBreakpointSchema,
-  }),
-  z.object({
-    type: z.literal('BoundValue'),
-    path: z.string(),
-  }),
-  z.object({
-    type: z.literal('UnboundValue'),
-    key: z.string(),
-  }),
-  z.object({
-    type: z.literal('ComponentValue'),
-    key: z.string(),
-  }),
+  DesignValueSchema,
+  BoundValueSchema,
+  UnboundValueSchema,
+  ComponentValueSchema,
 ]);
 
 export type ComponentPropertyValue = z.infer<typeof ComponentPropertyValueSchema>;
@@ -87,12 +92,25 @@ const ComponentSettingsSchema = z.object({
   variableDefinitions: z.record(
     z.string().regex(/^[a-zA-Z0-9-_]{1,54}$/), // Here the key is <variableName>_<nanoidId> so we need to allow for a longer length
     z.object({
-      displayName: z.string(),
+      displayName: z.string().optional(),
       type: ComponentDefinitionPropertyTypeSchema,
-      defaultValue: ComponentPropertyValueSchema.optional(),
+      defaultValue: PrimitiveValueSchema.or(ComponentPropertyValueSchema).optional(),
       description: z.string().optional(),
       group: z.string().optional(),
-      validations: z.record(z.string()).optional(),
+      validations: z
+        .object({
+          required: z.boolean().optional(),
+          format: z.literal('URL').optional(),
+          in: z
+            .array(
+              z.object({
+                value: z.union([z.string(), z.number()]),
+                displayName: z.string().optional(),
+              }),
+            )
+            .optional(),
+        })
+        .optional(),
     }),
   ),
 });
@@ -183,3 +201,7 @@ export type ExperienceComponentTree = z.infer<typeof ComponentTreeSchema>;
 export type ValuesByBreakpoint = z.infer<typeof ValuesByBreakpointSchema>;
 export type Breakpoint = z.infer<typeof BreakpointSchema>;
 export type PrimitiveValue = z.infer<typeof PrimitiveValueSchema>;
+export type DesignValue = z.infer<typeof DesignValueSchema>;
+export type BoundValue = z.infer<typeof BoundValueSchema>;
+export type UnboundValue = z.infer<typeof UnboundValueSchema>;
+export type ComponentValue = z.infer<typeof ComponentValueSchema>;

--- a/packages/validators/src/types.ts
+++ b/packages/validators/src/types.ts
@@ -10,5 +10,9 @@ export type {
   ComponentPropertyValue,
   ComponentTreeNode,
   PrimitiveValue,
+  DesignValue,
+  UnboundValue,
+  BoundValue,
+  ComponentValue,
 } from './schemas/latest';
 export type { SchemaVersions } from './schemas/schemaVersions';

--- a/packages/validators/test/v2023_09_28/componentSettings.spec.ts
+++ b/packages/validators/test/v2023_09_28/componentSettings.spec.ts
@@ -84,32 +84,6 @@ describe('componentSettings', () => {
     expect(result.error.issues[0]).toEqual(expect.objectContaining(expectedError));
   });
 
-  it('fails if variable definition is missing a displayName', () => {
-    const updatedPattern = {
-      ...experiencePattern,
-      fields: {
-        ...experience.fields,
-        componentSettings: {
-          [locale]: { variableDefinitions: { var1: { type: 'Text', defaultValue: '' } } },
-        },
-      },
-    };
-    const result = validateExperienceFields(updatedPattern, schemaVersion) as SafeParseError<
-      typeof updatedPattern
-    >;
-
-    const expectedError = {
-      received: 'undefined',
-      code: 'invalid_type',
-      expected: 'string',
-      path: ['componentSettings', 'en-US', 'variableDefinitions', 'var1', 'displayName'],
-      message: 'Required',
-    };
-
-    expect(result.success).toBe(false);
-    expect(result.error.issues[0]).toEqual(expect.objectContaining(expectedError));
-  });
-
   it('fails if componentSettings is used in conjuction with usedComponents', () => {
     const updatedPattern = {
       ...experiencePattern,


### PR DESCRIPTION
## Purpose
* fix: change inside and outside option to dashed, dotted, and solid for border options #375
* Structure component labels are displayed with any background component [ALT-466] #378
* fix: export main validator function #380
* fix: export individual types for each property value type [] #381


[ALT-466]: https://contentful.atlassian.net/browse/ALT-466?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ