### PR TITLE
refactor: rename experience-builder-visual-editor to experiences-visual-editor-react

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2898,10 +2898,6 @@
       "resolved": "packages/storybook-addon",
       "link": true
     },
-    "node_modules/@contentful/experience-builder-visual-editor": {
-      "resolved": "packages/visual-editor",
-      "link": true
-    },
     "node_modules/@contentful/experiences-components-react": {
       "resolved": "packages/components",
       "link": true
@@ -2912,6 +2908,10 @@
     },
     "node_modules/@contentful/experiences-validators": {
       "resolved": "packages/validators",
+      "link": true
+    },
+    "node_modules/@contentful/experiences-visual-editor-react": {
+      "resolved": "packages/visual-editor",
       "link": true
     },
     "node_modules/@contentful/f36-accordion": {
@@ -45806,9 +45806,9 @@
       "version": "4.0.0-alpha.25",
       "license": "MIT",
       "dependencies": {
-        "@contentful/experience-builder-visual-editor": "file:../visual-editor",
         "@contentful/experiences-components-react": "file:../components",
         "@contentful/experiences-core": "file:../core",
+        "@contentful/experiences-visual-editor-react": "file:../visual-editor",
         "@contentful/rich-text-types": "^16.2.1",
         "classnames": "^2.3.2",
         "csstype": "^3.1.2",
@@ -46108,8 +46108,8 @@
       }
     },
     "packages/visual-editor": {
-      "name": "@contentful/experience-builder-visual-editor",
-      "version": "0.0.2-alpha.26",
+      "name": "@contentful/experiences-visual-editor-react",
+      "version": "0.0.1-alpha.25",
       "dependencies": {
         "@contentful/experiences-components-react": "file:../components",
         "@contentful/experiences-core": "file:../core",

--- a/packages/experience-builder-sdk/package.json
+++ b/packages/experience-builder-sdk/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "@contentful/experiences-components-react": "file:../components",
     "@contentful/experiences-core": "file:../core",
-    "@contentful/experience-builder-visual-editor": "file:../visual-editor",
+    "@contentful/experiences-visual-editor-react": "file:../visual-editor",
     "@contentful/rich-text-types": "^16.2.1",
     "classnames": "^2.3.2",
     "csstype": "^3.1.2",

--- a/packages/experience-builder-sdk/src/blocks/editor/VisualEditorInjectScript.tsx
+++ b/packages/experience-builder-sdk/src/blocks/editor/VisualEditorInjectScript.tsx
@@ -16,7 +16,7 @@ const version = '@0.0.1-pre-20231213T210727.0';
  *
  * TODO: Reconsider unpkg
  */
-const scriptUrl = `https://unpkg.com/@contentful/experience-builder-visual-editor${version}/dist/renderApp.js`;
+const scriptUrl = `https://unpkg.com/@contentful/experiences-visual-editor-react${version}/dist/renderApp.js`;
 
 /**
  * This component injects the visual editor script into the page

--- a/packages/experience-builder-sdk/src/blocks/editor/VisualEditorLoader.tsx
+++ b/packages/experience-builder-sdk/src/blocks/editor/VisualEditorLoader.tsx
@@ -19,7 +19,7 @@ export const VisualEditorLoader: React.FC<VisualEditorLoaderProps> = ({ visualEd
 
       // VisualEditorMode.LazyLoad:
       default:
-        import('@contentful/experience-builder-visual-editor').then((module) => {
+        import('@contentful/experiences-visual-editor-react').then((module) => {
           setVisualEditor(() => module.default);
         });
     }

--- a/packages/visual-editor/package.json
+++ b/packages/visual-editor/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@contentful/experience-builder-visual-editor",
-  "version": "0.0.2-alpha.26",
+  "name": "@contentful/experiences-visual-editor-react",
+  "version": "0.0.1-alpha.25",
   "type": "module",
   "main": "./dist/index.js",
   "module": "./dist/index.js",


### PR DESCRIPTION
## Purpose
Rename experience builder sdk packages based on https://contentful.atlassian.net/wiki/spaces/PROD/pages/4480499829/Experience+Builder+package+rename+proposal

This PR in particular converts experience-builder-visual-editor to experiences-visual-editor-react

## Approach
Create feature branch called experience-release based on the development branch.
Ignored the `CHANGELOG.md` and `package-lock.json` files as those should be auto regenerated
