### PR TITLE
fix: increase property key length []

### DIFF
--- a/packages/validators/src/schemas/v2023_09_28/experience.ts
+++ b/packages/validators/src/schemas/v2023_09_28/experience.ts
@@ -4,9 +4,15 @@ import { SchemaVersions } from '../schemaVersions';
 const uuidKeySchema = z
   .string()
   .regex(/^[a-zA-Z0-9-_]{1,21}$/, { message: 'Does not match /^[a-zA-Z0-9-_]{1,21}$/' });
+
+/**
+ * Property keys for imported components have a limit of 32 characters (to be implemented) while
+ * property keys for patterns have a limit of 54 characters (<32-char-variabl-name>_<21-char-nanoid-id>).
+ * Because we cannot distinguish between the two in the componentTree, we will use the larger limit for both.
+ */
 const propertyKeySchema = z
   .string()
-  .regex(/^[a-zA-Z0-9-_]{1,32}$/, { message: 'Does not match /^[a-zA-Z0-9-_]{1,32}$/' });
+  .regex(/^[a-zA-Z0-9-_]{1,54}$/, { message: 'Does not match /^[a-zA-Z0-9-_]{1,54}$/' });
 
 const DataSourceSchema = z.record(
   uuidKeySchema,

--- a/packages/validators/test/v2023_09_28/componentTree.spec.ts
+++ b/packages/validators/test/v2023_09_28/componentTree.spec.ts
@@ -276,17 +276,17 @@ describe('componentTree', () => {
         const expectedError = {
           name: 'regex',
           path: ['componentTree', 'en-US', 'children', 0, 'variables', 'text&^:'],
-          details: 'Does not match /^[a-zA-Z0-9-_]{1,32}$/',
+          details: 'Does not match /^[a-zA-Z0-9-_]{1,54}$/',
         };
         expect(result.success).toBe(false);
         expect(result.errors).toEqual([expectedError]);
       });
-      it(`fails if name exceeds the allowed 32 character limit`, () => {
+      it(`fails if name exceeds the allowed 54 character limit`, () => {
         const componentTree = experience.fields.componentTree[locale];
         const child = {
           definitionId: 'test',
           variables: {
-            ['text'.repeat(10)]: { type: 'UnboundValue', key: 'test' },
+            ['text'.repeat(20)]: { type: 'UnboundValue', key: 'test' },
           },
           children: [],
         };
@@ -302,8 +302,8 @@ describe('componentTree', () => {
 
         const expectedError = {
           name: 'regex',
-          path: ['componentTree', 'en-US', 'children', 0, 'variables', 'text'.repeat(10)],
-          details: 'Does not match /^[a-zA-Z0-9-_]{1,32}$/',
+          path: ['componentTree', 'en-US', 'children', 0, 'variables', 'text'.repeat(20)],
+          details: 'Does not match /^[a-zA-Z0-9-_]{1,54}$/',
         };
         expect(result.success).toBe(false);
         expect(result.errors).toEqual([expectedError]);


### PR DESCRIPTION
## Purpose

Property keys for imported components have a limit of 32 characters (to be implemented) while property keys for patterns have a limit of 54 characters (<32-char-variable-name>_<21-char-nanoid-id>). Because we cannot distinguish between the two in the componentTree, we will use the larger limit for both.

Note: we should reconsider how we create the property keys for patterns to align with imported components, this is a quick fix to unblock the validations work.


## Approach

<!--

Three important notes on Pull Requests:
- In general, you should ask yourself whether this code change will improve or worsen the overall code quality. Any new tech debt will probably never be cleaned up.
- Please remember that newly introduced logic should be validated and protected through testing.
- Take a look at PR guides such as Google's [Google’s Code Review Guidelines](https://google.github.io/eng-practices/) and [Blockly - Writing a Good Pull Request](https://developers.google.com/blockly/guides/contribute/get-started/write_a_good_pr)

-->
