### PR TITLE
fix: hide overflowing content []

### DIFF
--- a/packages/visual-editor/src/components/Draggable/styles.module.css
+++ b/packages/visual-editor/src/components/Draggable/styles.module.css
@@ -7,6 +7,8 @@
   outline: 2px solid transparent;
   box-sizing: border-box;
   display: flex;
+  /* Especially, avoid horizontal overflow as this breaks the overall canvas scrolling */
+  overflow: hidden;
 }
 
 .DraggableComponent > * {


### PR DESCRIPTION
## Purpose

Reproduction steps:
- create columns, switch the right column to fill 3 out of 12 grid columns.
- Put two elements inside the right column and align them horizontally
- Give the first of the two elements `100px` margin on the left and right side

This will "push" the second element outside the column and thus overflow the overall editor canvas.

When trying to scroll horizontally anywhere in the canvas, the user would first scroll some (wrong) wrapper in the DOM tree and then, on the second try, scroll the whole editor canvas as expected.

## Approach

I described the bug and the solution in this Loom recording:
https://www.loom.com/share/e20358b7423f4846816ba6c1e406082a?sid=8a9e1e95-8725-4b92-805b-10f88da9a77b

You can also read the AI-generated summary:
> In this Loom, I discovered a specific bug related to the column layout. When arranging elements within columns, I encountered an issue where the margin of one element was pushing another element out of view. This caused scrolling to be cumbersome and required multiple attempts to scroll. I found a fix by applying overflow hidden to the draggable component. This bug only affects the editor mode and does not impact the preview. Please watch the Loom for more details.