### PR TITLE
fix: revise built-in component thumbnail urls [ALT-459]

### DIFF
--- a/packages/components/src/components/Button/index.ts
+++ b/packages/components/src/components/Button/index.ts
@@ -21,7 +21,6 @@ export const ButtonComponentDefinition: ComponentDefinition = {
     'cfLineHeight',
     'cfBorder',
   ],
-  thumbnailUrl: constants.thumbnails.button,
   variables: {
     cfFontSize: {
       displayName: 'Font Size',

--- a/packages/components/src/components/Button/index.ts
+++ b/packages/components/src/components/Button/index.ts
@@ -3,7 +3,6 @@ import {
   CONTENTFUL_COMPONENTS,
   CONTENTFUL_DEFAULT_CATEGORY,
 } from '@contentful/experience-builder-core/constants';
-import { constants } from '@/utils/constants';
 
 export * from './Button';
 

--- a/packages/components/src/components/Heading/index.ts
+++ b/packages/components/src/components/Heading/index.ts
@@ -26,7 +26,6 @@ export const HeadingComponentDefinition: ComponentDefinition = {
     'cfBackgroundColor',
     'cfBorder',
   ],
-  thumbnailUrl: constants.thumbnails.heading,
   variables: {
     // Built-in style variables with default values changed
     cfHeight: {

--- a/packages/components/src/components/Heading/index.ts
+++ b/packages/components/src/components/Heading/index.ts
@@ -3,7 +3,6 @@ import {
   CONTENTFUL_COMPONENTS,
   CONTENTFUL_DEFAULT_CATEGORY,
 } from '@contentful/experience-builder-core/constants';
-import { constants } from '@/utils/constants';
 
 export * from './Heading';
 

--- a/packages/components/src/components/Image/Image.cy.tsx
+++ b/packages/components/src/components/Image/Image.cy.tsx
@@ -1,11 +1,11 @@
-import { constants } from '@/utils/constants';
+import { placeholderImage } from '@/utils/constants';
 import { Image } from './Image';
 import React from 'react';
 
 describe('Image', () => {
   it('mounts', () => {
-    cy.mount(<Image src={constants.placeholderImage} />);
-    cy.get('img').invoke('attr', 'src').should('eq', constants.placeholderImage);
+    cy.mount(<Image src={placeholderImage} />);
+    cy.get('img').invoke('attr', 'src').should('eq', placeholderImage);
   });
 
   it('renders null when no src specified', () => {
@@ -14,22 +14,22 @@ describe('Image', () => {
   });
 
   it('renders at the proper width', () => {
-    cy.mount(<Image src={constants.placeholderImage} width={300} />);
+    cy.mount(<Image src={placeholderImage} width={300} />);
     cy.get('img').invoke('attr', 'width').should('eq', '300');
   });
 
   it('additional props should be passed to the image', () => {
-    cy.mount(<Image src={constants.placeholderImage} data-foo="bar" />);
+    cy.mount(<Image src={placeholderImage} data-foo="bar" />);
     cy.get('img').should('have.attr', 'data-foo', 'bar');
   });
 
   it('when className is provided, it should be added to the image', () => {
-    cy.mount(<Image src={constants.placeholderImage} className="custom-class" />);
+    cy.mount(<Image src={placeholderImage} className="custom-class" />);
     cy.get('img').should('have.class', 'custom-class');
   });
 
   it('has a default class of "cf-image"', () => {
-    cy.mount(<Image src={constants.placeholderImage} />);
+    cy.mount(<Image src={placeholderImage} />);
     cy.get('img').should('have.class', 'cf-image');
   });
 });

--- a/packages/components/src/components/Image/Image.stories.ts
+++ b/packages/components/src/components/Image/Image.stories.ts
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { constants } from '@/utils/constants';
+import { placeholderImage } from '@/utils/constants';
 import { Image, ImageComponentDefinition } from '.';
 
 // More on how to set up stories at: https://storybook.js.org/docs/react/writing-stories/introduction#default-export
@@ -23,7 +23,7 @@ type Story = StoryObj<typeof meta>;
 // More on writing stories with args: https://storybook.js.org/docs/react/writing-stories/args
 export const Default: Story = {
   args: {
-    src: constants.placeholderImage,
+    src: placeholderImage,
     width: 300,
   },
 };

--- a/packages/components/src/components/Image/index.ts
+++ b/packages/components/src/components/Image/index.ts
@@ -3,7 +3,7 @@ import {
   CONTENTFUL_COMPONENTS,
   CONTENTFUL_DEFAULT_CATEGORY,
 } from '@contentful/experience-builder-core/constants';
-import { constants } from '@/utils/constants';
+import { placeholderImage } from '@/utils/constants';
 
 export * from './Image';
 
@@ -12,7 +12,6 @@ export const ImageComponentDefinition: ComponentDefinition = {
   name: CONTENTFUL_COMPONENTS.image.name,
   category: CONTENTFUL_DEFAULT_CATEGORY,
   builtInStyles: ['cfMargin', 'cfPadding'],
-  thumbnailUrl: constants.thumbnails.image,
   variables: {
     alt: {
       displayName: 'Alt',
@@ -21,7 +20,7 @@ export const ImageComponentDefinition: ComponentDefinition = {
     src: {
       displayName: 'Image Src',
       type: 'Text',
-      defaultValue: constants.placeholderImage,
+      defaultValue: placeholderImage,
     },
     width: {
       displayName: 'Width',

--- a/packages/components/src/components/RichText/index.ts
+++ b/packages/components/src/components/RichText/index.ts
@@ -21,7 +21,6 @@ export const RichTextComponentDefinition: ComponentDefinition = {
     'cfBackgroundColor',
     'cfBorder',
   ],
-  thumbnailUrl: constants.thumbnails.richText,
   variables: {
     // Built-in style variables with default values changed
     cfLineHeight: {

--- a/packages/components/src/components/RichText/index.ts
+++ b/packages/components/src/components/RichText/index.ts
@@ -3,7 +3,6 @@ import {
   CONTENTFUL_COMPONENTS,
   CONTENTFUL_DEFAULT_CATEGORY,
 } from '@contentful/experience-builder-core/constants';
-import { constants } from '@/utils/constants';
 
 export * from './RichText';
 

--- a/packages/components/src/components/Text/index.ts
+++ b/packages/components/src/components/Text/index.ts
@@ -29,7 +29,6 @@ export const TextComponentDefinition: ComponentDefinition = {
     'cfWidth',
     'cfMaxWidth',
   ],
-  thumbnailUrl: constants.thumbnails.text,
   variables: {
     cfHeight: {
       displayName: 'Height',

--- a/packages/components/src/components/Text/index.ts
+++ b/packages/components/src/components/Text/index.ts
@@ -3,7 +3,6 @@ import {
   CONTENTFUL_COMPONENTS,
   CONTENTFUL_DEFAULT_CATEGORY,
 } from '@contentful/experience-builder-core/constants';
-import { constants } from '@/utils/constants';
 
 export * from './Text';
 

--- a/packages/components/src/utils/constants.ts
+++ b/packages/components/src/utils/constants.ts
@@ -1,19 +1,2 @@
-export const constants = {
-  placeholderImage:
-    'https://images.ctfassets.net/tofsejyzyo24/5owPX1vp6cXDZr7QOabwzT/d5580f5b4dbad3f74c87ce2f03efa581/Image_container.png',
-  thumbnails: {
-    button:
-      'https://images.ctfassets.net/tofsejyzyo24/7nSWHngZyMLp1kwp3uaIsL/d3b647f41e20f510644677dedd587cbb/button.png',
-    heading:
-      'https://images.ctfassets.net/tofsejyzyo24/3Q9azSMiVYtDD9Ra58HWv1/929cdcb67c10238f41ed7c97f9dfe101/heading.png',
-    image:
-      'https://images.ctfassets.net/tofsejyzyo24/3Svf1pYdVrhfYqKc8JT0Eb/055214f105b00658ccb3e3a17ca71656/image.png',
-    text: 'https://images.ctfassets.net/tofsejyzyo24/2k8kqqPRaLGX7a1Vo97mPb/8a5c1b5b4770e3ca49d6b808b563a305/text.png',
-    richText:
-      'https://images.ctfassets.net/tofsejyzyo24/7HIFYGzHZDN0CwQnz9EmzW/629d0d4580517395f1d1f8237d136e43/rich_text.png',
-    infoBlock:
-      'https://images.ctfassets.net/tofsejyzyo24/6DRBAjZUN4L2hwIkV4uM50/81e0a3a27fbada0c20f3420031ca85e5/info_block.png',
-    duplex:
-      'https://images.ctfassets.net/tofsejyzyo24/7cOHx0p0J1gUCFMPcoXnFg/73144735e3db345b101509bf707a56b1/Duplex.png',
-  },
-};
+export const placeholderImage =
+  'https://images.ctfassets.net/tofsejyzyo24/5owPX1vp6cXDZr7QOabwzT/d5580f5b4dbad3f74c87ce2f03efa581/Image_container.png';


### PR DESCRIPTION
## Purpose

Clean up old references to thumbnail URL icons for built-in components.

New component icons are being implemented in the UI code via https://github.com/contentful/user_interface/pull/19882