### PR TITLE
revert: hide overflowing content []

### DIFF
--- a/packages/visual-editor/src/components/Draggable/styles.module.css
+++ b/packages/visual-editor/src/components/Draggable/styles.module.css
@@ -7,8 +7,6 @@
   outline: 2px solid transparent;
   box-sizing: border-box;
   display: flex;
-  /* Especially, avoid horizontal overflow as this breaks the overall canvas scrolling */
-  overflow: hidden;
 }
 
 .DraggableComponent > * {


### PR DESCRIPTION
This breaks parts of the DND functionality. Let's revert this as this is something that users can cause on their own and doesn't need to be fixed by us. In the end, this was an editor only improvement and in preview, the user would have seen the overflowing content still.

Reverts contentful/experience-builder#429
