### PR TITLE
refactor: rename experience-builder-storybook-addon to experiences-storybook-addon [ALT-395]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2894,16 +2894,16 @@
       "resolved": "packages/experience-builder-sdk",
       "link": true
     },
-    "node_modules/@contentful/experience-builder-storybook-addon": {
-      "resolved": "packages/storybook-addon",
-      "link": true
-    },
     "node_modules/@contentful/experiences-components-react": {
       "resolved": "packages/components",
       "link": true
     },
     "node_modules/@contentful/experiences-core": {
       "resolved": "packages/core",
+      "link": true
+    },
+    "node_modules/@contentful/experiences-storybook-addon": {
+      "resolved": "packages/storybook-addon",
       "link": true
     },
     "node_modules/@contentful/experiences-validators": {
@@ -45860,8 +45860,8 @@
       }
     },
     "packages/storybook-addon": {
-      "name": "@contentful/experience-builder-storybook-addon",
-      "version": "0.0.2-alpha.26",
+      "name": "@contentful/experiences-storybook-addon",
+      "version": "0.0.1-alpha.25",
       "license": "MIT",
       "dependencies": {
         "@contentful/app-sdk": "^4.23.1",
@@ -45975,8 +45975,8 @@
       "version": "0.0.1-pre-20231216T233830.0",
       "dependencies": {
         "@contentful/experience-builder": "file:../experience-builder-sdk",
-        "@contentful/experience-builder-storybook-addon": "file:../storybook-addon",
         "@contentful/experiences-components-react": "file:../components",
+        "@contentful/experiences-storybook-addon": "file:../storybook-addon",
         "contentful": "^10.6.14",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",

--- a/packages/components/.storybook/main.ts
+++ b/packages/components/.storybook/main.ts
@@ -7,7 +7,7 @@ const config: StorybookConfig = {
     '@storybook/addon-essentials',
     '@storybook/addon-onboarding',
     '@storybook/addon-interactions',
-    '@contentful/experience-builder-storybook-addon',
+    '@contentful/experiences-storybook-addon',
   ],
   framework: {
     name: '@storybook/react-vite',

--- a/packages/storybook-addon/README.md
+++ b/packages/storybook-addon/README.md
@@ -19,7 +19,7 @@ options translate to a different UI for their editors.
 ### Installation
 
 ```bash
-npm install @contentful/experience-builder-storybook-addon
+npm install @contentful/experiences-storybook-addon
 ```
 
 ### Enabling the Plugin
@@ -34,7 +34,7 @@ const config: StorybookConfig = {
   addons: [
     '@storybook/addon-links',
     '@storybook/addon-essentials',
-    '@contentful/experience-builder-storybook-addon', // <- add storybook plugin here
+    '@contentful/experiences-storybook-addon', // <- add storybook plugin here
   ],
   // ... additional config
 };

--- a/packages/storybook-addon/package.json
+++ b/packages/storybook-addon/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@contentful/experience-builder-storybook-addon",
-  "version": "0.0.2-alpha.26",
+  "name": "@contentful/experiences-storybook-addon",
+  "version": "0.0.1-alpha.25",
   "description": "Develop Contentful experience builder components with storybook",
   "keywords": [
     "storybook-addons",

--- a/packages/test-app/.storybook/main.ts
+++ b/packages/test-app/.storybook/main.ts
@@ -16,7 +16,7 @@ const config: StorybookConfig = {
     getAbsolutePath('@storybook/addon-essentials'),
     getAbsolutePath('@storybook/addon-onboarding'),
     getAbsolutePath('@storybook/addon-interactions'),
-    getAbsolutePath('@contentful/experience-builder-storybook-addon'),
+    getAbsolutePath('@contentful/experiences-storybook-addon'),
   ],
   framework: {
     name: getAbsolutePath('@storybook/react-vite'),

--- a/packages/test-app/package.json
+++ b/packages/test-app/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "@contentful/experience-builder": "file:../experience-builder-sdk",
     "@contentful/experiences-components-react": "file:../components",
-    "@contentful/experience-builder-storybook-addon": "file:../storybook-addon",
+    "@contentful/experiences-storybook-addon": "file:../storybook-addon",
     "contentful": "^10.6.14",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",


### PR DESCRIPTION
## Purpose
Rename experience builder sdk packages based on https://contentful.atlassian.net/wiki/spaces/PROD/pages/4480499829/Experience+Builder+package+rename+proposal

This PR in particular converts `experience-builder-storybook-addon` to `experiences-storybook-addon`

## Approach
Create feature branch called experience-release based on the development branch.
Ignored the `CHANGELOG.md` and `package-lock.json` files as those should be auto regenerated
