### PR TITLE
fix: updating dev branch after release []

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -70,9 +70,10 @@ jobs:
             git push origin
             git checkout development
             git rebase next
-            git push origin
+            git push origin -f
           elif [ ${{ github.ref_name }} = next ]; then
             git checkout development
             git rebase next
-            git push origin
+            # Someone might have merged something into development in the meanwhile. This avoid the error: "the tip of your current branch is behind"
+            git push origin -f
           fi

--- a/package-lock.json
+++ b/package-lock.json
@@ -2616,6 +2616,7 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
The release pipeline recently failed with [this error](https://github.com/contentful/experience-builder/actions/runs/7933196824/job/21662811162). I compared the commit history of both branches but couldn't find the reason for that. Maybe, it's related to using different merge strategies on our PRs?
However, this ensure that these two branches don't get out of sync.