### PR TITLE
feat: adds tooltip defn for heading, text, richtext, button, and image [ALT-462

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "lerna": "^8.0.2",
         "lint-staged": "^15.0.1",
         "nx": "18.0.4",
-        "nx-cloud": "*",
+        "nx-cloud": "latest",
         "prettier": "3.2.5"
       }
     },
@@ -13266,20 +13266,6 @@
         "type-fest": "^2.19.0"
       }
     },
-    "node_modules/@storybook/csf-plugin": {
-      "version": "7.6.10",
-      "resolved": "https://registry.npmjs.org/@storybook/csf-plugin/-/csf-plugin-7.6.10.tgz",
-      "integrity": "sha512-Sc+zZg/BnPH2X28tthNaQBnDiFfO0QmfjVoOx0fGYM9SvY3P5ehzWwp5hMRBim6a/twOTzePADtqYL+t6GMqqg==",
-      "dev": true,
-      "dependencies": {
-        "@storybook/csf-tools": "7.6.10",
-        "unplugin": "^1.3.1"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/storybook"
-      }
-    },
     "node_modules/@storybook/csf-tools": {
       "version": "7.6.10",
       "resolved": "https://registry.npmjs.org/@storybook/csf-tools/-/csf-tools-7.6.10.tgz",
@@ -13306,25 +13292,6 @@
       "resolved": "https://registry.npmjs.org/@storybook/docs-mdx/-/docs-mdx-0.1.0.tgz",
       "integrity": "sha512-JDaBR9lwVY4eSH5W8EGHrhODjygPd6QImRbwjAuJNEnY0Vw4ie3bPkeGfnacB3OBW6u/agqPv2aRlR46JcAQLg==",
       "dev": true
-    },
-    "node_modules/@storybook/docs-tools": {
-      "version": "7.6.10",
-      "resolved": "https://registry.npmjs.org/@storybook/docs-tools/-/docs-tools-7.6.10.tgz",
-      "integrity": "sha512-UgbikducoXzqQHf2TozO0f2rshaeBNnShVbL5Ai4oW7pDymBmrfzdjGbF/milO7yxNKcoIByeoNmu384eBamgQ==",
-      "dev": true,
-      "dependencies": {
-        "@storybook/core-common": "7.6.10",
-        "@storybook/preview-api": "7.6.10",
-        "@storybook/types": "7.6.10",
-        "@types/doctrine": "^0.0.3",
-        "assert": "^2.1.0",
-        "doctrine": "^3.0.0",
-        "lodash": "^4.17.21"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/storybook"
-      }
     },
     "node_modules/@storybook/global": {
       "version": "5.0.0",
@@ -13546,20 +13513,6 @@
         "typescript": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@storybook/react-dom-shim": {
-      "version": "7.6.10",
-      "resolved": "https://registry.npmjs.org/@storybook/react-dom-shim/-/react-dom-shim-7.6.10.tgz",
-      "integrity": "sha512-M+N/h6ximacaFdIDjMN2waNoWwApeVYTpFeoDppiFTvdBTXChyIuiPgYX9QSg7gDz92OaA52myGOot4wGvXVzg==",
-      "dev": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/storybook"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/@storybook/react-vite": {

--- a/packages/components/src/components/Button/index.ts
+++ b/packages/components/src/components/Button/index.ts
@@ -20,6 +20,9 @@ export const ButtonComponentDefinition: ComponentDefinition = {
     'cfLineHeight',
     'cfBorder',
   ],
+  tooltip: {
+    description: 'A button that can be used to trigger an action or navigate to a different page.',
+  },
   variables: {
     cfFontSize: {
       displayName: 'Font Size',

--- a/packages/components/src/components/Heading/index.ts
+++ b/packages/components/src/components/Heading/index.ts
@@ -25,6 +25,9 @@ export const HeadingComponentDefinition: ComponentDefinition = {
     'cfBackgroundColor',
     'cfBorder',
   ],
+  tooltip: {
+    description: 'Click and drop to add a heading for your experience.',
+  },
   variables: {
     // Built-in style variables with default values changed
     cfHeight: {

--- a/packages/components/src/components/Image/index.ts
+++ b/packages/components/src/components/Image/index.ts
@@ -12,6 +12,9 @@ export const ImageComponentDefinition: ComponentDefinition = {
   name: CONTENTFUL_COMPONENTS.image.name,
   category: CONTENTFUL_DEFAULT_CATEGORY,
   builtInStyles: ['cfMargin', 'cfPadding'],
+  tooltip: {
+    description: 'Click and drop onto the canvas to upload an image or bind an existing asset.',
+  },
   variables: {
     alt: {
       displayName: 'Alt',

--- a/packages/components/src/components/RichText/index.ts
+++ b/packages/components/src/components/RichText/index.ts
@@ -20,6 +20,10 @@ export const RichTextComponentDefinition: ComponentDefinition = {
     'cfBackgroundColor',
     'cfBorder',
   ],
+  tooltip: {
+    description:
+      'Click and drop onto the canvas to add text with Rich text formatting options or bind existing content.',
+  },
   variables: {
     // Built-in style variables with default values changed
     cfLineHeight: {

--- a/packages/components/src/components/Text/index.ts
+++ b/packages/components/src/components/Text/index.ts
@@ -28,6 +28,9 @@ export const TextComponentDefinition: ComponentDefinition = {
     'cfWidth',
     'cfMaxWidth',
   ],
+  tooltip: {
+    description: 'Click and drop onto the canvas to add plain text or bind existing content.',
+  },
   variables: {
     cfHeight: {
       displayName: 'Height',

--- a/packages/core/src/definitions/components.ts
+++ b/packages/core/src/definitions/components.ts
@@ -13,6 +13,10 @@ export const sectionDefinition: ComponentDefinition = {
   category: CONTENTFUL_COMPONENT_CATEGORY,
   children: true,
   variables: builtInStyles,
+  tooltip: {
+    description:
+      'Create a new full width section of your experience by dragging this element onto the canvas. Elements and patterns can be added into a section.',
+  },
 };
 
 export const containerDefinition: ComponentDefinition = {
@@ -21,6 +25,10 @@ export const containerDefinition: ComponentDefinition = {
   category: CONTENTFUL_COMPONENT_CATEGORY,
   children: true,
   variables: containerBuiltInStyles,
+  tooltip: {
+    description:
+      'Create a new area or pattern within your page layout by dragging a container onto the canvas. Elements and patterns can be added into a container.',
+  },
 };
 
 export const columnsDefinition: ComponentDefinition = {
@@ -29,6 +37,10 @@ export const columnsDefinition: ComponentDefinition = {
   category: CONTENTFUL_COMPONENT_CATEGORY,
   children: true,
   variables: columnsBuiltInStyles,
+  tooltip: {
+    description:
+      'Add columns to a container to create your desired layout and ensure that the experience is responsive across different screen sizes.',
+  },
 };
 
 export const singleColumnDefinition: ComponentDefinition = {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -95,7 +95,7 @@ export interface ComponentDefinitionVariableBase<T extends ComponentDefinitionVa
 }
 
 export type ComponentDefinitionVariable<
-  T extends ComponentDefinitionVariableType = ComponentDefinitionVariableType
+  T extends ComponentDefinitionVariableType = ComponentDefinitionVariableType,
   // K extends ComponentDefinitionVariableArrayItemType = ComponentDefinitionVariableArrayItemType
 > =
   // T extends 'Link'
@@ -105,7 +105,7 @@ export type ComponentDefinitionVariable<
   /*:*/ ComponentDefinitionVariableBase<T>;
 
 export type ComponentDefinition<
-  T extends ComponentDefinitionVariableType = ComponentDefinitionVariableType
+  T extends ComponentDefinitionVariableType = ComponentDefinitionVariableType,
 > = {
   id: string;
   name: string;
@@ -115,6 +115,10 @@ export type ComponentDefinition<
     Record<string, ComponentDefinitionVariable<T>>;
   builtInStyles?: Array<keyof Omit<StyleProps, 'cfHyperlink' | 'cfOpenInNewTab'>>;
   children?: boolean;
+  tooltip?: {
+    imageUrl?: string;
+    description: string;
+  };
 };
 
 export type ComponentRegistration = {
@@ -309,7 +313,7 @@ export interface DeprecatedExperience {
 
 export type ResolveDesignValueType = (
   valuesByBreakpoint: ValuesByBreakpoint,
-  variableName: string
+  variableName: string,
 ) => PrimitiveValue;
 
 // The 'contentful' package only exposes CDA types while we received CMA ones in editor mode


### PR DESCRIPTION
## Purpose
Update component defn to allow us and external users to define their own tooltips by adding 
```
  tooltip?: {
    imageUrl?: string;
    description: string;
  };
```
to the component defn.

Also adds tooltip defns for the following Basic components - heading, text, richtext, button, and image