### PR TITLE
feat: Convert zod to contentful errors [SPA-1701]

### DIFF
--- a/packages/validators/package.json
+++ b/packages/validators/package.json
@@ -25,7 +25,8 @@
   "exports": {
     ".": {
       "import": "./dist/index.js",
-      "require": "./dist/index.js",
+      "require": "./dist/index.cjs",
+      "default": "./dist/index.js",
       "types": [
         "./dist/index.d.ts"
       ]

--- a/packages/validators/rollup.config.mjs
+++ b/packages/validators/rollup.config.mjs
@@ -1,18 +1,26 @@
 import { nodeResolve } from '@rollup/plugin-node-resolve';
 import typescript from '@rollup/plugin-typescript';
 import dts from 'rollup-plugin-dts';
+import commonjs from '@rollup/plugin-commonjs';
+
 export default [
   {
     input: 'src/index.ts',
     output: [
       {
-        dir: 'dist',
+        file: 'dist/index.js',
         format: 'esm',
+        sourcemap: true,
+      },
+      {
+        file: 'dist/index.cjs',
+        format: 'cjs',
         sourcemap: true,
       },
     ],
     plugins: [
       nodeResolve(),
+      commonjs(),
       typescript({ tsconfig: './tsconfig.json', noEmitOnError: process.env.DEV ? false : true })
     ],
     external: [/node_modules\/(?!tslib.*)/],

--- a/packages/validators/src/schemas/v2023_09_28/experience.ts
+++ b/packages/validators/src/schemas/v2023_09_28/experience.ts
@@ -6,7 +6,7 @@ const uuidKeySchema = z
   .regex(/^[a-zA-Z0-9-_]{1,21}$/, { message: 'Does not match /^[a-zA-Z0-9-_]{1,21}$/' });
 const propertyKeySchema = z
   .string()
-  .regex(/^[a-zA-Z0-9-_]{1,32}$/, { message: 'Does not match /^[a-zA-Z0-9-_]{1,21}$/' });
+  .regex(/^[a-zA-Z0-9-_]{1,32}$/, { message: 'Does not match /^[a-zA-Z0-9-_]{1,32}$/' });
 
 const DataSourceSchema = z.record(
   uuidKeySchema,
@@ -40,22 +40,30 @@ export const ComponentDefinitionPropertyTypeSchema = z.enum([
 
 const ValuesByBreakpointSchema = z.record(z.lazy(() => PrimitiveValueSchema));
 
-const DesignValueSchema = z.object({
-  type: z.literal('DesignValue'),
-  valuesByBreakpoint: ValuesByBreakpointSchema,
-});
-const BoundValueSchema = z.object({
-  type: z.literal('BoundValue'),
-  path: z.string(),
-});
-const UnboundValueSchema = z.object({
-  type: z.literal('UnboundValue'),
-  key: z.string(),
-});
-const ComponentValueSchema = z.object({
-  type: z.literal('ComponentValue'),
-  key: z.string(),
-});
+const DesignValueSchema = z
+  .object({
+    type: z.literal('DesignValue'),
+    valuesByBreakpoint: ValuesByBreakpointSchema,
+  })
+  .strict();
+const BoundValueSchema = z
+  .object({
+    type: z.literal('BoundValue'),
+    path: z.string(),
+  })
+  .strict();
+const UnboundValueSchema = z
+  .object({
+    type: z.literal('UnboundValue'),
+    key: z.string(),
+  })
+  .strict();
+const ComponentValueSchema = z
+  .object({
+    type: z.literal('ComponentValue'),
+    key: z.string(),
+  })
+  .strict();
 
 const ComponentPropertyValueSchema = z.union([
   DesignValueSchema,
@@ -66,12 +74,14 @@ const ComponentPropertyValueSchema = z.union([
 
 export type ComponentPropertyValue = z.infer<typeof ComponentPropertyValueSchema>;
 
-const BreakpointSchema = z.object({
-  id: propertyKeySchema,
-  query: z.string().regex(/^\*$|^<[0-9*]+px$/),
-  previewSize: z.string(),
-  displayName: z.string(),
-});
+const BreakpointSchema = z
+  .object({
+    id: propertyKeySchema,
+    query: z.string().regex(/^\*$|^<[0-9*]+px$/),
+    previewSize: z.string(),
+    displayName: z.string(),
+  })
+  .strict();
 
 const UnboundValuesSchema = z.record(
   uuidKeySchema,
@@ -134,7 +144,6 @@ const breakpointsRefinement = (value: Breakpoint[], ctx: z.RefinementCtx) => {
     ctx.addIssue({
       code: z.ZodIssueCode.custom,
       message: `The first breakpoint should include the following attributes: { "id": "desktop", "query": "*" }`,
-      path: [...ctx.path, 0],
     });
   }
   // Extract the queries boundary by removing the special characters around it
@@ -178,11 +187,13 @@ const componentSettingsRefinement = (value, ctx: z.RefinementCtx) => {
   }
 };
 
-const ComponentTreeSchema = z.object({
-  breakpoints: z.array(BreakpointSchema).superRefine(breakpointsRefinement),
-  children: z.array(ComponentTreeNodeSchema),
-  schemaVersion: SchemaVersions,
-});
+const ComponentTreeSchema = z
+  .object({
+    breakpoints: z.array(BreakpointSchema).superRefine(breakpointsRefinement),
+    children: z.array(ComponentTreeNodeSchema),
+    schemaVersion: SchemaVersions,
+  })
+  .strict();
 
 const localeWrapper = (fieldSchema: any) => z.record(z.string(), fieldSchema);
 

--- a/packages/validators/src/schemas/v2023_09_28/experience.ts
+++ b/packages/validators/src/schemas/v2023_09_28/experience.ts
@@ -16,7 +16,7 @@ const DataSourceSchema = z.record(
       id: z.string(),
       linkType: z.enum(['Entry', 'Asset']),
     }),
-  })
+  }),
 );
 
 const PrimitiveValueSchema = z.union([
@@ -65,7 +65,7 @@ const ComponentValueSchema = z
   })
   .strict();
 
-const ComponentPropertyValueSchema = z.union([
+const ComponentPropertyValueSchema = z.discriminatedUnion('type', [
   DesignValueSchema,
   BoundValueSchema,
   UnboundValueSchema,
@@ -87,7 +87,7 @@ const UnboundValuesSchema = z.record(
   uuidKeySchema,
   z.object({
     value: PrimitiveValueSchema,
-  })
+  }),
 );
 
 // Use helper schema to define a recursive schema with its type correctly below
@@ -120,12 +120,12 @@ const ComponentSettingsSchema = z.object({
               z.object({
                 value: z.union([z.string(), z.number()]),
                 displayName: z.string().optional(),
-              })
+              }),
             )
             .optional(),
         })
         .optional(),
-    })
+    }),
   ),
 });
 
@@ -136,7 +136,7 @@ const UsedComponentsSchema = z.array(
       id: z.string(),
       linkType: z.literal('Entry'),
     }),
-  })
+  }),
 );
 
 const breakpointsRefinement = (value: Breakpoint[], ctx: z.RefinementCtx) => {
@@ -148,7 +148,7 @@ const breakpointsRefinement = (value: Breakpoint[], ctx: z.RefinementCtx) => {
   }
   // Extract the queries boundary by removing the special characters around it
   const queries = value.map((bp) =>
-    bp.query === '*' ? bp.query : parseInt(bp.query.replace(/px|<|>/, ''))
+    bp.query === '*' ? bp.query : parseInt(bp.query.replace(/px|<|>/, '')),
   );
   // sort updates queries array in place so we need to create a copy
   const originalQueries = [...queries];

--- a/packages/validators/src/schemas/v2023_09_28/experience.ts
+++ b/packages/validators/src/schemas/v2023_09_28/experience.ts
@@ -1,8 +1,12 @@
 import { z } from 'zod';
 import { SchemaVersions } from '../schemaVersions';
 
-const uuidKeySchema = z.string().regex(/^[a-zA-Z0-9-_]{1,21}$/);
-const propertyKeySchema = z.string().regex(/^[a-zA-Z0-9-_]{1,32}$/);
+const uuidKeySchema = z
+  .string()
+  .regex(/^[a-zA-Z0-9-_]{1,21}$/, { message: 'Does not match /^[a-zA-Z0-9-_]{1,21}$/' });
+const propertyKeySchema = z
+  .string()
+  .regex(/^[a-zA-Z0-9-_]{1,32}$/, { message: 'Does not match /^[a-zA-Z0-9-_]{1,21}$/' });
 
 const DataSourceSchema = z.record(
   uuidKeySchema,
@@ -10,9 +14,9 @@ const DataSourceSchema = z.record(
     sys: z.object({
       type: z.literal('Link'),
       id: z.string(),
-      linkType: z.literal('Entry').or(z.literal('Asset')),
+      linkType: z.enum(['Entry', 'Asset']),
     }),
-  }),
+  })
 );
 
 const PrimitiveValueSchema = z.union([
@@ -73,7 +77,7 @@ const UnboundValuesSchema = z.record(
   uuidKeySchema,
   z.object({
     value: PrimitiveValueSchema,
-  }),
+  })
 );
 
 // Use helper schema to define a recursive schema with its type correctly below
@@ -106,12 +110,12 @@ const ComponentSettingsSchema = z.object({
               z.object({
                 value: z.union([z.string(), z.number()]),
                 displayName: z.string().optional(),
-              }),
+              })
             )
             .optional(),
         })
         .optional(),
-    }),
+    })
   ),
 });
 
@@ -122,7 +126,7 @@ const UsedComponentsSchema = z.array(
       id: z.string(),
       linkType: z.literal('Entry'),
     }),
-  }),
+  })
 );
 
 const breakpointsRefinement = (value: Breakpoint[], ctx: z.RefinementCtx) => {
@@ -135,7 +139,7 @@ const breakpointsRefinement = (value: Breakpoint[], ctx: z.RefinementCtx) => {
   }
   // Extract the queries boundary by removing the special characters around it
   const queries = value.map((bp) =>
-    bp.query === '*' ? bp.query : parseInt(bp.query.replace(/px|<|>/, '')),
+    bp.query === '*' ? bp.query : parseInt(bp.query.replace(/px|<|>/, ''))
   );
   // sort updates queries array in place so we need to create a copy
   const originalQueries = [...queries];

--- a/packages/validators/src/utils/zodToContentfulError.ts
+++ b/packages/validators/src/utils/zodToContentfulError.ts
@@ -1,6 +1,6 @@
 import { ZodIssueCode, ZodIssue, z } from 'zod';
 
-type ContentfulError = {
+export type ContentfulError = {
   details: string;
   min?: number | bigint;
   max?: number | bigint;

--- a/packages/validators/src/utils/zodToContentfulError.ts
+++ b/packages/validators/src/utils/zodToContentfulError.ts
@@ -1,0 +1,107 @@
+import { ZodIssueCode, ZodIssue, z } from 'zod';
+
+type ContentfulError = {
+  details: string;
+  min?: number | bigint;
+  max?: number | bigint;
+  name: string;
+  path: string[];
+  value?: string;
+  expected?: (string | number)[];
+};
+
+const convertInvalidType = (issue: z.ZodInvalidTypeIssue): ContentfulError => {
+  const name = issue.received === 'undefined' ? 'required' : 'type';
+  const details =
+    issue.received === 'undefined'
+      ? `The property "${issue.path.slice(-1)}" is required here`
+      : `The type of "${issue.path.slice(-1)}" is incorrect, expected type: ${issue.expected}`;
+
+  return {
+    details: details,
+    name: name,
+    path: issue.path.map(String),
+    value: issue.received.toString(),
+  };
+};
+
+const convertUnrecognizedKeys = (issue: z.ZodUnrecognizedKeysIssue): ContentfulError => {
+  return {
+    details: issue.message || `The properties ${issue.keys.join(', ')} are not expected`,
+    name: 'unexpected',
+    path: issue.path.map(String),
+  };
+};
+
+const convertInvalidString = (issue: z.ZodInvalidStringIssue): ContentfulError => {
+  return {
+    details: issue.message || '',
+    name: issue.validation === 'regex' ? 'regex' : 'unexpected',
+    path: issue.path.map(String),
+    value: issue.message || '',
+  };
+};
+const convertInvalidEnumValue = (issue: z.ZodInvalidEnumValueIssue): ContentfulError => {
+  return {
+    details: issue.message || 'Value must be one of expected values',
+    name: 'in',
+    path: issue.path.map(String),
+    value: issue.received.toString(),
+    expected: issue.options,
+  };
+};
+const convertInvalidLiteral = (issue: z.ZodInvalidLiteralIssue): ContentfulError => {
+  return {
+    details: issue.message || 'Value must be one of expected values',
+    name: 'in',
+    path: issue.path.map(String),
+    value: issue.received as string,
+    expected: [issue.expected as string],
+  };
+};
+
+const convertTooBig = (issue: z.ZodTooBigIssue): ContentfulError => {
+  return {
+    details: issue.message || `Size should be at most ${issue.maximum}`,
+    name: 'size',
+    path: issue.path.map(String),
+    max: issue.maximum,
+  };
+};
+
+const convertTooSmall = (issue: z.ZodTooSmallIssue): ContentfulError => {
+  return {
+    details: issue.message || `Size should be at least ${issue.minimum}`,
+    name: 'size',
+    path: issue.path.map(String),
+    min: issue.minimum,
+  };
+};
+const defaultConversion = (issue: ZodIssue): ContentfulError => {
+  return {
+    details: issue.message || 'An unexpected error occurred',
+    name: 'unexpected',
+    path: issue.path.map(String),
+  };
+};
+
+export const zodToContentfulError = (issue: ZodIssue): ContentfulError => {
+  switch (issue.code) {
+    case ZodIssueCode.invalid_type:
+      return convertInvalidType(issue);
+    case ZodIssueCode.unrecognized_keys:
+      return convertUnrecognizedKeys(issue);
+    case ZodIssueCode.invalid_enum_value:
+      return convertInvalidEnumValue(issue);
+    case ZodIssueCode.invalid_string:
+      return convertInvalidString(issue);
+    case ZodIssueCode.too_small:
+      return convertTooSmall(issue);
+    case ZodIssueCode.too_big:
+      return convertTooBig(issue);
+    case ZodIssueCode.invalid_literal:
+      return convertInvalidLiteral(issue);
+    default:
+      return defaultConversion(issue);
+  }
+};

--- a/packages/validators/src/utils/zodToContentfulError.ts
+++ b/packages/validators/src/utils/zodToContentfulError.ts
@@ -36,8 +36,12 @@ const convertInvalidType = (issue: z.ZodInvalidTypeIssue): ContentfulErrorDetail
 };
 
 const convertUnrecognizedKeys = (issue: z.ZodUnrecognizedKeysIssue): ContentfulErrorDetails => {
+  const missingProperties = issue.keys.map((k) => `"${k}"`).join(', ');
   return {
-    details: issue.message || `The properties ${issue.keys.join(', ')} are not expected`,
+    details:
+      issue.keys.length > 1
+        ? `The properties ${missingProperties} are not expected`
+        : `The property ${missingProperties} is not expected`,
     name: CodeNames.Unexpected,
     path: issue.path,
   };

--- a/packages/validators/test/utils/zodToContentfulError.spec.ts
+++ b/packages/validators/test/utils/zodToContentfulError.spec.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect } from 'vitest';
+import { zodToContentfulError } from '../../src/utils/zodToContentfulError';
+import { ZodInvalidStringIssue, ZodInvalidTypeIssue, ZodIssueCode } from 'zod';
+
+describe('zodToContentfulError', () => {
+  describe('ZodIssueCode.invalid_type', () => {
+    it('converts to name: type when type is mismatched', () => {
+      const issue = {
+        code: ZodIssueCode.invalid_type,
+        message: 'Expected string, received number',
+        path: ['fields', 'componentTree', 'schemaVersion'],
+        received: 'number' as const,
+        expected: 'string' as const,
+        unionErrors: ['number'],
+      };
+      const result = zodToContentfulError(issue);
+      expect(result).toEqual({
+        name: 'type',
+        path: ['fields', 'componentTree', 'schemaVersion'],
+        value: 'number',
+        details: 'The type of "schemaVersion" is incorrect, expected type: string',
+      });
+    });
+
+    it('converts to name: required when field is missing', () => {
+      const issue = {
+        code: ZodIssueCode.invalid_type,
+        message: 'Expected string, received number',
+        path: ['fields', 'componentTree', 'schemaVersion'],
+        received: 'undefined' as const,
+        expected: 'string' as const,
+        unionErrors: ['number'],
+      };
+      const result = zodToContentfulError(issue);
+      expect(result).toEqual({
+        name: 'required',
+        path: ['fields', 'componentTree', 'schemaVersion'],
+        value: 'undefined',
+        details: 'The property "schemaVersion" is required here',
+      });
+    });
+  });
+  describe('ZodIssueCode.invalid_string', () => {
+    it('converts to name: unexpected', () => {
+      const issue = {
+        code: ZodIssueCode.invalid_string,
+        message: 'Invalid string',
+        path: ['fields', 'componentTree', 'schemaVersion'],
+        validation: 'email' as const,
+      };
+      const result = zodToContentfulError(issue);
+      expect(result).toEqual({
+        name: 'unexpected',
+        path: ['fields', 'componentTree', 'schemaVersion'],
+        value: 'Invalid string',
+        details: 'Invalid string',
+      });
+    });
+    it("converts to name: regex if validation is 'regex'", () => {
+      const issue = {
+        code: ZodIssueCode.invalid_string,
+        message: 'Invalid string',
+        path: ['fields', 'componentTree', 'schemaVersion'],
+        validation: 'regex' as const,
+      };
+      const result = zodToContentfulError(issue);
+      expect(result).toEqual({
+        name: 'regex',
+        path: ['fields', 'componentTree', 'schemaVersion'],
+        value: 'Invalid string',
+        details: 'Invalid string',
+      });
+    });
+  });
+  describe('ZodIssueCode.too_big', () => {
+    it('converts to name: size', () => {
+      const issue = {
+        code: ZodIssueCode.too_big,
+        message: 'String must contain at most 32 character(s)',
+        path: ['fields', 'componentTree', 'schemaVersion'],
+        maximum: 32,
+        exact: false,
+        inclusive: true,
+        type: 'string' as const,
+      };
+      const result = zodToContentfulError(issue);
+      expect(result).toEqual({
+        name: 'size',
+        path: ['fields', 'componentTree', 'schemaVersion'],
+        details: 'String must contain at most 32 character(s)',
+        max: 32,
+      });
+    });
+  });
+  describe('ZodIssueCode.too_small', () => {
+    it('converts to name: size', () => {
+      const issue = {
+        code: ZodIssueCode.too_small,
+        message: 'String must contain at least 1 character(s)',
+        path: ['fields', 'componentTree', 'schemaVersion'],
+        minimum: 1,
+        exact: false,
+        inclusive: true,
+        type: 'string' as const,
+      };
+      const result = zodToContentfulError(issue);
+      expect(result).toEqual({
+        name: 'size',
+        path: ['fields', 'componentTree', 'schemaVersion'],
+        details: 'String must contain at least 1 character(s)',
+        min: 1,
+      });
+    });
+  });
+  describe('ZodIssueCode.invalid_enum_value', () => {
+    it('converts to name: in', () => {
+      const issue = {
+        code: ZodIssueCode.invalid_enum_value,
+        message: 'Value must be one of expected values',
+        path: ['fields', 'componentTree', 'schemaVersion'],
+        options: ['a', 'b', 'c'],
+        received: 'd',
+      };
+      const result = zodToContentfulError(issue);
+      expect(result).toEqual({
+        name: 'in',
+        path: ['fields', 'componentTree', 'schemaVersion'],
+        details: 'Value must be one of expected values',
+        expected: ['a', 'b', 'c'],
+        value: 'd',
+      });
+    });
+  });
+  describe('ZodIssueCode.invalid_literal', () => {
+    it('converts to name: in', () => {
+      const issue = {
+        code: ZodIssueCode.invalid_literal,
+        message: 'Value must be one of expected values',
+        path: ['fields', 'componentTree', 'schemaVersion'],
+        received: 'd',
+        expected: 'a',
+      };
+      const result = zodToContentfulError(issue);
+      expect(result).toEqual({
+        name: 'in',
+        path: ['fields', 'componentTree', 'schemaVersion'],
+        details: 'Value must be one of expected values',
+        expected: ['a'],
+        value: 'd',
+      });
+    });
+  });
+  describe('ZodIssueCode.unrecognized_keys', () => {
+    it('converts to name: unexpected', () => {
+      const issue = {
+        code: ZodIssueCode.unrecognized_keys,
+        message: 'The properties "a", "b", "c" are not expected',
+        path: ['fields', 'componentTree', 'schemaVersion'],
+        keys: ['a', 'b', 'c'],
+      };
+      const result = zodToContentfulError(issue);
+      expect(result).toEqual({
+        name: 'unexpected',
+        path: ['fields', 'componentTree', 'schemaVersion'],
+        details: 'The properties "a", "b", "c" are not expected',
+      });
+    });
+  });
+});

--- a/packages/validators/test/utils/zodToContentfulError.spec.ts
+++ b/packages/validators/test/utils/zodToContentfulError.spec.ts
@@ -52,7 +52,6 @@ describe('zodToContentfulError', () => {
       expect(result).toEqual({
         name: 'unexpected',
         path: ['fields', 'componentTree', 'schemaVersion'],
-        value: 'Invalid string',
         details: 'Invalid string',
       });
     });
@@ -67,7 +66,6 @@ describe('zodToContentfulError', () => {
       expect(result).toEqual({
         name: 'regex',
         path: ['fields', 'componentTree', 'schemaVersion'],
-        value: 'Invalid string',
         details: 'Invalid string',
       });
     });

--- a/packages/validators/test/v2023_09_28/componentSettings.spec.ts
+++ b/packages/validators/test/v2023_09_28/componentSettings.spec.ts
@@ -17,20 +17,17 @@ describe('componentSettings', () => {
         },
       },
     };
-    const result = validateExperienceFields(updatedPattern, schemaVersion) as SafeParseError<
-      typeof updatedPattern
-    >;
+    const result = validateExperienceFields(updatedPattern, schemaVersion);
 
     const expectedError = {
-      received: 'undefined',
-      code: 'invalid_type',
-      expected: 'object',
+      details: 'The property "variableDefinitions" is required here',
+      name: 'required',
       path: ['componentSettings', 'en-US', 'variableDefinitions'],
-      message: 'Required',
+      value: 'undefined',
     };
 
     expect(result.success).toBe(false);
-    expect(result.error.issues[0]).toEqual(expect.objectContaining(expectedError));
+    expect(result.errors).toEqual([expectedError]);
   });
 
   it('fails if variable definition is invalid', () => {
@@ -43,20 +40,17 @@ describe('componentSettings', () => {
         },
       },
     };
-    const result = validateExperienceFields(updatedPattern, schemaVersion) as SafeParseError<
-      typeof updatedPattern
-    >;
+    const result = validateExperienceFields(updatedPattern, schemaVersion);
 
     const expectedError = {
-      received: 'string',
-      code: 'invalid_type',
-      expected: 'object',
+      details: 'The type of "var1" is incorrect, expected type: object',
+      name: 'type',
       path: ['componentSettings', 'en-US', 'variableDefinitions', 'var1'],
-      message: 'Expected object, received string',
+      value: 'string',
     };
 
     expect(result.success).toBe(false);
-    expect(result.error.issues[0]).toEqual(expect.objectContaining(expectedError));
+    expect(result.errors).toEqual([expectedError]);
   });
 
   it('fails if variable definition key is longer than 54 characters', () => {
@@ -65,23 +59,20 @@ describe('componentSettings', () => {
       fields: {
         ...experience.fields,
         componentSettings: {
-          [locale]: { variableDefinitions: { ['variable1'.repeat(7)]: 'invalid' } },
+          [locale]: { variableDefinitions: { ['variable1'.repeat(7)]: {} } },
         },
       },
     };
-    const result = validateExperienceFields(updatedPattern, schemaVersion) as SafeParseError<
-      typeof updatedPattern
-    >;
+    const result = validateExperienceFields(updatedPattern, schemaVersion);
 
     const expectedError = {
-      code: 'invalid_string',
-      validation: 'regex',
+      details: 'Invalid',
+      name: 'regex',
       path: ['componentSettings', 'en-US', 'variableDefinitions', 'variable1'.repeat(7)],
-      message: 'Invalid',
     };
 
     expect(result.success).toBe(false);
-    expect(result.error.issues[0]).toEqual(expect.objectContaining(expectedError));
+    expect(result.errors?.[0]).toEqual(expectedError);
   });
 
   it('fails if componentSettings is used in conjuction with usedComponents', () => {
@@ -95,18 +86,16 @@ describe('componentSettings', () => {
       },
     };
 
-    const result = validateExperienceFields(updatedPattern, schemaVersion) as SafeParseError<
-      typeof updatedPattern
-    >;
+    const result = validateExperienceFields(updatedPattern, schemaVersion);
 
     const expectedError = {
-      code: 'custom',
-      message:
+      name: 'custom',
+      details:
         "'componentSettings' field cannot be used in conjunction with 'usedComponents' field",
       path: ['componentSettings', 'en-US'],
     };
 
     expect(result.success).toBe(false);
-    expect(result.error.issues[0]).toEqual(expect.objectContaining(expectedError));
+    expect(result.errors).toEqual([expectedError]);
   });
 });

--- a/packages/validators/test/v2023_09_28/componentTree.spec.ts
+++ b/packages/validators/test/v2023_09_28/componentTree.spec.ts
@@ -17,12 +17,13 @@ describe('componentTree', () => {
           componentTree: { [locale]: { ...componentTree, breakpoints: undefined } },
         },
       };
-      const result = validateExperienceFields(updatedExperience, schemaVersion) as SafeParseError<
-        typeof updatedExperience
-      >;
+      const result = validateExperienceFields(updatedExperience, schemaVersion);
 
       expect(result.success).toBe(false);
-      expect(result.error.issues[0].message).toBe('Required');
+      const error = result.errors?.[0];
+
+      expect(error?.name).toBe('required');
+      expect(error?.details).toBe(`The property "breakpoints" is required here`);
     });
 
     it(`fails if breakpoints is empty`, () => {
@@ -34,18 +35,20 @@ describe('componentTree', () => {
           componentTree: { [locale]: { ...componentTree, breakpoints: [] } },
         },
       };
-      const result = validateExperienceFields(updatedExperience, schemaVersion) as SafeParseError<
-        typeof updatedExperience
-      >;
+      const result = validateExperienceFields(updatedExperience, schemaVersion);
 
       expect(result.success).toBe(false);
-      expect(result.error.issues[0].message).toBe(
+      const error = result.errors?.[0];
+
+      expect(result.success).toBe(false);
+      expect(error?.name).toBe('custom');
+      expect(error?.details).toBe(
         'The first breakpoint should include the following attributes: { "id": "desktop", "query": "*" }'
       );
     });
 
     it(`fails if any breakpoint attribute is missing`, () => {
-      const breakpoint = { invalidAttribute: 'invalid' };
+      const breakpoint = {};
       const componentTree = experience.fields.componentTree[locale];
       const updatedExperience = {
         ...experience,
@@ -54,22 +57,49 @@ describe('componentTree', () => {
           componentTree: { [locale]: { ...componentTree, breakpoints: [breakpoint] } },
         },
       };
-      const result = validateExperienceFields(updatedExperience, schemaVersion) as SafeParseError<
-        typeof updatedExperience
-      >;
+      const result = validateExperienceFields(updatedExperience, schemaVersion);
 
       expect(result.success).toBe(false);
       const expectedErrors = ['id', 'query', 'previewSize', 'displayName'].map(
         (breakpointField) => ({
-          code: 'invalid_type',
-          expected: 'string',
-          received: 'undefined',
+          name: 'required',
+          value: 'undefined',
           path: ['componentTree', 'en-US', 'breakpoints', 0, breakpointField],
-          message: 'Required',
+          details: `The property "${breakpointField}" is required here`,
         })
       );
 
-      expect(result.error.issues).toEqual(expectedErrors);
+      expect(result.success).toBe(false);
+      expect(result.errors).toEqual(expectedErrors);
+    });
+
+    it(`fails if any breakpoint includes unexpected attribute`, () => {
+      const breakpoint = {
+        id: 'desktop',
+        query: '*',
+        previewSize: 'large',
+        displayName: 'Desktop',
+        extraAttr: 'unrecognised',
+      };
+      const componentTree = experience.fields.componentTree[locale];
+      const updatedExperience = {
+        ...experience,
+        fields: {
+          ...experience.fields,
+          componentTree: { [locale]: { ...componentTree, breakpoints: [breakpoint] } },
+        },
+      };
+      const result = validateExperienceFields(updatedExperience, schemaVersion);
+
+      expect(result.success).toBe(false);
+      const expectedErrors = {
+        name: 'unexpected',
+        path: ['componentTree', 'en-US', 'breakpoints', 0],
+        details: "Unrecognized key(s) in object: 'extraAttr'",
+      };
+
+      expect(result.success).toBe(false);
+      expect(result.errors).toEqual([expectedErrors]);
     });
 
     it(`fails if desktop breakpoint is not first in the list`, () => {
@@ -86,14 +116,23 @@ describe('componentTree', () => {
           componentTree: { [locale]: { ...componentTree, breakpoints } },
         },
       };
-      const result = validateExperienceFields(updatedExperience, schemaVersion) as SafeParseError<
-        typeof updatedExperience
-      >;
+      const result = validateExperienceFields(updatedExperience, schemaVersion);
 
+      const expectedErrors = [
+        {
+          details:
+            'The first breakpoint should include the following attributes: { "id": "desktop", "query": "*" }',
+          name: 'custom',
+          path: ['componentTree', 'en-US', 'breakpoints'],
+        },
+        {
+          details: 'Breakpoints should be ordered from largest to smallest pixel value',
+          name: 'custom',
+          path: ['componentTree', 'en-US', 'breakpoints'],
+        },
+      ];
       expect(result.success).toBe(false);
-      expect(result.error.issues[0].message).toBe(
-        'The first breakpoint should include the following attributes: { "id": "desktop", "query": "*" }'
-      );
+      expect(result.errors).toEqual(expectedErrors);
     });
 
     it(`fails if breakpoints are not ordered from largest to smallest`, () => {
@@ -110,12 +149,14 @@ describe('componentTree', () => {
           componentTree: { [locale]: { ...componentTree, breakpoints } },
         },
       };
-      const result = validateExperienceFields(updatedExperience, schemaVersion) as SafeParseError<
-        typeof updatedExperience
-      >;
+      const result = validateExperienceFields(updatedExperience, schemaVersion);
 
       expect(result.success).toBe(false);
-      expect(result.error.issues[0].message).toBe(
+      const error = result.errors?.[0];
+
+      expect(result.success).toBe(false);
+      expect(error?.name).toBe('custom');
+      expect(error?.details).toBe(
         'Breakpoints should be ordered from largest to smallest pixel value'
       );
     });
@@ -131,13 +172,33 @@ describe('componentTree', () => {
           componentTree: { [locale]: { ...componentTree, schemaVersion: undefined } },
         },
       };
-      const result = validateExperienceFields(updatedExperience, schemaVersion) as SafeParseError<
-        typeof updatedExperience
-      >;
+      const result = validateExperienceFields(updatedExperience);
 
       expect(result.success).toBe(false);
-      expect(result.error.issues[0].message).toBe('Invalid input');
+      const error = result.errors?.[0];
+      console.log(result.errors);
+
+      expect(result.success).toBe(false);
+      expect(error?.name).toBe('required');
+      expect(error?.details).toBe('The property "schemaVersion" is required here');
     });
+  });
+  it(`fails if unrecognised attribute is provided`, () => {
+    const componentTree = experience.fields.componentTree[locale];
+    const updatedExperience = {
+      ...experience,
+      fields: {
+        ...experience.fields,
+        componentTree: { [locale]: { ...componentTree, extraAttr: 'unrecognised' } },
+      },
+    };
+    const result = validateExperienceFields(updatedExperience, schemaVersion);
+
+    expect(result.success).toBe(false);
+    const error = result.errors?.[0];
+    expect(result.success).toBe(false);
+    expect(error?.name).toBe('unexpected');
+    expect(error?.details).toBe("Unrecognized key(s) in object: 'extraAttr'");
   });
 
   describe('children', () => {
@@ -150,12 +211,14 @@ describe('componentTree', () => {
           componentTree: { [locale]: { ...componentTree, children: {} } },
         },
       };
-      const result = validateExperienceFields(updatedExperience, schemaVersion) as SafeParseError<
-        typeof updatedExperience
-      >;
+      const result = validateExperienceFields(updatedExperience, schemaVersion);
 
       expect(result.success).toBe(false);
-      expect(result.error.issues[0].message).toBe('Expected array, received object');
+      const error = result.errors?.[0];
+      expect(result.success).toBe(false);
+      expect(error?.name).toBe('type');
+      expect(error?.path).toEqual(['componentTree', 'en-US', 'children']);
+      expect(error?.details).toBe('The type of "children" is incorrect, expected type: array');
     });
 
     it.each([
@@ -178,19 +241,16 @@ describe('componentTree', () => {
           componentTree: { [locale]: { ...componentTree, children: [child] } },
         },
       };
-      const result = validateExperienceFields(updatedExperience, schemaVersion) as SafeParseError<
-        typeof updatedExperience
-      >;
+      const result = validateExperienceFields(updatedExperience, schemaVersion);
 
       const expectedError = {
-        code: 'invalid_type',
-        expected: type,
-        received: 'undefined',
+        name: 'required',
+        value: 'undefined',
         path: ['componentTree', 'en-US', 'children', 0, attribute],
-        message: 'Required',
+        details: `The property "${attribute}" is required here`,
       };
       expect(result.success).toBe(false);
-      expect(result.error.issues[0]).toEqual(expectedError);
+      expect(result.errors).toEqual([expectedError]);
     });
 
     describe('variables name', () => {
@@ -199,7 +259,7 @@ describe('componentTree', () => {
         const child = {
           definitionId: 'test',
           variables: {
-            ['text&^:']: { type: 'DesignValue', value: 'test' },
+            ['text&^:']: { type: 'DesignValue', valuesByBreakpoint: { desktop: 'bold' } },
           },
           children: [],
         };
@@ -211,25 +271,22 @@ describe('componentTree', () => {
           },
         };
 
-        const result = validateExperienceFields(updatedExperience, schemaVersion) as SafeParseError<
-          typeof updatedExperience
-        >;
+        const result = validateExperienceFields(updatedExperience, schemaVersion);
 
         const expectedError = {
-          code: 'invalid_string',
+          name: 'regex',
           path: ['componentTree', 'en-US', 'children', 0, 'variables', 'text&^:'],
-          message: 'Does not match /^[a-zA-Z0-9-_]{1,21}$/',
-          validation: 'regex',
+          details: 'Does not match /^[a-zA-Z0-9-_]{1,32}$/',
         };
         expect(result.success).toBe(false);
-        expect(result.error.issues[0] as ZodInvalidUnionIssue).toEqual(expectedError);
+        expect(result.errors).toEqual([expectedError]);
       });
       it(`fails if name exceeds the allowed 32 character limit`, () => {
         const componentTree = experience.fields.componentTree[locale];
         const child = {
           definitionId: 'test',
           variables: {
-            ['text'.repeat(10)]: { type: 'DesignValue', value: 'test' },
+            ['text'.repeat(10)]: { type: 'UnboundValue', key: 'test' },
           },
           children: [],
         };
@@ -241,18 +298,15 @@ describe('componentTree', () => {
           },
         };
 
-        const result = validateExperienceFields(updatedExperience, schemaVersion) as SafeParseError<
-          typeof updatedExperience
-        >;
+        const result = validateExperienceFields(updatedExperience, schemaVersion);
 
         const expectedError = {
-          code: 'invalid_string',
+          name: 'regex',
           path: ['componentTree', 'en-US', 'children', 0, 'variables', 'text'.repeat(10)],
-          message: 'Does not match /^[a-zA-Z0-9-_]{1,21}$/',
-          validation: 'regex',
+          details: 'Does not match /^[a-zA-Z0-9-_]{1,32}$/',
         };
         expect(result.success).toBe(false);
-        expect(result.error.issues[0] as ZodInvalidUnionIssue).toEqual(expectedError);
+        expect(result.errors).toEqual([expectedError]);
       });
     });
 
@@ -276,10 +330,7 @@ describe('componentTree', () => {
             },
           };
 
-          const result = validateExperienceFields(
-            updatedExperience,
-            schemaVersion
-          ) as SafeParseError<typeof updatedExperience>;
+          const result = validateExperienceFields(updatedExperience, schemaVersion);
 
           const expectedError = {
             code: 'invalid_type',
@@ -297,9 +348,7 @@ describe('componentTree', () => {
             message: 'Required',
           };
           expect(result.success).toBe(false);
-          expect((result.error.issues[0] as ZodInvalidUnionIssue).unionErrors[0].issues[0]).toEqual(
-            expectedError
-          );
+          expect(result.errors).toEqual([expectedError]);
         });
       });
       describe('BoundValue', () => {
@@ -322,10 +371,7 @@ describe('componentTree', () => {
             },
           };
 
-          const result = validateExperienceFields(
-            updatedExperience,
-            schemaVersion
-          ) as SafeParseError<typeof updatedExperience>;
+          const result = validateExperienceFields(updatedExperience, schemaVersion);
 
           const expectedError = {
             code: 'invalid_type',
@@ -335,9 +381,7 @@ describe('componentTree', () => {
             message: 'Required',
           };
           expect(result.success).toBe(false);
-          expect((result.error.issues[0] as ZodInvalidUnionIssue).unionErrors[1].issues[0]).toEqual(
-            expectedError
-          );
+          expect(result.errors).toEqual([expectedError]);
         });
       });
       describe('UnboundValue', () => {
@@ -360,10 +404,7 @@ describe('componentTree', () => {
             },
           };
 
-          const result = validateExperienceFields(
-            updatedExperience,
-            schemaVersion
-          ) as SafeParseError<typeof updatedExperience>;
+          const result = validateExperienceFields(updatedExperience, schemaVersion);
 
           const expectedError = {
             code: 'invalid_type',
@@ -373,9 +414,7 @@ describe('componentTree', () => {
             message: 'Required',
           };
           expect(result.success).toBe(false);
-          expect((result.error.issues[0] as ZodInvalidUnionIssue).unionErrors[2].issues[0]).toEqual(
-            expectedError
-          );
+          expect(result.errors).toEqual([expectedError]);
         });
       });
       describe('ComponentValue', () => {
@@ -398,10 +437,7 @@ describe('componentTree', () => {
             },
           };
 
-          const result = validateExperienceFields(
-            updatedExperience,
-            schemaVersion
-          ) as SafeParseError<typeof updatedExperience>;
+          const result = validateExperienceFields(updatedExperience, schemaVersion);
 
           const expectedError = {
             code: 'invalid_type',
@@ -411,9 +447,7 @@ describe('componentTree', () => {
             message: 'Required',
           };
           expect(result.success).toBe(false);
-          expect((result.error.issues[0] as ZodInvalidUnionIssue).unionErrors[3].issues[0]).toEqual(
-            expectedError
-          );
+          expect(result.errors).toEqual([expectedError]);
         });
       });
     });

--- a/packages/validators/test/v2023_09_28/componentTree.spec.ts
+++ b/packages/validators/test/v2023_09_28/componentTree.spec.ts
@@ -40,7 +40,7 @@ describe('componentTree', () => {
 
       expect(result.success).toBe(false);
       expect(result.error.issues[0].message).toBe(
-        'The first breakpoint should include the following attributes: { "id": "desktop", "query": "*" }',
+        'The first breakpoint should include the following attributes: { "id": "desktop", "query": "*" }'
       );
     });
 
@@ -66,7 +66,7 @@ describe('componentTree', () => {
           received: 'undefined',
           path: ['componentTree', 'en-US', 'breakpoints', 0, breakpointField],
           message: 'Required',
-        }),
+        })
       );
 
       expect(result.error.issues).toEqual(expectedErrors);
@@ -92,7 +92,7 @@ describe('componentTree', () => {
 
       expect(result.success).toBe(false);
       expect(result.error.issues[0].message).toBe(
-        'The first breakpoint should include the following attributes: { "id": "desktop", "query": "*" }',
+        'The first breakpoint should include the following attributes: { "id": "desktop", "query": "*" }'
       );
     });
 
@@ -116,7 +116,7 @@ describe('componentTree', () => {
 
       expect(result.success).toBe(false);
       expect(result.error.issues[0].message).toBe(
-        'Breakpoints should be ordered from largest to smallest pixel value',
+        'Breakpoints should be ordered from largest to smallest pixel value'
       );
     });
   });
@@ -218,7 +218,7 @@ describe('componentTree', () => {
         const expectedError = {
           code: 'invalid_string',
           path: ['componentTree', 'en-US', 'children', 0, 'variables', 'text&^:'],
-          message: 'Invalid',
+          message: 'Does not match /^[a-zA-Z0-9-_]{1,21}$/',
           validation: 'regex',
         };
         expect(result.success).toBe(false);
@@ -248,7 +248,7 @@ describe('componentTree', () => {
         const expectedError = {
           code: 'invalid_string',
           path: ['componentTree', 'en-US', 'children', 0, 'variables', 'text'.repeat(10)],
-          message: 'Invalid',
+          message: 'Does not match /^[a-zA-Z0-9-_]{1,21}$/',
           validation: 'regex',
         };
         expect(result.success).toBe(false);
@@ -278,7 +278,7 @@ describe('componentTree', () => {
 
           const result = validateExperienceFields(
             updatedExperience,
-            schemaVersion,
+            schemaVersion
           ) as SafeParseError<typeof updatedExperience>;
 
           const expectedError = {
@@ -298,7 +298,7 @@ describe('componentTree', () => {
           };
           expect(result.success).toBe(false);
           expect((result.error.issues[0] as ZodInvalidUnionIssue).unionErrors[0].issues[0]).toEqual(
-            expectedError,
+            expectedError
           );
         });
       });
@@ -324,7 +324,7 @@ describe('componentTree', () => {
 
           const result = validateExperienceFields(
             updatedExperience,
-            schemaVersion,
+            schemaVersion
           ) as SafeParseError<typeof updatedExperience>;
 
           const expectedError = {
@@ -336,7 +336,7 @@ describe('componentTree', () => {
           };
           expect(result.success).toBe(false);
           expect((result.error.issues[0] as ZodInvalidUnionIssue).unionErrors[1].issues[0]).toEqual(
-            expectedError,
+            expectedError
           );
         });
       });
@@ -362,7 +362,7 @@ describe('componentTree', () => {
 
           const result = validateExperienceFields(
             updatedExperience,
-            schemaVersion,
+            schemaVersion
           ) as SafeParseError<typeof updatedExperience>;
 
           const expectedError = {
@@ -374,7 +374,7 @@ describe('componentTree', () => {
           };
           expect(result.success).toBe(false);
           expect((result.error.issues[0] as ZodInvalidUnionIssue).unionErrors[2].issues[0]).toEqual(
-            expectedError,
+            expectedError
           );
         });
       });
@@ -400,7 +400,7 @@ describe('componentTree', () => {
 
           const result = validateExperienceFields(
             updatedExperience,
-            schemaVersion,
+            schemaVersion
           ) as SafeParseError<typeof updatedExperience>;
 
           const expectedError = {
@@ -412,7 +412,7 @@ describe('componentTree', () => {
           };
           expect(result.success).toBe(false);
           expect((result.error.issues[0] as ZodInvalidUnionIssue).unionErrors[3].issues[0]).toEqual(
-            expectedError,
+            expectedError
           );
         });
       });

--- a/packages/validators/test/v2023_09_28/componentTree.spec.ts
+++ b/packages/validators/test/v2023_09_28/componentTree.spec.ts
@@ -43,7 +43,7 @@ describe('componentTree', () => {
       expect(result.success).toBe(false);
       expect(error?.name).toBe('custom');
       expect(error?.details).toBe(
-        'The first breakpoint should include the following attributes: { "id": "desktop", "query": "*" }'
+        'The first breakpoint should include the following attributes: { "id": "desktop", "query": "*" }',
       );
     });
 
@@ -66,7 +66,7 @@ describe('componentTree', () => {
           value: 'undefined',
           path: ['componentTree', 'en-US', 'breakpoints', 0, breakpointField],
           details: `The property "${breakpointField}" is required here`,
-        })
+        }),
       );
 
       expect(result.success).toBe(false);
@@ -157,7 +157,7 @@ describe('componentTree', () => {
       expect(result.success).toBe(false);
       expect(error?.name).toBe('custom');
       expect(error?.details).toBe(
-        'Breakpoints should be ordered from largest to smallest pixel value'
+        'Breakpoints should be ordered from largest to smallest pixel value',
       );
     });
   });
@@ -333,9 +333,8 @@ describe('componentTree', () => {
           const result = validateExperienceFields(updatedExperience, schemaVersion);
 
           const expectedError = {
-            code: 'invalid_type',
-            expected: 'object',
-            received: 'undefined',
+            details: 'The property "valuesByBreakpoint" is required here',
+            name: 'required',
             path: [
               'componentTree',
               'en-US',
@@ -345,7 +344,7 @@ describe('componentTree', () => {
               'text',
               'valuesByBreakpoint',
             ],
-            message: 'Required',
+            value: 'undefined',
           };
           expect(result.success).toBe(false);
           expect(result.errors).toEqual([expectedError]);
@@ -374,11 +373,10 @@ describe('componentTree', () => {
           const result = validateExperienceFields(updatedExperience, schemaVersion);
 
           const expectedError = {
-            code: 'invalid_type',
-            expected: 'string',
-            received: 'undefined',
+            details: 'The property "path" is required here',
+            name: 'required',
             path: ['componentTree', 'en-US', 'children', 0, 'variables', 'text', 'path'],
-            message: 'Required',
+            value: 'undefined',
           };
           expect(result.success).toBe(false);
           expect(result.errors).toEqual([expectedError]);
@@ -407,11 +405,10 @@ describe('componentTree', () => {
           const result = validateExperienceFields(updatedExperience, schemaVersion);
 
           const expectedError = {
-            code: 'invalid_type',
-            expected: 'string',
-            received: 'undefined',
+            details: 'The property "key" is required here',
+            name: 'required',
             path: ['componentTree', 'en-US', 'children', 0, 'variables', 'text', 'key'],
-            message: 'Required',
+            value: 'undefined',
           };
           expect(result.success).toBe(false);
           expect(result.errors).toEqual([expectedError]);
@@ -440,11 +437,10 @@ describe('componentTree', () => {
           const result = validateExperienceFields(updatedExperience, schemaVersion);
 
           const expectedError = {
-            code: 'invalid_type',
-            expected: 'string',
-            received: 'undefined',
+            details: 'The property "key" is required here',
+            name: 'required',
             path: ['componentTree', 'en-US', 'children', 0, 'variables', 'text', 'key'],
-            message: 'Required',
+            value: 'undefined',
           };
           expect(result.success).toBe(false);
           expect(result.errors).toEqual([expectedError]);

--- a/packages/validators/test/v2023_09_28/componentTree.spec.ts
+++ b/packages/validators/test/v2023_09_28/componentTree.spec.ts
@@ -95,7 +95,7 @@ describe('componentTree', () => {
       const expectedErrors = {
         name: 'unexpected',
         path: ['componentTree', 'en-US', 'breakpoints', 0],
-        details: "Unrecognized key(s) in object: 'extraAttr'",
+        details: 'The property "extraAttr" is not expected',
       };
 
       expect(result.success).toBe(false);
@@ -198,7 +198,7 @@ describe('componentTree', () => {
     const error = result.errors?.[0];
     expect(result.success).toBe(false);
     expect(error?.name).toBe('unexpected');
-    expect(error?.details).toBe("Unrecognized key(s) in object: 'extraAttr'");
+    expect(error?.details).toBe('The property "extraAttr" is not expected');
   });
 
   describe('children', () => {

--- a/packages/validators/test/v2023_09_28/dataSource.spec.ts
+++ b/packages/validators/test/v2023_09_28/dataSource.spec.ts
@@ -1,7 +1,6 @@
 import { validateExperienceFields } from '../../src/validators';
 import { experience } from '../__fixtures__/v2023_09_28';
 import { describe, it, expect } from 'vitest';
-import { SafeParseError, ZodInvalidUnionIssue } from 'zod';
 
 const schemaVersion = '2023-09-28' as const;
 const locale = 'en-US';
@@ -15,12 +14,16 @@ describe('dataSource', () => {
         dataSource: { [locale]: [] },
       },
     };
-    const result = validateExperienceFields(updatedExperience, schemaVersion) as SafeParseError<
-      typeof updatedExperience
-    >;
+    const result = validateExperienceFields(updatedExperience, schemaVersion);
 
     expect(result.success).toBe(false);
-    expect(result.error.issues[0].message).toBe('Expected object, received array');
+    const expectedError = {
+      name: 'type',
+      value: 'array',
+      path: ['dataSource', 'en-US'],
+      details: 'The type of "en-US" is incorrect, expected type: object',
+    };
+    expect(result.errors).toEqual([expectedError]);
   });
 
   it('fails if value is not an object', () => {
@@ -31,19 +34,16 @@ describe('dataSource', () => {
         dataSource: { [locale]: { uuid1: 'invalidValue' } },
       },
     };
-    const result = validateExperienceFields(updatedExperience, schemaVersion) as SafeParseError<
-      typeof updatedExperience
-    >;
+    const result = validateExperienceFields(updatedExperience, schemaVersion);
 
     const expectedError = {
-      code: 'invalid_type',
-      expected: 'object',
-      received: 'string',
+      name: 'type',
+      value: 'string',
       path: ['dataSource', 'en-US', 'uuid1'],
-      message: 'Expected object, received string',
+      details: 'The type of "uuid1" is incorrect, expected type: object',
     };
     expect(result.success).toBe(false);
-    expect(result.error.issues[0]).toEqual(expect.objectContaining(expectedError));
+    expect(result.errors).toEqual([expectedError]);
   });
 
   it('fails if key is longer than 21 characters', () => {
@@ -51,21 +51,18 @@ describe('dataSource', () => {
       ...experience,
       fields: {
         ...experience.fields,
-        dataSource: { [locale]: { ['uuid1'.repeat(5)]: 'invalidValue' } },
+        dataSource: { [locale]: { ['uuid1'.repeat(5)]: {} } },
       },
     };
-    const result = validateExperienceFields(updatedExperience, schemaVersion) as SafeParseError<
-      typeof updatedExperience
-    >;
+    const result = validateExperienceFields(updatedExperience, schemaVersion);
 
     const expectedError = {
-      code: 'invalid_string',
+      name: 'regex',
       path: ['dataSource', 'en-US', 'uuid1'.repeat(5)],
-      message: 'Does not match /^[a-zA-Z0-9-_]{1,21}$/',
-      validation: 'regex',
+      details: 'Does not match /^[a-zA-Z0-9-_]{1,21}$/',
     };
     expect(result.success).toBe(false);
-    expect(result.error.issues[0]).toEqual(expect.objectContaining(expectedError));
+    expect(result.errors?.[0]).toEqual(expectedError);
   });
 
   it('fails if key contains invalid characters', () => {
@@ -78,18 +75,15 @@ describe('dataSource', () => {
         },
       },
     };
-    const result = validateExperienceFields(updatedExperience, schemaVersion) as SafeParseError<
-      typeof updatedExperience
-    >;
+    const result = validateExperienceFields(updatedExperience, schemaVersion);
 
     const expectedError = {
-      code: 'invalid_string',
+      name: 'regex',
       path: ['dataSource', 'en-US', 'uuid1!$*'],
-      message: 'Does not match /^[a-zA-Z0-9-_]{1,21}$/',
-      validation: 'regex',
+      details: 'Does not match /^[a-zA-Z0-9-_]{1,21}$/',
     };
     expect(result.success).toBe(false);
-    expect(result.error.issues[0]).toEqual(expect.objectContaining(expectedError));
+    expect(result.errors?.[0]).toEqual(expectedError);
   });
 
   it('fails if value is an invalid link', () => {
@@ -102,18 +96,16 @@ describe('dataSource', () => {
         },
       },
     };
-    const result = validateExperienceFields(updatedExperience, schemaVersion) as SafeParseError<
-      typeof updatedExperience
-    >;
+    const result = validateExperienceFields(updatedExperience, schemaVersion);
 
     const expectedError = {
-      code: 'invalid_enum_value',
+      name: 'in',
+      expected: ['Entry', 'Asset'],
       path: ['dataSource', 'en-US', 'uuid1', 'sys', 'linkType'],
-      message: "Invalid enum value. Expected 'Entry' | 'Asset', received 'Invalid'",
-      options: ['Entry', 'Asset'],
+      details: "Invalid enum value. Expected 'Entry' | 'Asset', received 'Invalid'",
+      value: 'Invalid',
     };
-
     expect(result.success).toBe(false);
-    expect(result.error.issues[0]).toEqual(expect.objectContaining(expectedError));
+    expect(result.errors?.[0]).toEqual(expectedError);
   });
 });

--- a/packages/validators/test/v2023_09_28/experienceValidator.spec.ts
+++ b/packages/validators/test/v2023_09_28/experienceValidator.spec.ts
@@ -11,29 +11,31 @@ describe(`${schemaVersion} version`, () => {
   it.each(requiredFields)('should return an error if "%s" field is missing', (field) => {
     const { [field]: _, ...rest } = experience.fields;
     const updatedExperience = { ...experience, fields: rest };
-    const result = validateExperienceFields(updatedExperience, schemaVersion) as SafeParseError<
-      typeof updatedExperience
-    >;
+    const result = validateExperienceFields(updatedExperience, schemaVersion);
 
     expect(result.success).toBe(false);
-    expect(result.error.issues[0].message).toBe('Required');
+    expect(result.errors).toBeDefined();
+    const error = result.errors?.[0];
+
+    expect(error?.name).toBe('required');
+    expect(error?.details).toBe(`The property "${field}" is required here`);
   });
 
   it('should validate the experience successfully', () => {
-    const result = validateExperienceFields(experience, schemaVersion) as SafeParseSuccess<
-      typeof experience
-    >;
+    const result = validateExperienceFields(experience, schemaVersion);
 
     expect(result.success).toBe(true);
-    expect(result.data).not.toBeUndefined();
   });
 
   it('should validate the pattern successfully', () => {
-    const result = validateExperienceFields(experiencePattern, schemaVersion) as SafeParseSuccess<
-      typeof experiencePattern
-    >;
+    const result = validateExperienceFields(experiencePattern, schemaVersion);
 
     expect(result.success).toBe(true);
-    expect(result.data).not.toBeUndefined();
+  });
+
+  it('should read the schema version from the componentTree if no override is provided', () => {
+    const result = validateExperienceFields(experiencePattern);
+
+    expect(result.success).toBe(true);
   });
 });

--- a/packages/validators/test/v2023_09_28/unboundValues.spec.ts
+++ b/packages/validators/test/v2023_09_28/unboundValues.spec.ts
@@ -1,7 +1,6 @@
 import { validateExperienceFields } from '../../src/validators';
 import { experience } from '../__fixtures__/v2023_09_28';
 import { describe, it, expect } from 'vitest';
-import { SafeParseError } from 'zod';
 
 const schemaVersion = '2023-09-28' as const;
 const locale = 'en-US';
@@ -15,12 +14,16 @@ describe('unboundValues', () => {
         unboundValues: { [locale]: [] },
       },
     };
-    const result = validateExperienceFields(updatedExperience, schemaVersion) as SafeParseError<
-      typeof updatedExperience
-    >;
+    const result = validateExperienceFields(updatedExperience, schemaVersion);
 
     expect(result.success).toBe(false);
-    expect(result.error.issues[0].message).toBe('Expected object, received array');
+    const expectedError = {
+      name: 'type',
+      value: 'array',
+      path: ['unboundValues', 'en-US'],
+      details: 'The type of "en-US" is incorrect, expected type: object',
+    };
+    expect(result.errors).toEqual([expectedError]);
   });
 
   it('fails if value is not an object', () => {
@@ -31,11 +34,15 @@ describe('unboundValues', () => {
         unboundValues: { [locale]: { uuid1: 'invalidValue' } },
       },
     };
-    const result = validateExperienceFields(updatedExperience, schemaVersion) as SafeParseError<
-      typeof updatedExperience
-    >;
+    const result = validateExperienceFields(updatedExperience, schemaVersion);
 
     expect(result.success).toBe(false);
-    expect(result.error.issues[0].message).toBe('Expected object, received string');
+    const expectedError = {
+      name: 'type',
+      value: 'string',
+      path: ['unboundValues', 'en-US', 'uuid1'],
+      details: 'The type of "uuid1" is incorrect, expected type: object',
+    };
+    expect(result.errors).toEqual([expectedError]);
   });
 });

--- a/packages/validators/test/v2023_09_28/usedComponents.spec.ts
+++ b/packages/validators/test/v2023_09_28/usedComponents.spec.ts
@@ -1,7 +1,6 @@
 import { validateExperienceFields } from '../../src/validators';
 import { experience } from '../__fixtures__/v2023_09_28';
 import { describe, it, expect } from 'vitest';
-import { SafeParseError } from 'zod';
 
 const schemaVersion = '2023-09-28' as const;
 const locale = 'en-US';
@@ -17,19 +16,17 @@ describe('usedComponents', () => {
         },
       },
     };
-    const result = validateExperienceFields(updatedExperience, schemaVersion) as SafeParseError<
-      typeof updatedExperience
-    >;
+    const result = validateExperienceFields(updatedExperience, schemaVersion);
 
     const expectedError = {
-      received: 'Invalid',
-      code: 'invalid_literal',
-      expected: 'Entry',
+      name: 'in',
+      expected: ['Entry'],
       path: ['usedComponents', 'en-US', 0, 'sys', 'linkType'],
-      message: 'Invalid literal value, expected "Entry"',
+      details: 'Invalid literal value, expected "Entry"',
+      value: 'Invalid',
     };
 
     expect(result.success).toBe(false);
-    expect(result.error.issues[0]).toEqual(expect.objectContaining(expectedError));
+    expect(result.errors).toEqual([expectedError]);
   });
 });

--- a/packages/validators/test/validator.spec.ts
+++ b/packages/validators/test/validator.spec.ts
@@ -1,25 +1,21 @@
 import { validateExperienceFields } from '../src/validators';
 import { experience } from './__fixtures__/v2023_09_28/experience';
 import { describe, it, expect } from 'vitest';
-import { SafeParseError, SafeParseSuccess } from 'zod';
 
 describe('validateExperienceFields', () => {
   it('should return an error if schemaVersion is unsupported', () => {
     //@ts-expect-error - Testing invalid version
-    const result = validateExperienceFields(experience, 'invalid-version') as SafeParseError<
-      typeof experience
-    >;
+    const result = validateExperienceFields(experience, 'invalid-version');
 
     expect(result.success).toBe(false);
-    expect(result.error.issues[0].message).toBe('Unsupported schema version');
+    expect(result.errors?.[0].name).toBe('in');
+    expect(result.errors?.[0].expected).toEqual(['2023-09-28']);
+    expect(result.errors?.[0].details).toBe('Unsupported schema version');
   });
 
   it('should validate the experience successfully', () => {
-    const result = validateExperienceFields(experience, '2023-09-28') as SafeParseSuccess<
-      typeof experience
-    >;
+    const result = validateExperienceFields(experience, '2023-09-28');
 
     expect(result.success).toBe(true);
-    expect(result.data).not.toBeUndefined();
   });
 });


### PR DESCRIPTION
## Purpose

Create mapping between zod errors and contentful errors. Also updated the test to check for the new format. For the mapping I am following closely what we're doing for Ajv error mapping [here](https://github.com/contentful/content-stack/blob/master/packages/errors/lib/ajv-to-contentful-error/index.js).

Now the validator function returns a list of errors in the format expected in our management API.

See also https://github.com/contentful/content_api/pull/9359 that integrates this validator into CMA.

In addition this PR includes a couple smaller changes:
* Compile the source code to commonJS format as content_api doesn't work with ESM.
* Don't rely on the caller to provide the schema version, but read it from the experience itself.
* Add `strict` option in a some of the schema to avoid unexpected keys
* Switch ComponentPropertyValueSchema to discriminatedUnion for clearer error messages.

## Approach

<!--

Three important notes on Pull Requests:
- In general, you should ask yourself whether this code change will improve or worsen the overall code quality. Any new tech debt will probably never be cleaned up.
- Please remember that newly introduced logic should be validated and protected through testing.
- Take a look at PR guides such as Google's [Google’s Code Review Guidelines](https://google.github.io/eng-practices/) and [Blockly - Writing a Good Pull Request](https://developers.google.com/blockly/guides/contribute/get-started/write_a_good_pr)

-->
