### PR TITLE
chore: add github-like very short SHA to prerelease tag []

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -55,7 +55,7 @@ jobs:
           git config user.email "${{ github.actor}}@users.noreply.github.com"
 
           if [ ${{ github.ref_name }} = development ]; then
-            npx lerna publish prerelease --exact --conventional-commits --conventional-prerelease --preid dev-$(date +%Y%m%dT%H%M%S) --no-changelog --no-git-tag-version --dist-tag dev --no-push --yes
+            npx lerna publish prerelease --exact --conventional-commits --conventional-prerelease --preid dev-$(date +%Y%m%dT%H%M)-$(git rev-parse HEAD  | cut -c1-7) --no-changelog --no-git-tag-version --dist-tag dev --no-push --yes
           elif [ ${{ github.ref_name }} = next ]; then
             npx lerna publish prerelease --exact --conventional-commits --conventional-prerelease --preid alpha --yes --no-private --dist-tag latest
           else


### PR DESCRIPTION
## Purpose

To understand which prerelease belongs to which commit, we add the short hash to the version.

## Approach
- The hash is after the datetime so we don't break any kind of ordering
- Skipping seconds as this information is not needed
- Using the 7-digit version like GitHub does by manually cutting after 7 letters.

Btw, there is `git rev-parse --short HEAD` but it creates a 10 digit hash. I think it's save enough (and so does GH apparently)

## Test
You can run locally this to see it in action:
```
echo "dev-$(date +%Y%m%dT%H%M)-$(git rev-parse HEAD  | cut -c1-7)"
```