### PR TITLE
chore: add .npmrc file to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ yarn-debug.log*
 yarn-error.log*
 pnpm-debug.log*
 lerna-debug.log*
+.npmrc
 
 node_modules
 build

--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,0 @@
-//npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}
-@contentful:registry=https://npm.pkg.github.com


### PR DESCRIPTION
Git ignores a previously committed .npmrc file, which had a registry reference to install @contentful namespace packages from github. This would cause an issue for users outside of CTFL that don't have access to CTFL github packages and could accidentally install packages from github packages that were meant to be installed from npm.