### PR TITLE
refactor: rename experience-builder-core to experiences-core

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -58,6 +58,8 @@ jobs:
             npx lerna publish prerelease --exact --conventional-commits --conventional-prerelease --preid dev-$(date +%Y%m%dT%H%M%S) --no-changelog --no-git-tag-version --dist-tag dev --no-push --yes
           elif [ ${{ github.ref_name }} = next ]; then
             npx lerna publish prerelease --exact --conventional-commits --conventional-prerelease --preid alpha --yes --no-private --dist-tag latest
+          elif [ ${{ github.ref_name }} = experience-release ]; then
+            npx lerna publish prerelease --exact --conventional-commits --conventional-prerelease --preid dev-$(date +%Y%m%dT%H%M%S) --no-changelog --no-git-tag-version --dist-tag dev --no-push --yes
           else
             npx lerna publish --conventional-commits --conventional-graduate --yes --no-private --create-release github --dist-tag latest
           fi

--- a/package-lock.json
+++ b/package-lock.json
@@ -2897,16 +2897,16 @@
       "resolved": "packages/components",
       "link": true
     },
-    "node_modules/@contentful/experience-builder-core": {
-      "resolved": "packages/core",
-      "link": true
-    },
     "node_modules/@contentful/experience-builder-storybook-addon": {
       "resolved": "packages/storybook-addon",
       "link": true
     },
     "node_modules/@contentful/experience-builder-visual-editor": {
       "resolved": "packages/visual-editor",
+      "link": true
+    },
+    "node_modules/@contentful/experiences-core": {
+      "resolved": "packages/core",
       "link": true
     },
     "node_modules/@contentful/experiences-validators": {
@@ -45618,7 +45618,7 @@
       "version": "0.0.2-alpha.26",
       "license": "MIT",
       "dependencies": {
-        "@contentful/experience-builder-core": "file:../core",
+        "@contentful/experiences-core": "file:../core",
         "@contentful/rich-text-react-renderer": "^15.17.2",
         "postcss-import": "^15.1.0",
         "style-inject": "^0.3.0"
@@ -45693,8 +45693,8 @@
       }
     },
     "packages/core": {
-      "name": "@contentful/experience-builder-core",
-      "version": "0.0.2-alpha.23",
+      "name": "@contentful/experiences-core",
+      "version": "0.0.0-alpha.25",
       "license": "MIT",
       "dependencies": {
         "@contentful/experiences-validators": "file:../validators",
@@ -45806,8 +45806,8 @@
       "license": "MIT",
       "dependencies": {
         "@contentful/experience-builder-components": "file:../components",
-        "@contentful/experience-builder-core": "file:../core",
         "@contentful/experience-builder-visual-editor": "file:../visual-editor",
+        "@contentful/experiences-core": "file:../core",
         "@contentful/rich-text-types": "^16.2.1",
         "classnames": "^2.3.2",
         "csstype": "^3.1.2",
@@ -46111,7 +46111,7 @@
       "version": "0.0.2-alpha.26",
       "dependencies": {
         "@contentful/experience-builder-components": "file:../components",
-        "@contentful/experience-builder-core": "file:../core",
+        "@contentful/experiences-core": "file:../core",
         "@hello-pangea/dnd": "^16.3.0",
         "classnames": "^2.3.2",
         "contentful": "^10.6.14",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -75,7 +75,7 @@
     "react-dom": ">=17.0.0"
   },
   "dependencies": {
-    "@contentful/experience-builder-core": "file:../core",
+    "@contentful/experiences-core": "file:../core",
     "@contentful/rich-text-react-renderer": "^15.17.2",
     "postcss-import": "^15.1.0",
     "style-inject": "^0.3.0"

--- a/packages/components/src/components/Assembly/Assembly.tsx
+++ b/packages/components/src/components/Assembly/Assembly.tsx
@@ -2,7 +2,7 @@ import {
   CompositionComponentNode,
   ResolveDesignValueType,
   StyleProps,
-} from '@contentful/experience-builder-core/types';
+} from '@contentful/experiences-core/types';
 import React from 'react';
 
 export type AssemblyProps<EditorMode = boolean> = EditorMode extends true
@@ -17,7 +17,7 @@ export type AssemblyProps<EditorMode = boolean> = EditorMode extends true
       renderDropzone: (
         node: CompositionComponentNode,
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        props?: Record<string, any>
+        props?: Record<string, any>,
       ) => React.ReactNode;
     }
   : // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/components/src/components/Button/index.ts
+++ b/packages/components/src/components/Button/index.ts
@@ -1,8 +1,8 @@
-import type { ComponentDefinition } from '@contentful/experience-builder-core/types';
+import type { ComponentDefinition } from '@contentful/experiences-core/types';
 import {
   CONTENTFUL_COMPONENTS,
   CONTENTFUL_DEFAULT_CATEGORY,
-} from '@contentful/experience-builder-core/constants';
+} from '@contentful/experiences-core/constants';
 import { constants } from '@/utils/constants';
 
 export * from './Button';

--- a/packages/components/src/components/Columns/ColumnTypes.ts
+++ b/packages/components/src/components/Columns/ColumnTypes.ts
@@ -1,4 +1,4 @@
-import { CompositionComponentNode } from '@contentful/experience-builder-core/types';
+import { CompositionComponentNode } from '@contentful/experiences-core/types';
 import { CSSProperties, SyntheticEvent } from 'react';
 
 interface ColumnsBaseProps {
@@ -13,7 +13,7 @@ interface ColumnsEditorModeProps extends ColumnsBaseProps {
   node: CompositionComponentNode;
   renderDropzone: (
     node: CompositionComponentNode,
-    props?: Record<string, unknown>
+    props?: Record<string, unknown>,
   ) => React.ReactNode;
 }
 
@@ -26,7 +26,7 @@ interface SingleColumnEditorModeProps extends ColumnsBaseProps {
   node: CompositionComponentNode;
   renderDropzone: (
     node: CompositionComponentNode,
-    props?: Record<string, unknown>
+    props?: Record<string, unknown>,
   ) => React.ReactNode;
   cfColumnSpan: string;
 

--- a/packages/components/src/components/ContentfulContainer/ContentfulContainer.tsx
+++ b/packages/components/src/components/ContentfulContainer/ContentfulContainer.tsx
@@ -5,7 +5,7 @@ import { Flex } from '../Layout/Flex';
 import { ContentfulContainerAsHyperlink } from './ContentfulContainerAsHyperlink';
 import type { ContentfulContainerAsHyperlinkProps } from './ContentfulContainerAsHyperlink';
 import { combineClasses } from '../../utils/combineClasses';
-import { CONTENTFUL_SECTION_ID } from '@contentful/experience-builder-core/constants';
+import { CONTENTFUL_SECTION_ID } from '@contentful/experiences-core/constants';
 
 export const ContentfulContainer: React.FC<ContentfulContainerAsHyperlinkProps> = (props) => {
   const { className, editorMode, children, cfHyperlink } = props;

--- a/packages/components/src/components/ContentfulContainer/ContentfulContainerAsHyperlink.tsx
+++ b/packages/components/src/components/ContentfulContainer/ContentfulContainerAsHyperlink.tsx
@@ -6,9 +6,9 @@ import type {
   CompositionDataSource,
   CompositionUnboundValues,
   StyleProps,
-} from '@contentful/experience-builder-core/types';
+} from '@contentful/experiences-core/types';
 
-import { EntityStore } from '@contentful/experience-builder-core';
+import { EntityStore } from '@contentful/experiences-core';
 import { combineClasses } from '../../utils/combineClasses';
 
 export type ContentfulContainerAsHyperlinkProps<EditorMode = boolean> = (EditorMode extends true
@@ -22,7 +22,7 @@ export type ContentfulContainerAsHyperlinkProps<EditorMode = boolean> = (EditorM
       areEntitiesFetched?: boolean;
       renderDropzone: (
         node: CompositionComponentNode,
-        props?: Record<string, any>
+        props?: Record<string, any>,
       ) => React.ReactNode;
     }
   : {
@@ -36,7 +36,7 @@ export type ContentfulContainerAsHyperlinkProps<EditorMode = boolean> = (EditorM
 };
 
 export const ContentfulContainerAsHyperlink: React.FC<ContentfulContainerAsHyperlinkProps> = (
-  props
+  props,
 ) => {
   const { cfHyperlink, cfOpenInNewTab, editorMode, className, children } = props;
 

--- a/packages/components/src/components/Heading/index.ts
+++ b/packages/components/src/components/Heading/index.ts
@@ -1,8 +1,8 @@
-import type { ComponentDefinition } from '@contentful/experience-builder-core/types';
+import type { ComponentDefinition } from '@contentful/experiences-core/types';
 import {
   CONTENTFUL_COMPONENTS,
   CONTENTFUL_DEFAULT_CATEGORY,
-} from '@contentful/experience-builder-core/constants';
+} from '@contentful/experiences-core/constants';
 import { constants } from '@/utils/constants';
 
 export * from './Heading';

--- a/packages/components/src/components/Image/index.ts
+++ b/packages/components/src/components/Image/index.ts
@@ -1,8 +1,8 @@
-import type { ComponentDefinition } from '@contentful/experience-builder-core/types';
+import type { ComponentDefinition } from '@contentful/experiences-core/types';
 import {
   CONTENTFUL_COMPONENTS,
   CONTENTFUL_DEFAULT_CATEGORY,
-} from '@contentful/experience-builder-core/constants';
+} from '@contentful/experiences-core/constants';
 import { constants } from '@/utils/constants';
 
 export * from './Image';

--- a/packages/components/src/components/RichText/index.ts
+++ b/packages/components/src/components/RichText/index.ts
@@ -1,8 +1,8 @@
-import type { ComponentDefinition } from '@contentful/experience-builder-core/types';
+import type { ComponentDefinition } from '@contentful/experiences-core/types';
 import {
   CONTENTFUL_COMPONENTS,
   CONTENTFUL_DEFAULT_CATEGORY,
-} from '@contentful/experience-builder-core/constants';
+} from '@contentful/experiences-core/constants';
 import { constants } from '@/utils/constants';
 
 export * from './RichText';

--- a/packages/components/src/components/Text/index.ts
+++ b/packages/components/src/components/Text/index.ts
@@ -1,8 +1,8 @@
-import type { ComponentDefinition } from '@contentful/experience-builder-core/types';
+import type { ComponentDefinition } from '@contentful/experiences-core/types';
 import {
   CONTENTFUL_COMPONENTS,
   CONTENTFUL_DEFAULT_CATEGORY,
-} from '@contentful/experience-builder-core/constants';
+} from '@contentful/experiences-core/constants';
 import { constants } from '@/utils/constants';
 
 export * from './Text';

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@contentful/experience-builder-core",
-  "version": "0.0.2-alpha.23",
+  "name": "@contentful/experiences-core",
+  "version": "0.0.1-alpha.25",
   "description": "",
   "main": "dist/index.js",
   "module": "dist/index.js",

--- a/packages/core/src/exports.ts
+++ b/packages/core/src/exports.ts
@@ -1,3 +1,3 @@
-//this file maintains the exports (ie: '@contentful/experience-builder-core/constants') used in the package.json file
+//this file maintains the exports (ie: '@contentful/experiences-core/constants') used in the package.json file
 export * from './constants';
 export * from './types';

--- a/packages/experience-builder-sdk/package.json
+++ b/packages/experience-builder-sdk/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "@contentful/experience-builder-components": "file:../components",
-    "@contentful/experience-builder-core": "file:../core",
+    "@contentful/experiences-core": "file:../core",
     "@contentful/experience-builder-visual-editor": "file:../visual-editor",
     "@contentful/rich-text-types": "^16.2.1",
     "classnames": "^2.3.2",

--- a/packages/experience-builder-sdk/src/ExperienceRoot.tsx
+++ b/packages/experience-builder-sdk/src/ExperienceRoot.tsx
@@ -3,9 +3,9 @@ import {
   VisualEditorMode,
   isDeprecatedExperience,
   validateExperienceBuilderConfig,
-} from '@contentful/experience-builder-core';
-import { EntityStore } from '@contentful/experience-builder-core';
-import type { DeprecatedExperience, Experience } from '@contentful/experience-builder-core/types';
+} from '@contentful/experiences-core';
+import { EntityStore } from '@contentful/experiences-core';
+import type { DeprecatedExperience, Experience } from '@contentful/experiences-core/types';
 import { DeprecatedPreviewDeliveryRoot } from './blocks/preview/DeprecatedPreviewDeliveryRoot';
 import { PreviewDeliveryRoot } from './blocks/preview/PreviewDeliveryRoot';
 import VisualEditorRoot from './blocks/editor/VisualEditorRoot';

--- a/packages/experience-builder-sdk/src/blocks/editor/VisualEditorInjectScript.tsx
+++ b/packages/experience-builder-sdk/src/blocks/editor/VisualEditorInjectScript.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react';
-import { VISUAL_EDITOR_CONTAINER_ID } from '@contentful/experience-builder-core/constants';
+import { VISUAL_EDITOR_CONTAINER_ID } from '@contentful/experiences-core/constants';
 
 /**
  * The version can be any semver version or dist tag

--- a/packages/experience-builder-sdk/src/blocks/editor/VisualEditorLoader.tsx
+++ b/packages/experience-builder-sdk/src/blocks/editor/VisualEditorLoader.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { VisualEditorMode } from '@contentful/experience-builder-core';
+import { VisualEditorMode } from '@contentful/experiences-core';
 
 type VisualEditorLoaderProps = {
   visualEditorMode: VisualEditorMode;

--- a/packages/experience-builder-sdk/src/blocks/editor/VisualEditorRoot.tsx
+++ b/packages/experience-builder-sdk/src/blocks/editor/VisualEditorRoot.tsx
@@ -1,5 +1,5 @@
 import React, { Suspense } from 'react';
-import { EntityStore, VisualEditorMode } from '@contentful/experience-builder-core';
+import { EntityStore, VisualEditorMode } from '@contentful/experiences-core';
 import { ErrorBoundary } from '../../components/ErrorBoundary';
 import { useInitializeVisualEditor } from '../../hooks/useInitializeVisualEditor';
 

--- a/packages/experience-builder-sdk/src/blocks/preview/CompositionBlock.spec.tsx
+++ b/packages/experience-builder-sdk/src/blocks/preview/CompositionBlock.spec.tsx
@@ -2,9 +2,9 @@ import React from 'react';
 
 import { render } from '@testing-library/react';
 
-import { CONTENTFUL_COMPONENTS } from '@contentful/experience-builder-core/constants';
+import { CONTENTFUL_COMPONENTS } from '@contentful/experiences-core/constants';
 import { defineComponents, resetComponentRegistry } from '../../core/componentRegistry';
-import type { CompositionNode, ExperienceEntry } from '@contentful/experience-builder-core/types';
+import type { CompositionNode, ExperienceEntry } from '@contentful/experiences-core/types';
 import { CompositionBlock } from './CompositionBlock';
 import type { Entry } from 'contentful';
 import { compositionEntry } from '../../../test/__fixtures__/composition';
@@ -13,7 +13,7 @@ import {
   defaultAssemblyId,
   assemblyGeneratedVariableName,
 } from '../../../test/__fixtures__/assembly';
-import { EntityStore } from '@contentful/experience-builder-core';
+import { EntityStore } from '@contentful/experiences-core';
 import { assets, entries } from '../../../test/__fixtures__/entities';
 
 const TestComponent: React.FC<{ text: string }> = (props) => {

--- a/packages/experience-builder-sdk/src/blocks/preview/CompositionBlock.tsx
+++ b/packages/experience-builder-sdk/src/blocks/preview/CompositionBlock.tsx
@@ -1,27 +1,24 @@
 import React, { useMemo } from 'react';
 import type { UnresolvedLink } from 'contentful';
 import { omit } from 'lodash-es';
-import {
-  EntityStore,
-  isEmptyStructureWithRelativeHeight,
-} from '@contentful/experience-builder-core';
+import { EntityStore, isEmptyStructureWithRelativeHeight } from '@contentful/experiences-core';
 import {
   CF_STYLE_ATTRIBUTES,
   CONTENTFUL_COMPONENTS,
   EMPTY_CONTAINER_HEIGHT,
-} from '@contentful/experience-builder-core/constants';
+} from '@contentful/experiences-core/constants';
 import type {
   CompositionNode,
   CompositionVariableValueType,
   ResolveDesignValueType,
   StyleProps,
-} from '@contentful/experience-builder-core/types';
+} from '@contentful/experiences-core/types';
 import { createAssemblyRegistration, getComponentRegistration } from '../../core/componentRegistry';
 import {
   buildCfStyles,
   checkIsAssemblyNode,
   transformContentValue,
-} from '@contentful/experience-builder-core';
+} from '@contentful/experiences-core';
 import { useStyleTag } from '../../hooks/useStyleTag';
 import {
   Columns,

--- a/packages/experience-builder-sdk/src/blocks/preview/DeprecatedPreviewDeliveryRoot.tsx
+++ b/packages/experience-builder-sdk/src/blocks/preview/DeprecatedPreviewDeliveryRoot.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef } from 'react';
-import type { DeprecatedExperience } from '@contentful/experience-builder-core/types';
+import type { DeprecatedExperience } from '@contentful/experiences-core/types';
 import { CompositionBlock } from './CompositionBlock';
 import { compatibleVersions } from '../../constants';
 import { useBreakpoints, useFetchExperience } from '../../hooks';

--- a/packages/experience-builder-sdk/src/blocks/preview/PreviewDeliveryRoot.test.tsx
+++ b/packages/experience-builder-sdk/src/blocks/preview/PreviewDeliveryRoot.test.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { render } from '@testing-library/react';
-import { EntityStore } from '@contentful/experience-builder-core';
+import { EntityStore } from '@contentful/experiences-core';
 import { PreviewDeliveryRoot } from './PreviewDeliveryRoot';
-import type { Experience } from '@contentful/experience-builder-core/types';
+import type { Experience } from '@contentful/experiences-core/types';
 import { createCompositionEntry } from '../../../test/__fixtures__/composition';
 import { assets, entries } from '../../../test/__fixtures__/entities';
 import type { Entry } from 'contentful';

--- a/packages/experience-builder-sdk/src/blocks/preview/PreviewDeliveryRoot.tsx
+++ b/packages/experience-builder-sdk/src/blocks/preview/PreviewDeliveryRoot.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { EntityStore } from '@contentful/experience-builder-core';
-import type { Experience } from '@contentful/experience-builder-core/types';
+import { EntityStore } from '@contentful/experiences-core';
+import type { Experience } from '@contentful/experiences-core/types';
 import { CompositionBlock } from './CompositionBlock';
 import { compatibleVersions } from '../../constants';
 import { useBreakpoints } from '../../hooks';

--- a/packages/experience-builder-sdk/src/components/ErrorBoundary.tsx
+++ b/packages/experience-builder-sdk/src/components/ErrorBoundary.tsx
@@ -1,7 +1,7 @@
 import React, { ErrorInfo, ReactElement } from 'react';
-import { sendMessage } from '@contentful/experience-builder-core';
+import { sendMessage } from '@contentful/experiences-core';
 import '../styles/ErrorBoundary.css';
-import { OUTGOING_EVENTS } from '@contentful/experience-builder-core/constants';
+import { OUTGOING_EVENTS } from '@contentful/experiences-core/constants';
 
 class ImportedComponentError extends Error {}
 

--- a/packages/experience-builder-sdk/src/constants.ts
+++ b/packages/experience-builder-sdk/src/constants.ts
@@ -1,4 +1,4 @@
-import type { SchemaVersions } from '@contentful/experience-builder-core/types';
+import type { SchemaVersions } from '@contentful/experiences-core/types';
 
 // this is the array of version which currently LATEST_SCHEMA_VERSION is compatible with
 export const compatibleVersions: SchemaVersions[] = ['2023-08-23', '2023-09-28'];

--- a/packages/experience-builder-sdk/src/core/componentRegistry.test.tsx
+++ b/packages/experience-builder-sdk/src/core/componentRegistry.test.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
-import { containerDefinition, sectionDefinition } from '@contentful/experience-builder-core';
+import { containerDefinition, sectionDefinition } from '@contentful/experiences-core';
 import {
   INTERNAL_EVENTS,
   CONTENTFUL_COMPONENTS,
   ASSEMBLY_DEFAULT_CATEGORY,
-} from '@contentful/experience-builder-core/constants';
+} from '@contentful/experiences-core/constants';
 import * as registry from './componentRegistry';
-import type { ComponentRegistration } from '@contentful/experience-builder-core/types';
+import type { ComponentRegistration } from '@contentful/experiences-core/types';
 
 const TestComponent = () => {
   return <div data-test-id="test">Test</div>;

--- a/packages/experience-builder-sdk/src/core/componentRegistry.ts
+++ b/packages/experience-builder-sdk/src/core/componentRegistry.ts
@@ -3,13 +3,13 @@ import type {
   ComponentRegistration,
   ComponentDefinition,
   ComponentRegistrationOptions,
-} from '@contentful/experience-builder-core/types';
+} from '@contentful/experiences-core/types';
 import {
   OUTGOING_EVENTS,
   INTERNAL_EVENTS,
   CONTENTFUL_COMPONENTS,
   ASSEMBLY_DEFAULT_CATEGORY,
-} from '@contentful/experience-builder-core/constants';
+} from '@contentful/experiences-core/constants';
 import {
   builtInStyles as builtInStyleDefinitions,
   designTokensRegistry,
@@ -19,7 +19,7 @@ import {
   sectionDefinition,
   columnsDefinition,
   singleColumnDefinition,
-} from '@contentful/experience-builder-core';
+} from '@contentful/experiences-core';
 import { withComponentWrapper } from '../utils/withComponentWrapper';
 import { SDK_VERSION } from '../constants';
 

--- a/packages/experience-builder-sdk/src/core/preview/assemblyUtils.spec.ts
+++ b/packages/experience-builder-sdk/src/core/preview/assemblyUtils.spec.ts
@@ -2,9 +2,9 @@ import type { Entry } from 'contentful';
 import { compositionEntry } from '../../../test/__fixtures__/composition';
 import { createAssemblyEntry } from '../../../test/__fixtures__/assembly';
 import { assets, entries } from '../../../test/__fixtures__/entities';
-import { CONTENTFUL_COMPONENTS } from '@contentful/experience-builder-core/constants';
-import type { CompositionNode } from '@contentful/experience-builder-core/types';
-import { EntityStore } from '@contentful/experience-builder-core';
+import { CONTENTFUL_COMPONENTS } from '@contentful/experiences-core/constants';
+import type { CompositionNode } from '@contentful/experiences-core/types';
+import { EntityStore } from '@contentful/experiences-core';
 import { resolveAssembly } from './assemblyUtils';
 
 describe('resolveAssembly', () => {

--- a/packages/experience-builder-sdk/src/core/preview/assemblyUtils.ts
+++ b/packages/experience-builder-sdk/src/core/preview/assemblyUtils.ts
@@ -1,8 +1,8 @@
-import { checkIsAssemblyNode, EntityStore } from '@contentful/experience-builder-core';
+import { checkIsAssemblyNode, EntityStore } from '@contentful/experiences-core';
 import type {
   CompositionComponentPropValue,
   CompositionNode,
-} from '@contentful/experience-builder-core/types';
+} from '@contentful/experiences-core/types';
 
 export const deserializeAssemblyNode = ({
   node,

--- a/packages/experience-builder-sdk/src/hooks/useBreakpoints.spec.ts
+++ b/packages/experience-builder-sdk/src/hooks/useBreakpoints.spec.ts
@@ -1,5 +1,5 @@
-import { getValueForBreakpoint } from '@contentful/experience-builder-core';
-import { Breakpoint } from '@contentful/experience-builder-core/types';
+import { getValueForBreakpoint } from '@contentful/experiences-core';
+import { Breakpoint } from '@contentful/experiences-core/types';
 
 const breakpoints: Breakpoint[] = [
   {

--- a/packages/experience-builder-sdk/src/hooks/useBreakpoints.ts
+++ b/packages/experience-builder-sdk/src/hooks/useBreakpoints.ts
@@ -3,13 +3,13 @@ import type {
   Breakpoint,
   CompositionVariableValueType,
   ResolveDesignValueType,
-} from '@contentful/experience-builder-core/types';
+} from '@contentful/experiences-core/types';
 import {
   mediaQueryMatcher,
   getFallbackBreakpointIndex,
   getActiveBreakpointIndex,
   getValueForBreakpoint,
-} from '@contentful/experience-builder-core';
+} from '@contentful/experiences-core';
 import { useCallback, useEffect, useState } from 'react';
 
 // TODO: In order to support integrations without React, we should extract this heavy logic into simple

--- a/packages/experience-builder-sdk/src/hooks/useDetectEditorMode.tsx
+++ b/packages/experience-builder-sdk/src/hooks/useDetectEditorMode.tsx
@@ -3,8 +3,8 @@ import {
   doesMismatchMessageSchema,
   sendMessage,
   tryParseMessage,
-} from '@contentful/experience-builder-core';
-import { INCOMING_EVENTS, OUTGOING_EVENTS } from '@contentful/experience-builder-core/constants';
+} from '@contentful/experiences-core';
+import { INCOMING_EVENTS, OUTGOING_EVENTS } from '@contentful/experiences-core/constants';
 
 type UseDetectEditorModeArgs = {
   /** If running from a known client side only situation (ie: useFetchBySlug),

--- a/packages/experience-builder-sdk/src/hooks/useExperienceBuilder.ts
+++ b/packages/experience-builder-sdk/src/hooks/useExperienceBuilder.ts
@@ -1,8 +1,5 @@
 import { useMemo } from 'react';
-import type {
-  DeprecatedExperience,
-  ExternalSDKMode,
-} from '@contentful/experience-builder-core/types';
+import type { DeprecatedExperience, ExternalSDKMode } from '@contentful/experiences-core/types';
 import type { ContentfulClientApi } from 'contentful';
 import { defineComponents } from '../core/componentRegistry';
 

--- a/packages/experience-builder-sdk/src/hooks/useFetchByBase.ts
+++ b/packages/experience-builder-sdk/src/hooks/useFetchByBase.ts
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
-import { EntityStore } from '@contentful/experience-builder-core';
-import type { Experience } from '@contentful/experience-builder-core/types';
+import { EntityStore } from '@contentful/experiences-core';
+import type { Experience } from '@contentful/experiences-core/types';
 
 export const useFetchByBase = (
   fetchMethod: () => Promise<Experience<EntityStore> | undefined>,

--- a/packages/experience-builder-sdk/src/hooks/useFetchById.spec.ts
+++ b/packages/experience-builder-sdk/src/hooks/useFetchById.spec.ts
@@ -1,5 +1,5 @@
 import { useFetchById, UseFetchByIdArgs } from './useFetchById';
-import { EntityStore } from '@contentful/experience-builder-core';
+import { EntityStore } from '@contentful/experiences-core';
 import { renderHook, waitFor } from '@testing-library/react';
 import { compositionEntry } from '../../test/__fixtures__/composition';
 import { entries, assets } from '../../test/__fixtures__/entities';

--- a/packages/experience-builder-sdk/src/hooks/useFetchById.ts
+++ b/packages/experience-builder-sdk/src/hooks/useFetchById.ts
@@ -1,8 +1,8 @@
 import { useCallback } from 'react';
 import type { ContentfulClientApi } from 'contentful';
-import type { ExternalSDKMode } from '@contentful/experience-builder-core/types';
+import type { ExternalSDKMode } from '@contentful/experiences-core/types';
 import { useFetchByBase } from './useFetchByBase';
-import { fetchById } from '@contentful/experience-builder-core';
+import { fetchById } from '@contentful/experiences-core';
 import { useDetectEditorMode } from './useDetectEditorMode';
 
 export type UseFetchByIdArgs = {

--- a/packages/experience-builder-sdk/src/hooks/useFetchBySlug.spec.ts
+++ b/packages/experience-builder-sdk/src/hooks/useFetchBySlug.spec.ts
@@ -1,5 +1,5 @@
 import { useFetchBySlug, UseFetchBySlugArgs } from './useFetchBySlug';
-import { EntityStore } from '@contentful/experience-builder-core';
+import { EntityStore } from '@contentful/experiences-core';
 import { renderHook, waitFor } from '@testing-library/react';
 import { compositionEntry } from '../../test/__fixtures__/composition';
 import { entries, assets } from '../../test/__fixtures__/entities';

--- a/packages/experience-builder-sdk/src/hooks/useFetchBySlug.ts
+++ b/packages/experience-builder-sdk/src/hooks/useFetchBySlug.ts
@@ -1,8 +1,8 @@
 import { useCallback } from 'react';
 import type { ContentfulClientApi } from 'contentful';
-import type { ExternalSDKMode } from '@contentful/experience-builder-core/types';
+import type { ExternalSDKMode } from '@contentful/experiences-core/types';
 import { useFetchByBase } from './useFetchByBase';
-import { fetchBySlug } from '@contentful/experience-builder-core';
+import { fetchBySlug } from '@contentful/experiences-core';
 import { useDetectEditorMode } from './useDetectEditorMode';
 
 export type UseFetchBySlugArgs = {

--- a/packages/experience-builder-sdk/src/hooks/useFetchExperience.test.ts
+++ b/packages/experience-builder-sdk/src/hooks/useFetchExperience.test.ts
@@ -1,10 +1,10 @@
 import { useFetchExperience } from './useFetchExperience';
-import { EntityStore } from '@contentful/experience-builder-core';
+import { EntityStore } from '@contentful/experiences-core';
 import { act, renderHook } from '@testing-library/react';
 import { compositionEntry } from '../../test/__fixtures__/composition';
 import { entries, assets } from '../../test/__fixtures__/entities';
 import type { ContentfulClientApi, Entry } from 'contentful';
-import { ExternalSDKMode } from '@contentful/experience-builder-core/types';
+import { ExternalSDKMode } from '@contentful/experiences-core/types';
 
 const experienceTypeId = 'layout';
 const localeCode = 'en-US';

--- a/packages/experience-builder-sdk/src/hooks/useFetchExperience.ts
+++ b/packages/experience-builder-sdk/src/hooks/useFetchExperience.ts
@@ -4,8 +4,8 @@ import {
   EntityStore,
   fetchBySlug as fetchBySlugCore,
   fetchById as fetchByIdCore,
-} from '@contentful/experience-builder-core';
-import { Experience, ExternalSDKMode } from '@contentful/experience-builder-core/types';
+} from '@contentful/experiences-core';
+import { Experience, ExternalSDKMode } from '@contentful/experiences-core/types';
 
 type useClientsideExperienceFetchersProps = {
   /** @deprecated mode no longer required */

--- a/packages/experience-builder-sdk/src/hooks/useInitializeVisualEditor.ts
+++ b/packages/experience-builder-sdk/src/hooks/useInitializeVisualEditor.ts
@@ -1,15 +1,12 @@
 import { useEffect, useRef, useState } from 'react';
-import { EntityStore } from '@contentful/experience-builder-core';
+import { EntityStore } from '@contentful/experiences-core';
 import {
   componentRegistry,
   sendConnectedEventWithRegisteredComponents,
   sendRegisteredComponentsMessage,
 } from '../core/componentRegistry';
-import {
-  INTERNAL_EVENTS,
-  VISUAL_EDITOR_EVENTS,
-} from '@contentful/experience-builder-core/constants';
-import { designTokensRegistry } from '@contentful/experience-builder-core';
+import { INTERNAL_EVENTS, VISUAL_EDITOR_EVENTS } from '@contentful/experiences-core/constants';
+import { designTokensRegistry } from '@contentful/experiences-core';
 
 type InitializeVisualEditorParams = {
   initialLocale: string;

--- a/packages/experience-builder-sdk/src/hooks/useStyleTag.ts
+++ b/packages/experience-builder-sdk/src/hooks/useStyleTag.ts
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 
-import { buildStyleTag } from '@contentful/experience-builder-core';
-import type { CSSProperties } from '@contentful/experience-builder-core/types';
+import { buildStyleTag } from '@contentful/experiences-core';
+import type { CSSProperties } from '@contentful/experiences-core/types';
 
 /**
  *

--- a/packages/experience-builder-sdk/src/index.ts
+++ b/packages/experience-builder-sdk/src/index.ts
@@ -15,7 +15,7 @@ export {
   fetchById,
   fetchBySlug,
   createExperience,
-} from '@contentful/experience-builder-core';
+} from '@contentful/experiences-core';
 export {
   /** @deprecated use `CONTENTFUL_COMPONENTS.section.id` instead. This will be removed in version 4. */
   CONTENTFUL_SECTION_ID,
@@ -38,7 +38,7 @@ export {
   ASSEMBLY_NODE_TYPE,
   ASSEMBLY_NODE_TYPES,
   SCROLL_STATES,
-} from '@contentful/experience-builder-core/constants';
+} from '@contentful/experiences-core/constants';
 
 // Simple state store to store a few things that are needed across the SDK
 if (typeof window !== 'undefined') {
@@ -51,5 +51,5 @@ export type {
   InternalSDKMode,
   ExternalSDKMode,
   ComponentDefinition,
-} from '@contentful/experience-builder-core/types';
-export { EntityStore } from '@contentful/experience-builder-core';
+} from '@contentful/experiences-core/types';
+export { EntityStore } from '@contentful/experiences-core';

--- a/packages/experience-builder-sdk/src/utils/withComponentWrapper.tsx
+++ b/packages/experience-builder-sdk/src/utils/withComponentWrapper.tsx
@@ -1,4 +1,4 @@
-import { ComponentRegistration } from '@contentful/experience-builder-core/types';
+import { ComponentRegistration } from '@contentful/experiences-core/types';
 import React from 'react';
 
 interface CFProps {

--- a/packages/experience-builder-sdk/test/__fixtures__/assembly.ts
+++ b/packages/experience-builder-sdk/test/__fixtures__/assembly.ts
@@ -2,11 +2,8 @@ import {
   CONTENTFUL_COMPONENTS,
   ASSEMBLY_NODE_TYPE,
   LATEST_SCHEMA_VERSION,
-} from '@contentful/experience-builder-core/constants';
-import type {
-  CompositionComponentNode,
-  SchemaVersions,
-} from '@contentful/experience-builder-core/types';
+} from '@contentful/experiences-core/constants';
+import type { CompositionComponentNode, SchemaVersions } from '@contentful/experiences-core/types';
 
 type createAssemblyEntryArgs = {
   schemaVersion: SchemaVersions;

--- a/packages/experience-builder-sdk/test/__fixtures__/composition.ts
+++ b/packages/experience-builder-sdk/test/__fixtures__/composition.ts
@@ -2,9 +2,9 @@ import type {
   Composition,
   ExperienceEntry,
   SchemaVersions,
-} from '@contentful/experience-builder-core/types';
+} from '@contentful/experiences-core/types';
 import { entityIds } from './entities';
-import { LATEST_SCHEMA_VERSION } from '@contentful/experience-builder-core/constants';
+import { LATEST_SCHEMA_VERSION } from '@contentful/experiences-core/constants';
 
 const compositionFields: Composition = {
   title: 'Test Composition',

--- a/packages/storybook-addon/src/components/StyleSectionComponents/SizeInput/SizeSelector.tsx
+++ b/packages/storybook-addon/src/components/StyleSectionComponents/SizeInput/SizeSelector.tsx
@@ -1,10 +1,10 @@
-import { ComponentDefinitionVariable } from '@contentful/experience-builder-core/types';
+import { ComponentDefinitionVariable } from '@contentful/experiences-core/types';
 import React, { useCallback, useMemo, useState } from 'react';
 import { Grid, Select, Text, TextInput } from '@contentful/f36-components';
 import { useVariableState } from '@/hooks/useVariableState';
 import { styles } from './styles';
 import { useCompositionCanvasSubscriber } from '@/context/useCompositionCanvasSubscriber';
-import { EMPTY_CONTAINER_HEIGHT } from '@contentful/experience-builder-core/constants';
+import { EMPTY_CONTAINER_HEIGHT } from '@contentful/experiences-core/constants';
 
 const heightVariableName = 'cfHeight';
 const widthVariableName = 'cfWidth';
@@ -152,7 +152,7 @@ export const SizeSelector = ({ variableName, variableDefinition, label }: SizeSe
         </TextInput.Group>
       );
     },
-    [isNumberInputFocused, label, setValue, value]
+    [isNumberInputFocused, label, setValue, value],
   );
 
   return (

--- a/packages/storybook-addon/src/components/StylesTab.tsx
+++ b/packages/storybook-addon/src/components/StylesTab.tsx
@@ -11,7 +11,7 @@ import { SectionStyles } from './SectionStyles';
 
 import { AffectedBreakpoints, BreakpointInheritanceTree } from './StyleSectionComponents';
 import { capitalizeFirstLetter } from '@/utils/strings';
-import { isContentfulStructureComponent } from '@contentful/experience-builder-core';
+import { isContentfulStructureComponent } from '@contentful/experiences-core';
 
 const styles = {
   wrapper: css({
@@ -53,7 +53,7 @@ const StylesTab = ({ componentDefinition }: StylesTabProps) => {
     const fields: JSX.Element[] = [];
     if (componentDefinition) {
       for (const [variableName, variableDefinition] of Object.entries(
-        componentDefinition.variables
+        componentDefinition.variables,
       )) {
         if (variableName.startsWith('cf')) {
           continue;
@@ -89,7 +89,7 @@ const StylesTab = ({ componentDefinition }: StylesTabProps) => {
                     }
                     defaultValue={defaultValue}
                   />
-                )
+                ),
               );
               break;
             case 'Number':
@@ -113,7 +113,7 @@ const StylesTab = ({ componentDefinition }: StylesTabProps) => {
                     }
                     defaultValue={defaultValue}
                   />
-                )
+                ),
               );
               break;
             case 'Boolean':
@@ -125,7 +125,7 @@ const StylesTab = ({ componentDefinition }: StylesTabProps) => {
                     variableDefinition.displayName || capitalizeFirstLetter(variableName)
                   }
                   defaultValue={defaultValue}
-                />
+                />,
               );
               break;
             default:
@@ -142,7 +142,7 @@ const StylesTab = ({ componentDefinition }: StylesTabProps) => {
   const hasStyleVariables =
     componentDefinition &&
     Object.values(componentDefinition.variables).find(
-      (variableDefinition) => variableDefinition.group === 'style'
+      (variableDefinition) => variableDefinition.group === 'style',
     );
 
   if (!componentDefinition) {

--- a/packages/visual-editor/package.json
+++ b/packages/visual-editor/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@contentful/experience-builder-components": "file:../components",
-    "@contentful/experience-builder-core": "file:../core",
+    "@contentful/experiences-core": "file:../core",
     "@hello-pangea/dnd": "^16.3.0",
     "classnames": "^2.3.2",
     "contentful": "^10.6.14",

--- a/packages/visual-editor/src/communication/MouseOverHandler.ts
+++ b/packages/visual-editor/src/communication/MouseOverHandler.ts
@@ -1,10 +1,10 @@
-import type { HoveredElement } from '@contentful/experience-builder-core/types';
-import { sendMessage } from '@contentful/experience-builder-core';
+import type { HoveredElement } from '@contentful/experiences-core/types';
+import { sendMessage } from '@contentful/experiences-core';
 import {
   DESIGN_COMPONENT_NODE_TYPE,
   ASSEMBLY_NODE_TYPE,
   OUTGOING_EVENTS,
-} from '@contentful/experience-builder-core/constants';
+} from '@contentful/experiences-core/constants';
 
 export class MouseOverHandler {
   private currentHoveredElementId: string | null = null;
@@ -54,7 +54,7 @@ export class MouseOverHandler {
 
   private getFullCoordinates = (element: HTMLElement) => {
     const validChildren = Array.from(element.children).filter(
-      (child) => child instanceof HTMLElement && child.dataset.cfNodeBlockType === 'block'
+      (child) => child instanceof HTMLElement && child.dataset.cfNodeBlockType === 'block',
     );
 
     const { left, top, width, height } = this.getBoundingClientRect(element);
@@ -77,7 +77,7 @@ export class MouseOverHandler {
   };
 
   private getClosestComponentInformation = (
-    element: HTMLElement | null
+    element: HTMLElement | null,
   ): [HTMLElement | null, HoveredElement] | undefined => {
     let target = element;
 
@@ -146,7 +146,7 @@ export class MouseOverHandler {
         };
         const parentChildrenElements = parentHTMLElement.children;
         parentSectionIndex = Array.from(parentChildrenElements).findIndex(
-          (child) => child === hoveredElement
+          (child) => child === hoveredElement,
         );
         break;
       }

--- a/packages/visual-editor/src/communication/onComponentDrop.ts
+++ b/packages/visual-editor/src/communication/onComponentDrop.ts
@@ -1,6 +1,6 @@
-import { sendMessage } from '@contentful/experience-builder-core';
-import { CompositionComponentNode } from '@contentful/experience-builder-core/types';
-import { OUTGOING_EVENTS } from '@contentful/experience-builder-core/constants';
+import { sendMessage } from '@contentful/experiences-core';
+import { CompositionComponentNode } from '@contentful/experiences-core/types';
+import { OUTGOING_EVENTS } from '@contentful/experiences-core/constants';
 
 export const onComponentDropped = ({
   node,

--- a/packages/visual-editor/src/communication/onComponentMoved.ts
+++ b/packages/visual-editor/src/communication/onComponentMoved.ts
@@ -1,5 +1,5 @@
-import { sendMessage } from '@contentful/experience-builder-core';
-import { OUTGOING_EVENTS } from '@contentful/experience-builder-core/constants';
+import { sendMessage } from '@contentful/experiences-core';
+import { OUTGOING_EVENTS } from '@contentful/experiences-core/constants';
 
 export const onComponentMoved = (options: {
   nodeId: string;

--- a/packages/visual-editor/src/communication/sendSelectedComponentCoordinates.ts
+++ b/packages/visual-editor/src/communication/sendSelectedComponentCoordinates.ts
@@ -1,5 +1,5 @@
-import { sendMessage, getElementCoordinates } from '@contentful/experience-builder-core';
-import { OUTGOING_EVENTS } from '@contentful/experience-builder-core/constants';
+import { sendMessage, getElementCoordinates } from '@contentful/experiences-core';
+import { OUTGOING_EVENTS } from '@contentful/experiences-core/constants';
 
 /**
  * This function gets the element co-ordinates of a specified component in the DOM and its parent

--- a/packages/visual-editor/src/components/Draggable/canvasToolsUtils.ts
+++ b/packages/visual-editor/src/components/Draggable/canvasToolsUtils.ts
@@ -1,5 +1,5 @@
-import type { ComponentDefinition } from '@contentful/experience-builder-core/types';
-import { ASSEMBLY_DEFAULT_CATEGORY } from '@contentful/experience-builder-core/constants';
+import type { ComponentDefinition } from '@contentful/experiences-core/types';
+import { ASSEMBLY_DEFAULT_CATEGORY } from '@contentful/experiences-core/constants';
 
 export type Breakpoints = Array<BreakpointItem>;
 

--- a/packages/visual-editor/src/components/Dropzone/Dropzone.tsx
+++ b/packages/visual-editor/src/components/Dropzone/Dropzone.tsx
@@ -1,6 +1,6 @@
 import React, { ElementType, useCallback, useEffect } from 'react';
 import { Droppable } from '@hello-pangea/dnd';
-import type { ResolveDesignValueType } from '@contentful/experience-builder-core/types';
+import type { ResolveDesignValueType } from '@contentful/experiences-core/types';
 import { EditorBlock } from './EditorBlock';
 import { ComponentData } from '@/types/Config';
 import { useTreeStore } from '@/store/tree';
@@ -17,7 +17,7 @@ import {
   DESIGN_COMPONENT_NODE_TYPES,
   ASSEMBLY_NODE_TYPES,
   CONTENTFUL_COMPONENTS,
-} from '@contentful/experience-builder-core/constants';
+} from '@contentful/experiences-core/constants';
 import { RenderDropzoneFunction } from './Dropzone.types';
 
 type DropzoneProps = {
@@ -37,7 +37,7 @@ function isDropEnabled(
   draggingRootZone: boolean,
   isRootZone: boolean,
   isAssembly: boolean,
-  blockId: string = ''
+  blockId: string = '',
 ) {
   if (isAssembly) {
     return false;
@@ -122,7 +122,7 @@ export function Dropzone({
     draggingRootZone,
     isRootZone,
     isAssembly,
-    node?.data.blockId
+    node?.data.blockId,
   );
 
   // To avoid a circular dependency, we create the recursive rendering function here and trickle it down
@@ -138,7 +138,7 @@ export function Dropzone({
         />
       );
     },
-    [resolveDesignValue]
+    [resolveDesignValue],
   );
 
   if (!resolveDesignValue) {
@@ -173,7 +173,7 @@ export function Dropzone({
                 [styles.isDestination]: isDestination && !isAssembly,
                 [styles.isExpanded]: userIsDragging,
               },
-              className
+              className,
             )}
             node={node}
             onMouseOver={(e) => {

--- a/packages/visual-editor/src/components/Dropzone/Dropzone.types.ts
+++ b/packages/visual-editor/src/components/Dropzone/Dropzone.types.ts
@@ -1,6 +1,6 @@
-import { CompositionComponentNode } from '@contentful/experience-builder-core/types';
+import { CompositionComponentNode } from '@contentful/experiences-core/types';
 
 export type RenderDropzoneFunction = (
   node: CompositionComponentNode,
-  props?: Record<string, unknown>
+  props?: Record<string, unknown>,
 ) => React.JSX.Element;

--- a/packages/visual-editor/src/components/Dropzone/EditorBlock.tsx
+++ b/packages/visual-editor/src/components/Dropzone/EditorBlock.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import styles from './styles.module.css';
 import { DraggableComponent } from '../Draggable/DraggableComponent';
-import { sendMessage } from '@contentful/experience-builder-core';
+import { sendMessage } from '@contentful/experiences-core';
 import { useSelectedInstanceCoordinates } from '@/hooks/useSelectedInstanceCoordinates';
 import { useEditorStore } from '@/store/editor';
 import { useComponent } from './useComponent';
@@ -9,12 +9,12 @@ import { useZoneStore } from '@/store/zone';
 import type {
   CompositionComponentNode,
   ResolveDesignValueType,
-} from '@contentful/experience-builder-core/types';
+} from '@contentful/experiences-core/types';
 import {
   CONTENTFUL_COMPONENTS,
   ASSEMBLY_BLOCK_NODE_TYPE,
   OUTGOING_EVENTS,
-} from '@contentful/experience-builder-core/constants';
+} from '@contentful/experiences-core/constants';
 import { DraggableChildComponent } from '@components/Draggable/DraggableChildComponent';
 import { RenderDropzoneFunction } from './Dropzone.types';
 

--- a/packages/visual-editor/src/components/Dropzone/useComponent.ts
+++ b/packages/visual-editor/src/components/Dropzone/useComponent.ts
@@ -3,14 +3,14 @@ import type {
   ComponentRegistration,
   CompositionComponentNode,
   ResolveDesignValueType,
-} from '@contentful/experience-builder-core/types';
+} from '@contentful/experiences-core/types';
 import { useMemo } from 'react';
 import { useComponentProps } from './useComponentProps';
 import { builtInComponents } from '@/types/constants';
 import {
   DESIGN_COMPONENT_NODE_TYPE,
   ASSEMBLY_NODE_TYPE,
-} from '@contentful/experience-builder-core/constants';
+} from '@contentful/experiences-core/constants';
 import { Assembly } from '@contentful/experience-builder-components';
 import { resolveAssembly } from '@/utils/assemblyUtils';
 import { componentRegistry, createAssemblyRegistration } from '@/store/registries';
@@ -79,9 +79,9 @@ export const useComponent = ({
     ? (dragProps?: NoWrapDraggableProps) =>
         React.createElement(componentRegistration.component, { ...dragProps, ...componentProps })
     : node.type === DESIGN_COMPONENT_NODE_TYPE || node.type === ASSEMBLY_NODE_TYPE
-    ? // Assembly.tsx requires renderDropzone and editorMode as well
-      () => React.createElement(componentRegistration.component, componentProps)
-    : () => React.createElement(componentRegistration.component, otherComponentProps);
+      ? // Assembly.tsx requires renderDropzone and editorMode as well
+        () => React.createElement(componentRegistration.component, componentProps)
+      : () => React.createElement(componentRegistration.component, otherComponentProps);
 
   return {
     node,

--- a/packages/visual-editor/src/components/Dropzone/useComponentProps.ts
+++ b/packages/visual-editor/src/components/Dropzone/useComponentProps.ts
@@ -5,13 +5,13 @@ import {
   transformContentValue,
   isLinkToAsset,
   isEmptyStructureWithRelativeHeight,
-} from '@contentful/experience-builder-core';
+} from '@contentful/experiences-core';
 import {
   CF_STYLE_ATTRIBUTES,
   DESIGN_COMPONENT_NODE_TYPE,
   ASSEMBLY_NODE_TYPE,
   EMPTY_CONTAINER_HEIGHT,
-} from '@contentful/experience-builder-core/constants';
+} from '@contentful/experiences-core/constants';
 import type {
   StyleProps,
   CompositionVariableValueType,
@@ -19,7 +19,7 @@ import type {
   ResolveDesignValueType,
   ComponentRegistration,
   Link,
-} from '@contentful/experience-builder-core/types';
+} from '@contentful/experiences-core/types';
 import { useMemo } from 'react';
 import { useStyleTag } from '../../hooks/useStyleTag';
 import { omit } from 'lodash-es';
@@ -72,7 +72,7 @@ export const useComponentProps = ({
         if (variableMapping.type === 'DesignValue') {
           const valueByBreakpoint = resolveDesignValue(
             variableMapping.valuesByBreakpoint,
-            variableName
+            variableName,
           );
           const designValue =
             variableName === 'cfHeight'
@@ -132,7 +132,7 @@ export const useComponentProps = ({
           };
         }
       },
-      {}
+      {},
     );
   }, [
     definition,

--- a/packages/visual-editor/src/components/RootRenderer/DNDProvider.tsx
+++ b/packages/visual-editor/src/components/RootRenderer/DNDProvider.tsx
@@ -2,8 +2,8 @@ import useCanvasInteractions from '@/hooks/useCanvasInteractions';
 import { usePlaceholderStyle } from '@/hooks/usePlaceholderStyle';
 import { useDraggedItemStore } from '@/store/draggedItem';
 import { useEditorStore } from '@/store/editor';
-import { sendMessage } from '@contentful/experience-builder-core';
-import { OUTGOING_EVENTS } from '@contentful/experience-builder-core/constants';
+import { sendMessage } from '@contentful/experiences-core';
+import { OUTGOING_EVENTS } from '@contentful/experiences-core/constants';
 import {
   DragDropContext,
   OnBeforeCaptureResponder,

--- a/packages/visual-editor/src/components/RootRenderer/RootRenderer.tsx
+++ b/packages/visual-editor/src/components/RootRenderer/RootRenderer.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { useEffect } from 'react';
 import { Dropzone } from '../Dropzone/Dropzone';
 import DraggableContainer from '../Draggable/DraggableComponentList';
-import type { CompositionTree } from '@contentful/experience-builder-core/types';
+import type { CompositionTree } from '@contentful/experiences-core/types';
 
 import { ROOT_ID } from '@/types/constants';
 import { useTreeStore } from '@/store/tree';
@@ -12,8 +12,8 @@ import styles from './render.module.css';
 import { useBreakpoints } from '@/hooks/useBreakpoints';
 import { useEditorSubscriber } from '@/hooks/useEditorSubscriber';
 import { DNDProvider } from './DNDProvider';
-import { sendMessage } from '@contentful/experience-builder-core';
-import { OUTGOING_EVENTS } from '@contentful/experience-builder-core/constants';
+import { sendMessage } from '@contentful/experiences-core';
+import { OUTGOING_EVENTS } from '@contentful/experiences-core/constants';
 
 interface Props {
   onChange?: (data: CompositionTree) => void;

--- a/packages/visual-editor/src/components/VisualEditorRoot.tsx
+++ b/packages/visual-editor/src/components/VisualEditorRoot.tsx
@@ -1,9 +1,9 @@
 import React, { useEffect } from 'react';
-import { sendMessage } from '@contentful/experience-builder-core';
+import { sendMessage } from '@contentful/experiences-core';
 import dragState from '@/utils/dragState';
 import { RootRenderer } from './RootRenderer/RootRenderer';
 import { simulateMouseEvent } from '@/utils/simulateMouseEvent';
-import { OUTGOING_EVENTS } from '@contentful/experience-builder-core/constants';
+import { OUTGOING_EVENTS } from '@contentful/experiences-core/constants';
 import { useInitializeEditor } from '@/hooks/useInitializeEditor';
 import { useEntityStore } from '@/store/entityStore';
 import { useEditorStore } from '@/store/editor';

--- a/packages/visual-editor/src/hooks/useBreakpoints.spec.ts
+++ b/packages/visual-editor/src/hooks/useBreakpoints.spec.ts
@@ -1,5 +1,5 @@
-import { getValueForBreakpoint } from '@contentful/experience-builder-core';
-import { Breakpoint } from '@contentful/experience-builder-core/types';
+import { getValueForBreakpoint } from '@contentful/experiences-core';
+import { Breakpoint } from '@contentful/experiences-core/types';
 import { describe, it, expect } from 'vitest';
 
 const breakpoints: Breakpoint[] = [

--- a/packages/visual-editor/src/hooks/useBreakpoints.ts
+++ b/packages/visual-editor/src/hooks/useBreakpoints.ts
@@ -3,13 +3,13 @@ import type {
   Breakpoint,
   CompositionVariableValueType,
   ResolveDesignValueType,
-} from '@contentful/experience-builder-core/types';
+} from '@contentful/experiences-core/types';
 import {
   mediaQueryMatcher,
   getFallbackBreakpointIndex,
   getActiveBreakpointIndex,
   getValueForBreakpoint,
-} from '@contentful/experience-builder-core';
+} from '@contentful/experiences-core';
 import { useCallback, useEffect, useState } from 'react';
 
 // TODO: In order to support integrations without React, we should extract this heavy logic into simple
@@ -54,22 +54,22 @@ export const useBreakpoints = (breakpoints: Breakpoint[]) => {
   const activeBreakpointIndex = getActiveBreakpointIndex(
     breakpoints,
     mediaQueryMatches,
-    fallbackBreakpointIndex
+    fallbackBreakpointIndex,
   );
 
   const resolveDesignValue: ResolveDesignValueType = useCallback(
     (
       valuesByBreakpoint: ValuesByBreakpoint,
-      variableName: string
+      variableName: string,
     ): CompositionVariableValueType => {
       return getValueForBreakpoint(
         valuesByBreakpoint,
         breakpoints,
         activeBreakpointIndex,
-        variableName
+        variableName,
       );
     },
-    [activeBreakpointIndex, breakpoints]
+    [activeBreakpointIndex, breakpoints],
   );
 
   return { resolveDesignValue };

--- a/packages/visual-editor/src/hooks/useCanvasInteractions.ts
+++ b/packages/visual-editor/src/hooks/useCanvasInteractions.ts
@@ -3,7 +3,7 @@ import { useTreeStore } from '@/store/tree';
 import { ROOT_ID } from '@/types/constants';
 import { createTreeNode } from '@/utils/createTreeNode';
 import { onDrop } from '@/utils/onDrop';
-import { CONTENTFUL_COMPONENTS } from '@contentful/experience-builder-core/constants';
+import { CONTENTFUL_COMPONENTS } from '@contentful/experiences-core/constants';
 import { DropResult } from '@hello-pangea/dnd';
 
 export default function useCanvasInteractions() {

--- a/packages/visual-editor/src/hooks/useDropzoneDirection.ts
+++ b/packages/visual-editor/src/hooks/useDropzoneDirection.ts
@@ -1,11 +1,11 @@
-import { CONTENTFUL_COMPONENTS } from '@contentful/experience-builder-core/constants';
+import { CONTENTFUL_COMPONENTS } from '@contentful/experiences-core/constants';
 import type {
   CompositionComponentNode,
   ResolveDesignValueType,
-} from '@contentful/experience-builder-core/types';
+} from '@contentful/experiences-core/types';
 import { useEffect } from 'react';
 import { useZoneStore } from '@/store/zone';
-import { isContentfulStructureComponent } from '@contentful/experience-builder-core';
+import { isContentfulStructureComponent } from '@contentful/experiences-core';
 
 interface Params {
   resolveDesignValue: ResolveDesignValueType | undefined;

--- a/packages/visual-editor/src/hooks/useEditorSubscriber.ts
+++ b/packages/visual-editor/src/hooks/useEditorSubscriber.ts
@@ -4,13 +4,13 @@ import {
   getDataFromTree,
   doesMismatchMessageSchema,
   tryParseMessage,
-} from '@contentful/experience-builder-core';
+} from '@contentful/experiences-core';
 import {
   OUTGOING_EVENTS,
   INCOMING_EVENTS,
   SCROLL_STATES,
   PostMessageMethods,
-} from '@contentful/experience-builder-core/constants';
+} from '@contentful/experiences-core/constants';
 import {
   CompositionTree,
   CompositionComponentNode,
@@ -19,7 +19,7 @@ import {
   Link,
   CompositionDataSource,
   ManagementEntity,
-} from '@contentful/experience-builder-core/types';
+} from '@contentful/experiences-core/types';
 import { sendSelectedComponentCoordinates } from '@/communication/sendSelectedComponentCoordinates';
 import dragState from '@/utils/dragState';
 import { useTreeStore } from '@/store/tree';
@@ -94,7 +94,7 @@ export function useEditorSubscriber() {
         setFetchingEntities(false);
       }
     },
-    [dataSource, entityStore, setEntitiesFetched]
+    [dataSource, entityStore, setEntitiesFetched],
   );
   // When the tree was updated, we store the dataSource and
   // afterward, this effect fetches the respective entities.
@@ -115,7 +115,7 @@ export function useEditorSubscriber() {
         } else {
           console.warn(
             `[exp-builder.sdk::onMessage] Ignoring alien incoming message from origin [${event.origin}], due to: [${reason}]`,
-            event
+            event,
           );
         }
         return;
@@ -128,7 +128,7 @@ export function useEditorSubscriber() {
       }
       console.debug(
         `[exp-builder.sdk::onMessage] Received message [${eventData.eventType}]`,
-        eventData
+        eventData,
       );
 
       const { payload } = eventData;
@@ -257,7 +257,7 @@ export function useEditorSubscriber() {
           };
           if (updatedEntity) {
             const storedEntity = entityStore.entities.find(
-              (entity) => entity.sys.id === updatedEntity.sys.id
+              (entity) => entity.sys.id === updatedEntity.sys.id,
             ) as unknown as ManagementEntity | undefined;
 
             const didEntityChange = storedEntity?.sys.version !== updatedEntity.sys.version;
@@ -298,7 +298,7 @@ export function useEditorSubscriber() {
         }
         default:
           console.error(
-            `[exp-builder.sdk::onMessage] Logic error, unsupported eventType: [${eventData.eventType}]`
+            `[exp-builder.sdk::onMessage] Logic error, unsupported eventType: [${eventData.eventType}]`,
           );
       }
     };

--- a/packages/visual-editor/src/hooks/useInitializeEditor.ts
+++ b/packages/visual-editor/src/hooks/useInitializeEditor.ts
@@ -1,10 +1,7 @@
 import { useEditorStore } from '@/store/editor';
 import { useEntityStore } from '@/store/entityStore';
 
-import {
-  INTERNAL_EVENTS,
-  VISUAL_EDITOR_EVENTS,
-} from '@contentful/experience-builder-core/constants';
+import { INTERNAL_EVENTS, VISUAL_EDITOR_EVENTS } from '@contentful/experiences-core/constants';
 import { useEffect, useState } from 'react';
 
 export const useInitializeEditor = () => {

--- a/packages/visual-editor/src/hooks/useSelectedInstanceCoordinates.ts
+++ b/packages/visual-editor/src/hooks/useSelectedInstanceCoordinates.ts
@@ -1,8 +1,8 @@
 import { useEffect } from 'react';
-import type { CompositionComponentNode } from '@contentful/experience-builder-core/types';
+import type { CompositionComponentNode } from '@contentful/experiences-core/types';
 import { sendSelectedComponentCoordinates } from '@/communication/sendSelectedComponentCoordinates';
 import { useEditorStore } from '@/store/editor';
-import { getElementCoordinates } from '@contentful/experience-builder-core';
+import { getElementCoordinates } from '@contentful/experiences-core';
 /**
  * This hook gets the element co-ordinates of a specified element in the DOM
  * and sends the DOM Rect to the client app

--- a/packages/visual-editor/src/hooks/useStyleTag.ts
+++ b/packages/visual-editor/src/hooks/useStyleTag.ts
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
-import { buildStyleTag } from '@contentful/experience-builder-core';
-import type { CSSProperties } from '@contentful/experience-builder-core/types';
+import { buildStyleTag } from '@contentful/experiences-core';
+import type { CSSProperties } from '@contentful/experiences-core/types';
 
 /**
  *

--- a/packages/visual-editor/src/renderApp.tsx
+++ b/packages/visual-editor/src/renderApp.tsx
@@ -3,10 +3,10 @@ import './global.css';
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { VisualEditorRoot } from './components/VisualEditorRoot';
-import { VISUAL_EDITOR_CONTAINER_ID } from '@contentful/experience-builder-core/constants';
+import { VISUAL_EDITOR_CONTAINER_ID } from '@contentful/experiences-core/constants';
 
 ReactDOM.createRoot(document.getElementById(VISUAL_EDITOR_CONTAINER_ID)!).render(
   <React.StrictMode>
     <VisualEditorRoot />
-  </React.StrictMode>
+  </React.StrictMode>,
 );

--- a/packages/visual-editor/src/store/editor.ts
+++ b/packages/visual-editor/src/store/editor.ts
@@ -1,10 +1,10 @@
-import { defineDesignTokens } from '@contentful/experience-builder-core';
+import { defineDesignTokens } from '@contentful/experiences-core';
 import type {
   ComponentRegistration,
   CompositionDataSource,
   CompositionUnboundValues,
   DesignTokensDefinition,
-} from '@contentful/experience-builder-core/types';
+} from '@contentful/experiences-core/types';
 import { create } from 'zustand';
 import { componentRegistry } from './registries';
 import { isEqual } from 'lodash-es';
@@ -64,7 +64,7 @@ export const useEditorStore = create<EditorStore>((set, get) => ({
       componentRegistry.set(registration.definition.id, registration);
     });
 
-    // Re-register the design tokens with the Visual Editor's instance of the experience-builder-core package
+    // Re-register the design tokens with the Visual Editor's instance of the experiences-core package
     defineDesignTokens(designTokens);
 
     set({ locale: initialLocale });

--- a/packages/visual-editor/src/store/entityStore.ts
+++ b/packages/visual-editor/src/store/entityStore.ts
@@ -1,4 +1,4 @@
-import { EditorModeEntityStore } from '@contentful/experience-builder-core';
+import { EditorModeEntityStore } from '@contentful/experiences-core';
 import { create } from 'zustand';
 
 export interface EntityState {
@@ -21,7 +21,7 @@ export const useEntityStore = create<EntityState>((set) => ({
   },
   resetEntityStore(locale, entities = []) {
     console.debug(
-      `[exp-builder.sdk] Resetting entity store because the locale changed to '${locale}'.`
+      `[exp-builder.sdk] Resetting entity store because the locale changed to '${locale}'.`,
     );
     set({
       entityStore: new EditorModeEntityStore({ locale, entities }),

--- a/packages/visual-editor/src/store/registries.ts
+++ b/packages/visual-editor/src/store/registries.ts
@@ -2,9 +2,9 @@ import type {
   ComponentRegistration,
   ComponentDefinition,
   Link,
-} from '@contentful/experience-builder-core/types';
+} from '@contentful/experiences-core/types';
 
-import { ASSEMBLY_DEFAULT_CATEGORY } from '@contentful/experience-builder-core/constants';
+import { ASSEMBLY_DEFAULT_CATEGORY } from '@contentful/experiences-core/constants';
 
 // Note: During development, the hot reloading might empty this and it
 // stays empty leading to not rendering assemblies. Ideally, this is

--- a/packages/visual-editor/src/store/tree.ts
+++ b/packages/visual-editor/src/store/tree.ts
@@ -2,7 +2,7 @@ import type {
   Breakpoint,
   CompositionComponentNode,
   CompositionTree,
-} from '@contentful/experience-builder-core/types';
+} from '@contentful/experiences-core/types';
 import { ROOT_ID, TreeAction } from '@/types/constants';
 import { create } from 'zustand';
 import { produce } from 'immer';
@@ -18,7 +18,7 @@ import { treeVisit } from '@/utils/treeTraversal';
 import {
   ASSEMBLY_NODE_TYPE,
   DESIGN_COMPONENT_NODE_TYPE,
-} from '@contentful/experience-builder-core/constants';
+} from '@contentful/experiences-core/constants';
 export interface TreeStore {
   tree: CompositionTree;
   breakpoints: Breakpoint[];
@@ -28,12 +28,12 @@ export interface TreeStore {
   addChild: (
     destinationIndex: number,
     destinationParentId: string,
-    node: CompositionComponentNode
+    node: CompositionComponentNode,
   ) => void;
   reorderChildren: (
     destinationIndex: number,
     destinationParentId: string,
-    sourceIndex: number
+    sourceIndex: number,
   ) => void;
 }
 
@@ -72,7 +72,7 @@ export const useTreeStore = create<TreeStore>((set, get) => ({
             updateNode(node.data.id, cloneDeepAsPOJO(node), draftState.tree.root);
           }
         });
-      })
+      }),
     );
   },
 
@@ -109,7 +109,7 @@ export const useTreeStore = create<TreeStore>((set, get) => ({
     // The current and updated tree are the same, no tree update required.
     if (!treeDiff.length) {
       console.debug(
-        `[exp-builder.visual-editor::updateTree()]: During smart-diffing no diffs. Skipping tree update.`
+        `[exp-builder.visual-editor::updateTree()]: During smart-diffing no diffs. Skipping tree update.`,
       );
       return;
     }
@@ -132,7 +132,7 @@ export const useTreeStore = create<TreeStore>((set, get) => ({
                 diff.indexToRemove,
                 diff.idToRemove,
                 diff.parentNodeId,
-                state.tree.root
+                state.tree.root,
               );
               break;
             case TreeAction.MOVE_NODE:
@@ -145,21 +145,21 @@ export const useTreeStore = create<TreeStore>((set, get) => ({
         });
 
         state.breakpoints = tree?.root?.data?.breakpoints || [];
-      })
+      }),
     );
   },
   addChild: (index, parentId, node) => {
     set(
       produce((state: TreeStore) => {
         addChildNode(index, parentId, node, state.tree.root);
-      })
+      }),
     );
   },
   reorderChildren: (destinationIndex, destinationParentId, sourceIndex) => {
     set(
       produce((state: TreeStore) => {
         reorderChildNode(sourceIndex, destinationIndex, destinationParentId, state.tree.root);
-      })
+      }),
     );
   },
 }));

--- a/packages/visual-editor/src/types/Config.tsx
+++ b/packages/visual-editor/src/types/Config.tsx
@@ -1,4 +1,4 @@
-import type { CompositionComponentNode } from '@contentful/experience-builder-core/types';
+import type { CompositionComponentNode } from '@contentful/experiences-core/types';
 
 type WithCtflProps<Props> = Props & {
   id: string;
@@ -9,12 +9,12 @@ export type DefaultComponentProps = { [key: string]: unknown; editorMode?: boole
 export type Content = ComponentData[];
 
 export type CtflComponent<Props extends DefaultComponentProps = DefaultComponentProps> = (
-  props: WithCtflProps<Props & { ctfl: unknown }>
+  props: WithCtflProps<Props & { ctfl: unknown }>,
 ) => JSX.Element;
 
 export type ComponentConfig<
   ComponentProps extends DefaultComponentProps = DefaultComponentProps,
-  DefaultProps = ComponentProps
+  DefaultProps = ComponentProps,
 > = {
   id: string;
   render: CtflComponent<ComponentProps>;

--- a/packages/visual-editor/src/types/constants.ts
+++ b/packages/visual-editor/src/types/constants.ts
@@ -1,4 +1,4 @@
-import { CONTENTFUL_COMPONENTS } from '@contentful/experience-builder-core/constants';
+import { CONTENTFUL_COMPONENTS } from '@contentful/experiences-core/constants';
 
 export const DRAGGABLE_HEIGHT = 40;
 export const DRAGGABLE_WIDTH = 40;

--- a/packages/visual-editor/src/types/treeActions.ts
+++ b/packages/visual-editor/src/types/treeActions.ts
@@ -1,4 +1,4 @@
-import { CompositionComponentNode } from '@contentful/experience-builder-core/types';
+import { CompositionComponentNode } from '@contentful/experiences-core/types';
 import { TreeAction } from './constants';
 
 interface DiffBase {

--- a/packages/visual-editor/src/utils/assemblyUtils.spec.ts
+++ b/packages/visual-editor/src/utils/assemblyUtils.spec.ts
@@ -9,12 +9,9 @@ import { assets } from '../../test/__fixtures__/entities';
 import {
   ASSEMBLY_BLOCK_NODE_TYPE,
   ASSEMBLY_NODE_TYPE,
-} from '@contentful/experience-builder-core/constants';
-import type {
-  CompositionComponentNode,
-  CompositionNode,
-} from '@contentful/experience-builder-core/types';
-import { EditorModeEntityStore } from '@contentful/experience-builder-core';
+} from '@contentful/experiences-core/constants';
+import type { CompositionComponentNode, CompositionNode } from '@contentful/experiences-core/types';
+import { EditorModeEntityStore } from '@contentful/experiences-core';
 import { deserializeAssemblyNode, resolveAssembly } from './assemblyUtils';
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { assembliesRegistry } from '@/store/registries';

--- a/packages/visual-editor/src/utils/assemblyUtils.ts
+++ b/packages/visual-editor/src/utils/assemblyUtils.ts
@@ -1,4 +1,4 @@
-import { EntityStoreBase } from '@contentful/experience-builder-core';
+import { EntityStoreBase } from '@contentful/experiences-core';
 import type {
   CompositionNode,
   CompositionDataSource,
@@ -6,15 +6,15 @@ import type {
   CompositionComponentNode,
   CompositionComponentPropValue,
   Composition,
-} from '@contentful/experience-builder-core/types';
+} from '@contentful/experiences-core/types';
 import type { Entry } from 'contentful';
 
 import {
   DESIGN_COMPONENT_NODE_TYPE,
   ASSEMBLY_BLOCK_NODE_TYPE,
   ASSEMBLY_NODE_TYPE,
-} from '@contentful/experience-builder-core/constants';
-import { generateRandomId } from '@contentful/experience-builder-core';
+} from '@contentful/experiences-core/constants';
+import { generateRandomId } from '@contentful/experiences-core';
 import { assembliesRegistry } from '@/store/registries';
 
 export const checkIsAssemblyEntry = (entry: Entry): boolean => {
@@ -83,7 +83,7 @@ export const deserializeAssemblyNode = ({
       componentInstanceProps,
       componentInstanceUnboundValues,
       componentInstanceDataSource,
-    })
+    }),
   );
 
   return {

--- a/packages/visual-editor/src/utils/createTreeNode.ts
+++ b/packages/visual-editor/src/utils/createTreeNode.ts
@@ -1,4 +1,4 @@
-import { CompositionComponentNode } from '@contentful/experience-builder-core/types';
+import { CompositionComponentNode } from '@contentful/experiences-core/types';
 import { generateId } from './generate-id';
 
 interface Params {

--- a/packages/visual-editor/src/utils/getItem.ts
+++ b/packages/visual-editor/src/utils/getItem.ts
@@ -1,7 +1,4 @@
-import type {
-  CompositionComponentNode,
-  CompositionTree,
-} from '@contentful/experience-builder-core/types';
+import type { CompositionComponentNode, CompositionTree } from '@contentful/experiences-core/types';
 import { ROOT_ID } from '../types/constants';
 
 export type ItemSelector = {
@@ -10,7 +7,7 @@ export type ItemSelector = {
 
 function getItemFromTree(
   id: string,
-  node: CompositionComponentNode
+  node: CompositionComponentNode,
 ): CompositionComponentNode | undefined {
   // Check if the current node's id matches the search id
 
@@ -33,7 +30,7 @@ function getItemFromTree(
 
 export const getItem = (
   selector: ItemSelector,
-  tree: CompositionTree
+  tree: CompositionTree,
 ): CompositionComponentNode | undefined => {
   return getItemFromTree(selector.id, {
     type: 'block',

--- a/packages/visual-editor/src/utils/getTreeDiff.ts
+++ b/packages/visual-editor/src/utils/getTreeDiff.ts
@@ -1,7 +1,4 @@
-import {
-  CompositionComponentNode,
-  CompositionTree,
-} from '@contentful/experience-builder-core/types';
+import { CompositionComponentNode, CompositionTree } from '@contentful/experiences-core/types';
 
 import { getItem } from './getItem';
 import { isEqual } from 'lodash-es';
@@ -183,7 +180,7 @@ function compareNodes({
 export function getTreeDiffs(
   tree1: CompositionComponentNode,
   tree2: CompositionComponentNode,
-  originalTree: CompositionTree
+  originalTree: CompositionTree,
 ): TreeDiff[] {
   const differences: TreeDiff[] = [];
 

--- a/packages/visual-editor/src/utils/getUnboundValues.ts
+++ b/packages/visual-editor/src/utils/getUnboundValues.ts
@@ -2,7 +2,7 @@ import { get } from 'lodash-es';
 import type {
   CompositionUnboundValues,
   CompositionVariableValueType,
-} from '@contentful/experience-builder-core/types';
+} from '@contentful/experiences-core/types';
 
 export const getUnboundValues = ({
   key,

--- a/packages/visual-editor/src/utils/onDrop.ts
+++ b/packages/visual-editor/src/utils/onDrop.ts
@@ -1,9 +1,6 @@
 import { onComponentDropped } from '@/communication/onComponentDrop';
 import { getItem } from './getItem';
-import type {
-  CompositionComponentNode,
-  CompositionTree,
-} from '@contentful/experience-builder-core/types';
+import type { CompositionComponentNode, CompositionTree } from '@contentful/experiences-core/types';
 import { generateId } from './generate-id';
 import { ROOT_ID } from '../types/constants';
 

--- a/packages/visual-editor/src/utils/treeHelpers.ts
+++ b/packages/visual-editor/src/utils/treeHelpers.ts
@@ -1,10 +1,10 @@
-import type { CompositionComponentNode } from '@contentful/experience-builder-core/types';
+import type { CompositionComponentNode } from '@contentful/experiences-core/types';
 import { isEqual } from 'lodash-es';
 
 export function updateNode(
   nodeId: string,
   updatedNode: CompositionComponentNode,
-  node: CompositionComponentNode
+  node: CompositionComponentNode,
 ) {
   if (node.data.id === nodeId) {
     node.data = updatedNode.data;
@@ -16,7 +16,7 @@ export function updateNode(
 export function replaceNode(
   indexToReplace: number,
   updatedNode: CompositionComponentNode,
-  node: CompositionComponentNode
+  node: CompositionComponentNode,
 ) {
   if (node.data.id === updatedNode.parentId) {
     node.children = [
@@ -33,7 +33,7 @@ export function replaceNode(
 export function reorderChildrenNodes(
   nodeId: string,
   updatedChildren: CompositionComponentNode[],
-  node: CompositionComponentNode
+  node: CompositionComponentNode,
 ) {
   if (node.data.id === nodeId) {
     node.children = updatedChildren;
@@ -47,11 +47,11 @@ export function addChildToNode(
   nodeId: string,
   oldChildren: CompositionComponentNode[],
   updatedChildren: CompositionComponentNode[],
-  node: CompositionComponentNode
+  node: CompositionComponentNode,
 ) {
   if (node.data.id !== nodeId) {
     node.children.forEach((childNode) =>
-      addChildToNode(nodeId, oldChildren, updatedChildren, childNode)
+      addChildToNode(nodeId, oldChildren, updatedChildren, childNode),
     );
   }
 
@@ -73,7 +73,7 @@ export function addChildToNode(
       oldChildren.length,
       node.data.id,
       updatedChildren[updatedChildren.length - 1],
-      node
+      node,
     );
   }
 }
@@ -82,7 +82,7 @@ export function removeChildNode(
   indexToRemove: number,
   nodeId: string,
   parentNodeId: string,
-  node: CompositionComponentNode
+  node: CompositionComponentNode,
 ) {
   if (node.data.id === parentNodeId) {
     const childIndex = node.children.findIndex((child) => child.data.id === nodeId);
@@ -92,7 +92,7 @@ export function removeChildNode(
   }
 
   node.children.forEach((childNode) =>
-    removeChildNode(indexToRemove, nodeId, parentNodeId, childNode)
+    removeChildNode(indexToRemove, nodeId, parentNodeId, childNode),
   );
 }
 
@@ -100,7 +100,7 @@ export function addChildNode(
   indexToAdd: number,
   parentNodeId: string,
   nodeToAdd: CompositionComponentNode,
-  node: CompositionComponentNode
+  node: CompositionComponentNode,
 ) {
   if (node.data.id === parentNodeId) {
     node.children = [
@@ -113,7 +113,7 @@ export function addChildNode(
   }
 
   node.children.forEach((childNode) =>
-    addChildNode(indexToAdd, parentNodeId, nodeToAdd, childNode)
+    addChildNode(indexToAdd, parentNodeId, nodeToAdd, childNode),
   );
 }
 
@@ -121,7 +121,7 @@ export function reorderChildNode(
   oldIndex: number,
   newIndex: number,
   parentNodeId: string,
-  node: CompositionComponentNode
+  node: CompositionComponentNode,
 ) {
   if (node.data.id === parentNodeId) {
     // Remove the child from the old position
@@ -133,6 +133,6 @@ export function reorderChildNode(
   }
 
   node.children.forEach((childNode) =>
-    reorderChildNode(oldIndex, newIndex, parentNodeId, childNode)
+    reorderChildNode(oldIndex, newIndex, parentNodeId, childNode),
   );
 }

--- a/packages/visual-editor/test/__fixtures__/assembly.ts
+++ b/packages/visual-editor/test/__fixtures__/assembly.ts
@@ -2,11 +2,8 @@ import {
   CONTENTFUL_COMPONENTS,
   ASSEMBLY_NODE_TYPE,
   LATEST_SCHEMA_VERSION,
-} from '@contentful/experience-builder-core/constants';
-import type {
-  CompositionComponentNode,
-  SchemaVersions,
-} from '@contentful/experience-builder-core/types';
+} from '@contentful/experiences-core/constants';
+import type { CompositionComponentNode, SchemaVersions } from '@contentful/experiences-core/types';
 
 type createAssemblyEntryArgs = {
   schemaVersion: SchemaVersions;

--- a/packages/visual-editor/test/__fixtures__/composition.ts
+++ b/packages/visual-editor/test/__fixtures__/composition.ts
@@ -2,9 +2,9 @@ import type {
   Composition,
   ExperienceEntry,
   SchemaVersions,
-} from '@contentful/experience-builder-core/types';
+} from '@contentful/experiences-core/types';
 import { entityIds } from './entities';
-import { LATEST_SCHEMA_VERSION } from '@contentful/experience-builder-core/constants';
+import { LATEST_SCHEMA_VERSION } from '@contentful/experiences-core/constants';
 
 const compositionFields: Composition = {
   title: 'Test Composition',


### PR DESCRIPTION
## Purpose
Rename experience builder sdk packages based on https://contentful.atlassian.net/wiki/spaces/PROD/pages/4480499829/Experience+Builder+package+rename+proposal

This PR in particular converts experience-builder-core to experiences-core.

## Approach
Create feature branch called experience-release based on the development branch.
Ignored the `CHANGELOG.md` and `package-lock.json` files as those should be auto regenerated
