### PR TITLE
fix: use merge instead of rebase when syncing branches [ci skip]

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -70,13 +70,13 @@ jobs:
 
           if [ ${{ github.ref_name }} = main ]; then
             git checkout next
-            git rebase main
+            git merge main
             git push origin
             git checkout development
-            git rebase next
+            git merge next
             git push origin
           elif [ ${{ github.ref_name }} = next ]; then
             git checkout development
-            git rebase next
+            git merge next
             git push origin
           fi


### PR DESCRIPTION
## Purpose

Avoid rebase conflicts when syncing branches in CI.

## Approach

Sometimes rebase fails when trying to sync `development` branch with `next`. E.g. in [this build](https://github.com/contentful/experience-builder/actions/runs/8110520652/job/22168113172#step:8:286). Last time that this happened was because:
* merging from a feature branch into `development` commits were not squashed (PR of ~70 commits)
* merging from `development` into `next` the 70 commits were squashed into one
* when later CI tried to rebase `development` over `next` there were conflicts between the individual commits in development and the squashed commit in next.

Using `merge` instead of `rebase` does not produce any conflicts. Only caveat is that it will create a new merge commit on next but that shouldn't cause any problems on followup PRs.
