### PR TITLE
refactor: rename experience-builder-components to experiences-components-react [ALT-395]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2616,6 +2616,7 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -2893,16 +2894,16 @@
       "resolved": "packages/experience-builder-sdk",
       "link": true
     },
-    "node_modules/@contentful/experience-builder-components": {
-      "resolved": "packages/components",
-      "link": true
-    },
     "node_modules/@contentful/experience-builder-storybook-addon": {
       "resolved": "packages/storybook-addon",
       "link": true
     },
     "node_modules/@contentful/experience-builder-visual-editor": {
       "resolved": "packages/visual-editor",
+      "link": true
+    },
+    "node_modules/@contentful/experiences-components-react": {
+      "resolved": "packages/components",
       "link": true
     },
     "node_modules/@contentful/experiences-core": {
@@ -45614,8 +45615,8 @@
       }
     },
     "packages/components": {
-      "name": "@contentful/experience-builder-components",
-      "version": "0.0.2-alpha.26",
+      "name": "@contentful/experiences-components-react",
+      "version": "0.0.1-alpha.25",
       "license": "MIT",
       "dependencies": {
         "@contentful/experiences-core": "file:../core",
@@ -45694,7 +45695,7 @@
     },
     "packages/core": {
       "name": "@contentful/experiences-core",
-      "version": "0.0.0-alpha.25",
+      "version": "0.0.1-alpha.25",
       "license": "MIT",
       "dependencies": {
         "@contentful/experiences-validators": "file:../validators",
@@ -45805,8 +45806,8 @@
       "version": "4.0.0-alpha.25",
       "license": "MIT",
       "dependencies": {
-        "@contentful/experience-builder-components": "file:../components",
         "@contentful/experience-builder-visual-editor": "file:../visual-editor",
+        "@contentful/experiences-components-react": "file:../components",
         "@contentful/experiences-core": "file:../core",
         "@contentful/rich-text-types": "^16.2.1",
         "classnames": "^2.3.2",
@@ -45865,7 +45866,7 @@
       "dependencies": {
         "@contentful/app-sdk": "^4.23.1",
         "@contentful/experience-builder": "file:../experience-builder-sdk",
-        "@contentful/experience-builder-components": "file:../components",
+        "@contentful/experiences-components-react": "file:../components",
         "@contentful/f36-components": "^4.52.1",
         "@contentful/f36-tokens": "^4.0.2",
         "@contentful/f36-workbench": "^4.21.0",
@@ -45974,8 +45975,8 @@
       "version": "0.0.1-pre-20231216T233830.0",
       "dependencies": {
         "@contentful/experience-builder": "file:../experience-builder-sdk",
-        "@contentful/experience-builder-components": "file:../components",
         "@contentful/experience-builder-storybook-addon": "file:../storybook-addon",
+        "@contentful/experiences-components-react": "file:../components",
         "contentful": "^10.6.14",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -46110,7 +46111,7 @@
       "name": "@contentful/experience-builder-visual-editor",
       "version": "0.0.2-alpha.26",
       "dependencies": {
-        "@contentful/experience-builder-components": "file:../components",
+        "@contentful/experiences-components-react": "file:../components",
         "@contentful/experiences-core": "file:../core",
         "@hello-pangea/dnd": "^16.3.0",
         "classnames": "^2.3.2",

--- a/packages/components/README.md
+++ b/packages/components/README.md
@@ -32,7 +32,7 @@ The following components are available:
 ### Installation
 
 ```bash
-npm install @contentful/experience-builder-components
+npm install @contentful/experiences-components-react
 ```
 
 ### Register the components with Experience Builder
@@ -41,10 +41,10 @@ npm install @contentful/experience-builder-components
 
 In the section of code (usually the main App or Page components) where Experience Builder is configured, perform the following steps:
 
-Import the `useExperienceBuilderComponents` hook from the `@contentful/experience-builder-components` package:
+Import the `useExperienceBuilderComponents` hook from the `@contentful/experiences-components-react` package:
 
 ```jsx
-import { useExperienceBuilderComponents } from '@contentful/experience-builder-components';
+import { useExperienceBuilderComponents } from '@contentful/experiences-components-react';
 ```
 
 After the call to `useExperienceBuilder` (where you obtain the `defineComponents` method), pass in `defineComponents` to the `userExperienceBuilder` hook:
@@ -61,10 +61,10 @@ By default, the components are unstyled. This allows you to style the components
 
 ### Including default styles
 
-A set of optional, default styles are included with the components. To include them, import the `styles.css` file from the `@contentful/experience-builder-components` package:
+A set of optional, default styles are included with the components. To include them, import the `styles.css` file from the `@contentful/experiences-components-react` package:
 
 ```jsx
-import '@contentful/experience-builder-components/styles.css';
+import '@contentful/experiences-components-react/styles.css';
 ```
 
 ### Adding custom styles

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@contentful/experience-builder-components",
-  "version": "0.0.2-alpha.26",
+  "name": "@contentful/experiences-components-react",
+  "version": "0.0.1-alpha.25",
   "description": "A basic set of components to use with Experience Builder",
   "homepage": "https://github.com/contentful/experience-builder/tree/next/packages/components#readme",
   "repository": {

--- a/packages/components/src/components/Button/README.md
+++ b/packages/components/src/components/Button/README.md
@@ -13,7 +13,7 @@ Has a default class of `cf-button`, which can be used to style the component.
 ## Usage
 
 ```tsx
-import { Button } from '@contentful/experience-builder-components';
+import { Button } from '@contentful/experiences-components-react';
 
 const MyPage = () => <Button label="Go" url="https://www.contentful.com" />;
 ```

--- a/packages/components/src/components/Heading/README.md
+++ b/packages/components/src/components/Heading/README.md
@@ -11,7 +11,7 @@ Has a default class of `cf-heading`, which can be used to style the component.
 ## Usage
 
 ```tsx
-import { Heading } from '@contentful/experience-builder-components';
+import { Heading } from '@contentful/experiences-components-react';
 
 const MyPage = () => <Heading>Hello world</Heading>;
 ```

--- a/packages/components/src/components/Image/README.md
+++ b/packages/components/src/components/Image/README.md
@@ -11,7 +11,7 @@ Has a default class of `cf-image`, which can be used to style the component.
 ## Usage
 
 ```tsx
-import { Image } from '@contentful/experience-builder-components';
+import { Image } from '@contentful/experiences-components-react';
 
 const MyPage = () => <Image src="https://mysite.com/assets/image.png" alt="My Image" />;
 ```

--- a/packages/components/src/components/RichText/README.md
+++ b/packages/components/src/components/RichText/README.md
@@ -11,7 +11,7 @@ Has a default class of `cf-richtext`, which can be used to style the component.
 ## Usage
 
 ```tsx
-import { RichText } from '@contentful/experience-builder-components';
+import { RichText } from '@contentful/experiences-components-react';
 
 const MyPage = () => <RichText value={document} />;
 ```

--- a/packages/components/src/components/Text/README.md
+++ b/packages/components/src/components/Text/README.md
@@ -11,7 +11,7 @@ Has a default class of `cf-text`, which can be used to style the component.
 ## Usage
 
 ```tsx
-import { Text } from '@contentful/experience-builder-components';
+import { Text } from '@contentful/experiences-components-react';
 
 const MyPage = () => <Text value="Go" />;
 ```

--- a/packages/create-experience-builder/src/fsClient.ts
+++ b/packages/create-experience-builder/src/fsClient.ts
@@ -20,7 +20,7 @@ export class FsClient {
 
     this.copyTemplateFiles(projectDir, templateDir, variant.srcDir);
 
-    const installEbLibsCommand = `npm i --prefix ${projectDir} @contentful/experience-builder @contentful/experience-builder-components`;
+    const installEbLibsCommand = `npm i --prefix ${projectDir} @contentful/experience-builder @contentful/experiences-components-react`;
 
     const ebLibStatus = await this.runCommand(installEbLibsCommand);
 
@@ -37,7 +37,7 @@ export class FsClient {
 VITE_SPACE_ID=${envFileData.spaceId}
 VITE_ACCESS_TOKEN=${envFileData.accessToken}
 VITE_PREVIEW_ACCESS_TOKEN=${envFileData.previewAccessToken}
-VITE_EB_TYPE_ID=${envFileData.typeId}`
+VITE_EB_TYPE_ID=${envFileData.typeId}`,
     );
   }
 

--- a/packages/create-experience-builder/templates/react-vite-ts/src/App.tsx
+++ b/packages/create-experience-builder/templates/react-vite-ts/src/App.tsx
@@ -1,11 +1,11 @@
 import { createClient } from 'contentful';
 import { useExperienceBuilder, ExperienceRoot } from '@contentful/experience-builder';
-import { useExperienceBuilderComponents } from '@contentful/experience-builder-components';
+import { useExperienceBuilderComponents } from '@contentful/experiences-components-react';
 import './App.css';
 import { ExternalSDKMode } from '@contentful/experience-builder/dist/types';
 
 // Import the styles for the default components
-import '@contentful/experience-builder-components/styles.css';
+import '@contentful/experiences-components-react/styles.css';
 
 const experienceTypeId = import.meta.env.VITE_EB_TYPE_ID || 'layout';
 

--- a/packages/experience-builder-sdk/package.json
+++ b/packages/experience-builder-sdk/package.json
@@ -31,7 +31,7 @@
     "depcruise": "depcruise src"
   },
   "dependencies": {
-    "@contentful/experience-builder-components": "file:../components",
+    "@contentful/experiences-components-react": "file:../components",
     "@contentful/experiences-core": "file:../core",
     "@contentful/experience-builder-visual-editor": "file:../visual-editor",
     "@contentful/rich-text-types": "^16.2.1",

--- a/packages/experience-builder-sdk/src/blocks/preview/CompositionBlock.tsx
+++ b/packages/experience-builder-sdk/src/blocks/preview/CompositionBlock.tsx
@@ -24,7 +24,7 @@ import {
   Columns,
   ContentfulContainer,
   SingleColumn,
-} from '@contentful/experience-builder-components';
+} from '@contentful/experiences-components-react';
 
 import { resolveAssembly } from '../../core/preview/assemblyUtils';
 import { Assembly } from '../../components/Assembly';

--- a/packages/experience-builder-sdk/src/core/componentRegistry.ts
+++ b/packages/experience-builder-sdk/src/core/componentRegistry.ts
@@ -1,4 +1,4 @@
-import * as Components from '@contentful/experience-builder-components';
+import * as Components from '@contentful/experiences-components-react';
 import type {
   ComponentRegistration,
   ComponentDefinition,

--- a/packages/storybook-addon/package.json
+++ b/packages/storybook-addon/package.json
@@ -117,7 +117,7 @@
   "dependencies": {
     "@contentful/app-sdk": "^4.23.1",
     "@contentful/experience-builder": "file:../experience-builder-sdk",
-    "@contentful/experience-builder-components": "file:../components",
+    "@contentful/experiences-components-react": "file:../components",
     "@contentful/f36-components": "^4.52.1",
     "@contentful/f36-tokens": "^4.0.2",
     "@contentful/f36-workbench": "^4.21.0",

--- a/packages/test-app/package.json
+++ b/packages/test-app/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "@contentful/experience-builder": "file:../experience-builder-sdk",
-    "@contentful/experience-builder-components": "file:../components",
+    "@contentful/experiences-components-react": "file:../components",
     "@contentful/experience-builder-storybook-addon": "file:../storybook-addon",
     "contentful": "^10.6.14",
     "react": "^18.2.0",

--- a/packages/test-app/src/Page.tsx
+++ b/packages/test-app/src/Page.tsx
@@ -1,6 +1,6 @@
 import './eb-config';
 import { useParams } from 'react-router-dom';
-import '@contentful/experience-builder-components/styles.css';
+import '@contentful/experiences-components-react/styles.css';
 import './styles.css';
 import { ExperienceRoot, useFetchBySlug } from '@contentful/experience-builder';
 import { useContentfulClient } from './hooks/useContentfulClient';

--- a/packages/test-app/src/stories/Button.stories.ts
+++ b/packages/test-app/src/stories/Button.stories.ts
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react';
 
-import { Button, ButtonComponentDefinition } from '@contentful/experience-builder-components';
+import { Button, ButtonComponentDefinition } from '@contentful/experiences-components-react';
 
 // More on how to set up stories at: https://storybook.js.org/docs/react/writing-stories/introduction#default-export
 const meta = {

--- a/packages/visual-editor/package.json
+++ b/packages/visual-editor/package.json
@@ -27,7 +27,7 @@
     "depcruise": "depcruise src"
   },
   "dependencies": {
-    "@contentful/experience-builder-components": "file:../components",
+    "@contentful/experiences-components-react": "file:../components",
     "@contentful/experiences-core": "file:../core",
     "@hello-pangea/dnd": "^16.3.0",
     "classnames": "^2.3.2",

--- a/packages/visual-editor/src/components/Dropzone/useComponent.ts
+++ b/packages/visual-editor/src/components/Dropzone/useComponent.ts
@@ -11,7 +11,7 @@ import {
   DESIGN_COMPONENT_NODE_TYPE,
   ASSEMBLY_NODE_TYPE,
 } from '@contentful/experiences-core/constants';
-import { Assembly } from '@contentful/experience-builder-components';
+import { Assembly } from '@contentful/experiences-components-react';
 import { resolveAssembly } from '@/utils/assemblyUtils';
 import { componentRegistry, createAssemblyRegistration } from '@/store/registries';
 import { useEntityStore } from '@/store/entityStore';

--- a/packages/visual-editor/src/hooks/useEditorSubscriber.ts
+++ b/packages/visual-editor/src/hooks/useEditorSubscriber.ts
@@ -25,7 +25,7 @@ import dragState from '@/utils/dragState';
 import { useTreeStore } from '@/store/tree';
 import { useEditorStore } from '@/store/editor';
 import { useDraggedItemStore } from '@/store/draggedItem';
-import { Assembly } from '@contentful/experience-builder-components';
+import { Assembly } from '@contentful/experiences-components-react';
 import { addComponentRegistration, assembliesRegistry, setAssemblies } from '@/store/registries';
 import { sendHoveredComponentCoordinates } from '@/communication/sendHoveredComponentCoordinates';
 import { useEntityStore } from '@/store/entityStore';


### PR DESCRIPTION
## Purpose
Rename experience builder sdk packages based on https://contentful.atlassian.net/wiki/spaces/PROD/pages/4480499829/Experience+Builder+package+rename+proposal

This PR in particular converts experience-builder-builder to experiences-components-react.

## Approach
Create feature branch called experience-release based on the development branch.
Ignored the `CHANGELOG.md` and `package-lock.json` files as those should be auto regenerated
