### PR TITLE
fix: update component tooltips to use component term instead of elements [ALT-544]

### DIFF
--- a/packages/components/src/components/Button/index.ts
+++ b/packages/components/src/components/Button/index.ts
@@ -21,7 +21,7 @@ export const ButtonComponentDefinition: ComponentDefinition = {
     'cfBorder',
   ],
   tooltip: {
-    description: 'A button that can be used to trigger an action or navigate to a different page.',
+    description: 'Drop onto the canvas to add button that can be used to trigger an action.',
   },
   variables: {
     cfFontSize: {

--- a/packages/components/src/components/Heading/index.ts
+++ b/packages/components/src/components/Heading/index.ts
@@ -26,7 +26,7 @@ export const HeadingComponentDefinition: ComponentDefinition = {
     'cfBorder',
   ],
   tooltip: {
-    description: 'Click and drop to add a heading for your experience.',
+    description: 'Drop onto the canvas to add a heading.',
   },
   variables: {
     // Built-in style variables with default values changed

--- a/packages/components/src/components/Image/index.ts
+++ b/packages/components/src/components/Image/index.ts
@@ -13,7 +13,7 @@ export const ImageComponentDefinition: ComponentDefinition = {
   category: CONTENTFUL_DEFAULT_CATEGORY,
   builtInStyles: ['cfMargin', 'cfPadding'],
   tooltip: {
-    description: 'Click and drop onto the canvas to upload an image or bind an existing asset.',
+    description: 'Drop onto the canvas to upload an image.',
   },
   variables: {
     alt: {

--- a/packages/components/src/components/RichText/index.ts
+++ b/packages/components/src/components/RichText/index.ts
@@ -21,8 +21,7 @@ export const RichTextComponentDefinition: ComponentDefinition = {
     'cfBorder',
   ],
   tooltip: {
-    description:
-      'Click and drop onto the canvas to add text with Rich text formatting options or bind existing content.',
+    description: 'Drop onto the canvas to add text with Rich text formatting options.',
   },
   variables: {
     // Built-in style variables with default values changed

--- a/packages/components/src/components/Text/index.ts
+++ b/packages/components/src/components/Text/index.ts
@@ -29,7 +29,7 @@ export const TextComponentDefinition: ComponentDefinition = {
     'cfMaxWidth',
   ],
   tooltip: {
-    description: 'Click and drop onto the canvas to add plain text or bind existing content.',
+    description: 'Drop onto the canvas to add plain text.',
   },
   variables: {
     cfHeight: {

--- a/packages/core/src/definitions/components.ts
+++ b/packages/core/src/definitions/components.ts
@@ -15,7 +15,7 @@ export const sectionDefinition: ComponentDefinition = {
   variables: builtInStyles,
   tooltip: {
     description:
-      'Create a new full width section of your experience by dragging this element onto the canvas. Elements and patterns can be added into a section.',
+      'Create a new full width section of your experience by dragging this component onto the canvas. Other components and patterns can be added into a section.',
   },
 };
 
@@ -27,7 +27,7 @@ export const containerDefinition: ComponentDefinition = {
   variables: containerBuiltInStyles,
   tooltip: {
     description:
-      'Create a new area or pattern within your page layout by dragging a container onto the canvas. Elements and patterns can be added into a container.',
+      'Create a new area or pattern within your page layout by dragging a container onto the canvas. Other components and patterns can be added into a container.',
   },
 };
 


### PR DESCRIPTION
## Purpose
Replace the term Elements with Components
Clean up the consistency between tooltip descriptions

