### PR TITLE
fix(canvas-interactions): prevent draggables from flying off mouse cursor

### DIFF
--- a/packages/visual-editor/src/components/Dropzone/Dropzone.tsx
+++ b/packages/visual-editor/src/components/Dropzone/Dropzone.tsx
@@ -81,6 +81,7 @@ export function Dropzone({
           zoneId={node.data.id}
           node={node}
           resolveDesignValue={resolveDesignValue}
+          renderDropzone={renderClonedDropzone}
           {...props}
         />
       );

--- a/packages/visual-editor/src/components/Dropzone/Dropzone.tsx
+++ b/packages/visual-editor/src/components/Dropzone/Dropzone.tsx
@@ -18,6 +18,8 @@ import {
   CONTENTFUL_COMPONENTS,
 } from '@contentful/experience-builder-core/constants';
 import { RenderDropzoneFunction } from './Dropzone.types';
+import { EditorBlockClone } from './EditorBlockClone';
+import { DropzoneClone } from './DropzoneClone';
 
 type DropzoneProps = {
   zoneId: string;
@@ -71,6 +73,20 @@ export function Dropzone({
     },
     [resolveDesignValue],
   );
+  // To avoid a circular dependency, we create the recursive rendering function here and trickle it down
+  const renderClonedDropzone: RenderDropzoneFunction = useCallback(
+    (node, props) => {
+      return (
+        <DropzoneClone
+          zoneId={node.data.id}
+          node={node}
+          resolveDesignValue={resolveDesignValue}
+          {...props}
+        />
+      );
+    },
+    [resolveDesignValue],
+  );
 
   if (!resolveDesignValue) {
     return null;
@@ -99,7 +115,19 @@ export function Dropzone({
   };
 
   return (
-    <Droppable droppableId={zoneId} direction={direction} isDropDisabled={!isDropzoneEnabled()}>
+    <Droppable
+      droppableId={zoneId}
+      direction={direction}
+      isDropDisabled={!isDropzoneEnabled()}
+      renderClone={(provided, snapshot, rubic) => (
+        <EditorBlockClone
+          node={content[rubic.source.index]}
+          resolveDesignValue={resolveDesignValue}
+          provided={provided}
+          snapshot={snapshot}
+          renderDropzone={renderClonedDropzone}
+        />
+      )}>
       {(provided, snapshot) => {
         return (
           <WrapperComponent

--- a/packages/visual-editor/src/components/Dropzone/Dropzone.tsx
+++ b/packages/visual-editor/src/components/Dropzone/Dropzone.tsx
@@ -73,7 +73,7 @@ export function Dropzone({
     },
     [resolveDesignValue],
   );
-  // To avoid a circular dependency, we create the recursive rendering function here and trickle it down
+
   const renderClonedDropzone: RenderDropzoneFunction = useCallback(
     (node, props) => {
       return (

--- a/packages/visual-editor/src/components/Dropzone/DropzoneClone.tsx
+++ b/packages/visual-editor/src/components/Dropzone/DropzoneClone.tsx
@@ -1,0 +1,78 @@
+import React, { ElementType, useCallback } from 'react';
+import type { ResolveDesignValueType } from '@contentful/experience-builder-core/types';
+import { ComponentData } from '@/types/Config';
+import { useTreeStore } from '@/store/tree';
+import styles from './styles.module.css';
+import classNames from 'classnames';
+import { ROOT_ID } from '@/types/constants';
+
+import { RenderDropzoneFunction } from './Dropzone.types';
+import { EditorBlockClone } from './EditorBlockClone';
+
+type DropzoneProps = {
+  zoneId: string;
+  node?: ComponentData;
+  resolveDesignValue?: ResolveDesignValueType;
+  className?: string;
+  WrapperComponent?: ElementType | string;
+};
+
+export function DropzoneClone({
+  node,
+  zoneId,
+  resolveDesignValue,
+  className,
+  WrapperComponent = 'div',
+  ...rest
+}: DropzoneProps) {
+  const tree = useTreeStore((state) => state.tree);
+  const content = node?.children || tree.root?.children || [];
+
+  const isRootZone = zoneId === ROOT_ID;
+
+  // To avoid a circular dependency, we create the recursive rendering function here and trickle it down
+  const renderClonedDropzone: RenderDropzoneFunction = useCallback(
+    (node, props) => {
+      return (
+        <DropzoneClone
+          zoneId={node.data.id}
+          node={node}
+          resolveDesignValue={resolveDesignValue}
+          {...props}
+        />
+      );
+    },
+    [resolveDesignValue],
+  );
+
+  if (!resolveDesignValue) {
+    return null;
+  }
+
+  return (
+    <WrapperComponent
+      className={classNames(
+        styles.container,
+        {
+          [styles.isRoot]: isRootZone,
+          [styles.isEmptyZone]: !content.length,
+        },
+        className,
+      )}
+      node={node}
+      {...rest}>
+      {content.map((item) => {
+        const componentId = item.data.id;
+
+        return (
+          <EditorBlockClone
+            key={componentId}
+            node={item}
+            resolveDesignValue={resolveDesignValue}
+            renderDropzone={renderClonedDropzone}
+          />
+        );
+      })}
+    </WrapperComponent>
+  );
+}

--- a/packages/visual-editor/src/components/Dropzone/DropzoneClone.tsx
+++ b/packages/visual-editor/src/components/Dropzone/DropzoneClone.tsx
@@ -1,4 +1,4 @@
-import React, { ElementType, useCallback } from 'react';
+import React, { ElementType } from 'react';
 import type { ResolveDesignValueType } from '@contentful/experience-builder-core/types';
 import { ComponentData } from '@/types/Config';
 import { useTreeStore } from '@/store/tree';
@@ -15,6 +15,7 @@ type DropzoneProps = {
   resolveDesignValue?: ResolveDesignValueType;
   className?: string;
   WrapperComponent?: ElementType | string;
+  renderDropzone: RenderDropzoneFunction;
 };
 
 export function DropzoneClone({
@@ -23,27 +24,13 @@ export function DropzoneClone({
   resolveDesignValue,
   className,
   WrapperComponent = 'div',
+  renderDropzone,
   ...rest
 }: DropzoneProps) {
   const tree = useTreeStore((state) => state.tree);
   const content = node?.children || tree.root?.children || [];
 
   const isRootZone = zoneId === ROOT_ID;
-
-  // To avoid a circular dependency, we create the recursive rendering function here and trickle it down
-  const renderClonedDropzone: RenderDropzoneFunction = useCallback(
-    (node, props) => {
-      return (
-        <DropzoneClone
-          zoneId={node.data.id}
-          node={node}
-          resolveDesignValue={resolveDesignValue}
-          {...props}
-        />
-      );
-    },
-    [resolveDesignValue],
-  );
 
   if (!resolveDesignValue) {
     return null;
@@ -69,7 +56,7 @@ export function DropzoneClone({
             key={componentId}
             node={item}
             resolveDesignValue={resolveDesignValue}
-            renderDropzone={renderClonedDropzone}
+            renderDropzone={renderDropzone}
           />
         );
       })}

--- a/packages/visual-editor/src/components/Dropzone/EditorBlockClone.tsx
+++ b/packages/visual-editor/src/components/Dropzone/EditorBlockClone.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import styles from '../Draggable/styles.module.css';
+import { useComponent } from './useComponent';
+import type {
+  CompositionComponentNode,
+  ResolveDesignValueType,
+} from '@contentful/experience-builder-core/types';
+import { RenderDropzoneFunction } from './Dropzone.types';
+import { DraggableProvided, DraggableStateSnapshot } from '@hello-pangea/dnd';
+import classNames from 'classnames';
+import {
+  ASSEMBLY_BLOCK_NODE_TYPE,
+  CONTENTFUL_COMPONENTS,
+} from '@contentful/experience-builder-core/constants';
+
+function getStyle(style = {}, snapshot?: DraggableStateSnapshot) {
+  if (!snapshot?.isDropAnimating) {
+    return style;
+  }
+  return {
+    ...style,
+    // cannot be 0, but make it super tiny
+    transitionDuration: `0.001s`,
+  };
+}
+
+type EditorBlockCloneProps = {
+  node: CompositionComponentNode;
+  resolveDesignValue: ResolveDesignValueType;
+  provided?: DraggableProvided;
+  snapshot?: DraggableStateSnapshot;
+  renderDropzone: RenderDropzoneFunction;
+};
+
+export const EditorBlockClone: React.FC<EditorBlockCloneProps> = ({
+  node: rawNode,
+  resolveDesignValue,
+  snapshot,
+  provided,
+  renderDropzone,
+}) => {
+  const { node, wrapperProps, elementToRender } = useComponent({
+    node: rawNode,
+    resolveDesignValue,
+    renderDropzone,
+  });
+
+  const isAssemblyBlock = node.type === ASSEMBLY_BLOCK_NODE_TYPE;
+  const isSingleColumn = node.data.blockId === CONTENTFUL_COMPONENTS.singleColumn.id;
+
+  if (isSingleColumn) {
+    return elementToRender();
+  }
+
+  return (
+    <div
+      ref={provided?.innerRef}
+      {...wrapperProps}
+      {...provided?.draggableProps}
+      {...provided?.dragHandleProps}
+      className={classNames(styles.DraggableComponent, wrapperProps.className, {
+        [styles.isAssemblyBlock]: isAssemblyBlock,
+        [styles.isDragging]: snapshot?.isDragging,
+      })}
+      style={getStyle(provided?.draggableProps.style, snapshot)}>
+      {elementToRender()}
+    </div>
+  );
+};

--- a/packages/visual-editor/src/hooks/useCanvasInteractions.ts
+++ b/packages/visual-editor/src/hooks/useCanvasInteractions.ts
@@ -9,6 +9,7 @@ import { DropResult } from '@hello-pangea/dnd';
 export default function useCanvasInteractions() {
   const tree = useTreeStore((state) => state.tree);
   const reorderChildren = useTreeStore((state) => state.reorderChildren);
+  const reparentChild = useTreeStore((state) => state.reparentChild);
   const addChild = useTreeStore((state) => state.addChild);
 
   const onAddComponent = (droppedItem: DropResult) => {
@@ -56,6 +57,10 @@ export default function useCanvasInteractions() {
 
     if (destination.droppableId === source.droppableId) {
       reorderChildren(destination.index, destination.droppableId, source.index);
+    }
+
+    if (destination.droppableId !== source.droppableId) {
+      reparentChild(destination.index, destination.droppableId, source.index, source.droppableId);
     }
 
     onComponentMoved({

--- a/packages/visual-editor/src/store/tree.ts
+++ b/packages/visual-editor/src/store/tree.ts
@@ -10,6 +10,7 @@ import {
   addChildNode,
   removeChildNode,
   reorderChildNode,
+  reparentChildNode,
   replaceNode,
   updateNode,
 } from '@/utils/treeHelpers';
@@ -28,12 +29,18 @@ export interface TreeStore {
   addChild: (
     destinationIndex: number,
     destinationParentId: string,
-    node: CompositionComponentNode
+    node: CompositionComponentNode,
   ) => void;
   reorderChildren: (
     destinationIndex: number,
     destinationParentId: string,
-    sourceIndex: number
+    sourceIndex: number,
+  ) => void;
+  reparentChild: (
+    destinationIndex: number,
+    destinationParentId: string,
+    sourceIndex: number,
+    sourceParentId: string,
   ) => void;
 }
 
@@ -72,7 +79,7 @@ export const useTreeStore = create<TreeStore>((set, get) => ({
             updateNode(node.data.id, cloneDeepAsPOJO(node), draftState.tree.root);
           }
         });
-      })
+      }),
     );
   },
 
@@ -109,7 +116,7 @@ export const useTreeStore = create<TreeStore>((set, get) => ({
     // The current and updated tree are the same, no tree update required.
     if (!treeDiff.length) {
       console.debug(
-        `[exp-builder.visual-editor::updateTree()]: During smart-diffing no diffs. Skipping tree update.`
+        `[exp-builder.visual-editor::updateTree()]: During smart-diffing no diffs. Skipping tree update.`,
       );
       return;
     }
@@ -132,7 +139,7 @@ export const useTreeStore = create<TreeStore>((set, get) => ({
                 diff.indexToRemove,
                 diff.idToRemove,
                 diff.parentNodeId,
-                state.tree.root
+                state.tree.root,
               );
               break;
             case TreeAction.MOVE_NODE:
@@ -145,21 +152,34 @@ export const useTreeStore = create<TreeStore>((set, get) => ({
         });
 
         state.breakpoints = tree?.root?.data?.breakpoints || [];
-      })
+      }),
     );
   },
   addChild: (index, parentId, node) => {
     set(
       produce((state: TreeStore) => {
         addChildNode(index, parentId, node, state.tree.root);
-      })
+      }),
     );
   },
   reorderChildren: (destinationIndex, destinationParentId, sourceIndex) => {
     set(
       produce((state: TreeStore) => {
         reorderChildNode(sourceIndex, destinationIndex, destinationParentId, state.tree.root);
-      })
+      }),
+    );
+  },
+  reparentChild: (destinationIndex, destinationParentId, sourceIndex, sourceParentId) => {
+    set(
+      produce((state: TreeStore) => {
+        reparentChildNode(
+          sourceIndex,
+          destinationIndex,
+          sourceParentId,
+          destinationParentId,
+          state.tree.root,
+        );
+      }),
     );
   },
 }));

--- a/packages/visual-editor/src/utils/getItem.ts
+++ b/packages/visual-editor/src/utils/getItem.ts
@@ -10,7 +10,7 @@ export type ItemSelector = {
 
 function getItemFromTree(
   id: string,
-  node: CompositionComponentNode
+  node: CompositionComponentNode,
 ): CompositionComponentNode | undefined {
   // Check if the current node's id matches the search id
 
@@ -31,9 +31,33 @@ function getItemFromTree(
   return undefined;
 }
 
+export const getChildFromTree = (
+  parentId: string,
+  index: number,
+  node: CompositionComponentNode,
+): CompositionComponentNode | undefined => {
+  // Check if the current node's id matches the search id
+
+  if (node.data.id === parentId) {
+    return node.children[index];
+  }
+
+  // Recursively search through each child
+  for (const child of node.children) {
+    const foundNode = getChildFromTree(parentId, index, child);
+    if (foundNode) {
+      // Node found in children
+      return foundNode;
+    }
+  }
+
+  // If the node is not found in this branch of the tree, return undefined
+  return undefined;
+};
+
 export const getItem = (
   selector: ItemSelector,
-  tree: CompositionTree
+  tree: CompositionTree,
 ): CompositionComponentNode | undefined => {
   return getItemFromTree(selector.id, {
     type: 'block',

--- a/packages/visual-editor/src/utils/treeHelpers.ts
+++ b/packages/visual-editor/src/utils/treeHelpers.ts
@@ -1,10 +1,11 @@
 import type { CompositionComponentNode } from '@contentful/experience-builder-core/types';
 import { isEqual } from 'lodash-es';
+import { getChildFromTree } from './getItem';
 
 export function updateNode(
   nodeId: string,
   updatedNode: CompositionComponentNode,
-  node: CompositionComponentNode
+  node: CompositionComponentNode,
 ) {
   if (node.data.id === nodeId) {
     node.data = updatedNode.data;
@@ -16,7 +17,7 @@ export function updateNode(
 export function replaceNode(
   indexToReplace: number,
   updatedNode: CompositionComponentNode,
-  node: CompositionComponentNode
+  node: CompositionComponentNode,
 ) {
   if (node.data.id === updatedNode.parentId) {
     node.children = [
@@ -33,7 +34,7 @@ export function replaceNode(
 export function reorderChildrenNodes(
   nodeId: string,
   updatedChildren: CompositionComponentNode[],
-  node: CompositionComponentNode
+  node: CompositionComponentNode,
 ) {
   if (node.data.id === nodeId) {
     node.children = updatedChildren;
@@ -47,11 +48,11 @@ export function addChildToNode(
   nodeId: string,
   oldChildren: CompositionComponentNode[],
   updatedChildren: CompositionComponentNode[],
-  node: CompositionComponentNode
+  node: CompositionComponentNode,
 ) {
   if (node.data.id !== nodeId) {
     node.children.forEach((childNode) =>
-      addChildToNode(nodeId, oldChildren, updatedChildren, childNode)
+      addChildToNode(nodeId, oldChildren, updatedChildren, childNode),
     );
   }
 
@@ -73,7 +74,7 @@ export function addChildToNode(
       oldChildren.length,
       node.data.id,
       updatedChildren[updatedChildren.length - 1],
-      node
+      node,
     );
   }
 }
@@ -82,7 +83,7 @@ export function removeChildNode(
   indexToRemove: number,
   nodeId: string,
   parentNodeId: string,
-  node: CompositionComponentNode
+  node: CompositionComponentNode,
 ) {
   if (node.data.id === parentNodeId) {
     const childIndex = node.children.findIndex((child) => child.data.id === nodeId);
@@ -92,7 +93,7 @@ export function removeChildNode(
   }
 
   node.children.forEach((childNode) =>
-    removeChildNode(indexToRemove, nodeId, parentNodeId, childNode)
+    removeChildNode(indexToRemove, nodeId, parentNodeId, childNode),
   );
 }
 
@@ -100,7 +101,7 @@ export function addChildNode(
   indexToAdd: number,
   parentNodeId: string,
   nodeToAdd: CompositionComponentNode,
-  node: CompositionComponentNode
+  node: CompositionComponentNode,
 ) {
   if (node.data.id === parentNodeId) {
     node.children = [
@@ -113,7 +114,7 @@ export function addChildNode(
   }
 
   node.children.forEach((childNode) =>
-    addChildNode(indexToAdd, parentNodeId, nodeToAdd, childNode)
+    addChildNode(indexToAdd, parentNodeId, nodeToAdd, childNode),
   );
 }
 
@@ -121,7 +122,7 @@ export function reorderChildNode(
   oldIndex: number,
   newIndex: number,
   parentNodeId: string,
-  node: CompositionComponentNode
+  node: CompositionComponentNode,
 ) {
   if (node.data.id === parentNodeId) {
     // Remove the child from the old position
@@ -133,6 +134,23 @@ export function reorderChildNode(
   }
 
   node.children.forEach((childNode) =>
-    reorderChildNode(oldIndex, newIndex, parentNodeId, childNode)
+    reorderChildNode(oldIndex, newIndex, parentNodeId, childNode),
   );
+}
+
+export function reparentChildNode(
+  oldIndex: number,
+  newIndex: number,
+  sourceNodeId: string,
+  destinationNodeId: string,
+  node: CompositionComponentNode,
+) {
+  const nodeToMove = getChildFromTree(sourceNodeId, oldIndex, node);
+
+  if (!nodeToMove) {
+    return;
+  }
+
+  removeChildNode(oldIndex, nodeToMove.data.id, sourceNodeId, node);
+  addChildNode(newIndex, destinationNodeId, nodeToMove, node);
 }


### PR DESCRIPTION
## Purpose

By implementing the cloning API offered from the hello-pangea/dnd [re-parenting docs](https://github.com/hello-pangea/dnd/blob/main/docs/guides/reparenting.md), we can prevent unwanted css transforms from reaching the draggable component by reparenting the draggable to the body of the document.

## Side Quest
I ended up implementing a reparentChildNode fn in our smart tree update logic. With this enabled, causing a reparent event will instantly commit the changes to the tree instead of waiting for a postMessage from the user_interface with the updated tree. This removes component flickering when reparenting where the component was in it's old location until the update was received.

### Before:

https://github.com/contentful/experience-builder/assets/23040747/40c674b7-b837-4dd8-b3a0-9ad67c285867

### With cloning enabled
(The flickering dropzone indicators will be tackled in another ticket):

https://github.com/contentful/experience-builder/assets/23040747/e6118159-69ad-4fb7-9ff8-c9c7cdfd7d69


## Approach
Use `renderClone` as defined in the hello-pangea/dnd reparenting docs. This clones the draggable and appends it to the body of the document.

### Caveat
Implementing cloning results in the following warning appearing in the console when moving a component that has a nested dropzone.

<img width="886" alt="Screenshot 2024-02-27 at 5 07 44 PM" src="https://github.com/contentful/experience-builder/assets/23040747/b03e9fa0-fdc4-4aef-bb34-6448a44c0b0b">

The reasoning is because when we start a drag with cloning enabled, it removes the draggable from the component tree and appends it to the body instead. This technically changes the amount of `droppableIds` present in the tree which throws this warning. I've thoroughly tested and this has no affect on the actual experience since the droppableIds removed are part of the component being dragged but it does show up for us while developing locally.
