### PR TITLE
Update display names to Background image and Background color [ALT-460]

### DIFF
--- a/packages/components/src/components/Button/index.ts
+++ b/packages/components/src/components/Button/index.ts
@@ -43,7 +43,7 @@ export const ButtonComponentDefinition: ComponentDefinition = {
       defaultValue: 'rgba(255, 255, 255, 1)',
     },
     cfBackgroundColor: {
-      displayName: 'Background Color',
+      displayName: 'Background color',
       type: 'Text',
       group: 'style',
       description: 'The background color of the button.',

--- a/packages/core/src/definitions/styles.ts
+++ b/packages/core/src/definitions/styles.ts
@@ -64,7 +64,7 @@ export const builtInStyles: Partial<
     defaultValue: '0 0 0 0',
   },
   cfBackgroundColor: {
-    displayName: 'Background',
+    displayName: 'Background color',
     type: 'Text',
     group: 'style',
     description: 'The background color of the section',
@@ -120,13 +120,13 @@ export const builtInStyles: Partial<
     defaultValue: '0px',
   },
   cfBackgroundImageUrl: {
-    displayName: 'Background Image',
+    displayName: 'Background image',
     type: 'Text',
     defaultValue: '',
     description: 'Background image for section or container',
   },
   cfBackgroundImageScaling: {
-    displayName: 'Image Scaling',
+    displayName: 'Image scaling',
     type: 'Text',
     group: 'style',
     description: 'Adjust background image to fit, fill or tile the container',
@@ -149,7 +149,7 @@ export const builtInStyles: Partial<
     },
   },
   cfBackgroundImageAlignment: {
-    displayName: 'Image Alignment',
+    displayName: 'Image alignment',
     type: 'Text',
     group: 'style',
     description: 'Align background image to the edges of the container',
@@ -376,7 +376,7 @@ export const singleColumnBuiltInStyles: Partial<
     defaultValue: '0 0 0 0',
   },
   cfBackgroundColor: {
-    displayName: 'Background',
+    displayName: 'Background color',
     type: 'Text',
     group: 'style',
     description: 'The background color of the column',
@@ -411,13 +411,13 @@ export const singleColumnBuiltInStyles: Partial<
     defaultValue: '0px',
   },
   cfBackgroundImageUrl: {
-    displayName: 'Background Image',
+    displayName: 'Background image',
     type: 'Text',
     defaultValue: '',
     description: 'Background image for section or container',
   },
   cfBackgroundImageScaling: {
-    displayName: 'Image Scaling',
+    displayName: 'Image scaling',
     type: 'Text',
     group: 'style',
     description: 'Adjust background image to fit, fill or tile the column',
@@ -440,7 +440,7 @@ export const singleColumnBuiltInStyles: Partial<
     },
   },
   cfBackgroundImageAlignment: {
-    displayName: 'Image Alignment',
+    displayName: 'Image alignment',
     type: 'Text',
     group: 'style',
     description: 'Align background image to the edges of the column',
@@ -490,7 +490,7 @@ export const columnsBuiltInStyles: Partial<
     defaultValue: '10px 10px 10px 10px',
   },
   cfBackgroundColor: {
-    displayName: 'Background',
+    displayName: 'Background color',
     type: 'Text',
     group: 'style',
     description: 'The background color of the columns',
@@ -504,7 +504,7 @@ export const columnsBuiltInStyles: Partial<
     defaultValue: '1px solid rgba(0, 0, 0, 0)',
   },
   cfBackgroundImageUrl: {
-    displayName: 'Background Image',
+    displayName: 'Background image',
     type: 'Text',
     defaultValue: '',
     description: 'Background image for section or container',
@@ -517,7 +517,7 @@ export const columnsBuiltInStyles: Partial<
     defaultValue: '10px 10px',
   },
   cfBackgroundImageScaling: {
-    displayName: 'Image Scaling',
+    displayName: 'Image scaling',
     type: 'Text',
     group: 'style',
     description: 'Adjust background image to fit, fill or tile the columns',
@@ -540,7 +540,7 @@ export const columnsBuiltInStyles: Partial<
     },
   },
   cfBackgroundImageAlignment: {
-    displayName: 'Image Alignment',
+    displayName: 'Image alignment',
     type: 'Text',
     group: 'style',
     description: 'Align background image to the edges of the columns',

--- a/packages/storybook-addon/src/components/StyleSectionComponents/BackgroundImage/BackgroundImageInput.tsx
+++ b/packages/storybook-addon/src/components/StyleSectionComponents/BackgroundImage/BackgroundImageInput.tsx
@@ -27,7 +27,7 @@ export const BackgroundImageInput = ({
   return (
     <Flex flexDirection="column">
       <Text color="gray500" fontWeight="fontWeightNormal" className={styles.label}>
-        Background Image
+        Background image
       </Text>
       <Flex flexDirection="column" gap="spacingS">
         {!!backgroundImageScaling && (

--- a/packages/storybook-addon/src/utils/variables.ts
+++ b/packages/storybook-addon/src/utils/variables.ts
@@ -68,7 +68,7 @@ export const builtInStyles: Record<
     defaultValue: '0px',
   },
   cfBackgroundColor: {
-    displayName: 'Background',
+    displayName: 'Background color',
     type: 'Text',
     group: 'style',
     description: 'The background color of the section',
@@ -124,13 +124,13 @@ export const builtInStyles: Record<
     defaultValue: '0px',
   },
   cfBackgroundImageUrl: {
-    displayName: 'Background Image',
+    displayName: 'Background image',
     type: 'Text',
     defaultValue: '',
     description: 'Background image for section or container',
   },
   cfBackgroundImageScaling: {
-    displayName: 'Image Scaling',
+    displayName: 'Image scaling',
     type: 'Text',
     group: 'style',
     description: 'Adjust background image to fit, fill or tile the container',
@@ -153,7 +153,7 @@ export const builtInStyles: Record<
     },
   },
   cfBackgroundImageAlignment: {
-    displayName: 'Image Alignment',
+    displayName: 'Image alignment',
     type: 'Text',
     group: 'style',
     description: 'Align background image to the edges of the container',

--- a/packages/validators/test/__fixtures__/v2023_09_28/experiencePattern.ts
+++ b/packages/validators/test/__fixtures__/v2023_09_28/experiencePattern.ts
@@ -290,7 +290,7 @@ export const experiencePattern = {
       'en-US': {
         variableDefinitions: {
           cfBackgroundImageUrl_AtBrirchNbwfpkWlSfTD6: {
-            displayName: 'Background Image',
+            displayName: 'Background image',
             type: 'Text',
             defaultValue: {
               key: '36j5IQjr3FKEQ4Yvyd034',


### PR DESCRIPTION
## Purpose
Ensure we have the display name to be Background image, Background color, Image scaling, and Image alignment

<img width="344" alt="Screenshot 2024-02-27 at 10 11 41 AM" src="https://github.com/contentful/experience-builder/assets/124832189/15326f13-8918-4fe0-865b-15849420b531">
<img width="1445" alt="Screenshot 2024-02-27 at 10 11 31 AM" src="https://github.com/contentful/experience-builder/assets/124832189/9c85a1cd-5d64-4af7-9dee-046a23fed895">
<img width="385" alt="Screenshot 2024-02-27 at 10 11 47 AM" src="https://github.com/contentful/experience-builder/assets/124832189/e896b22e-c170-4714-9c22-248f09245ddd">
