### PR TITLE
fix(canvas-interactions): disable dropzones that are assemblies [ALT-552]

### DIFF
--- a/packages/visual-editor/src/components/Draggable/styles.module.css
+++ b/packages/visual-editor/src/components/Draggable/styles.module.css
@@ -52,10 +52,6 @@
   background-color: var(--exp-builder-purple600);
 }
 
-/* .DraggableComponent:hover .overlay {
-  opacity: 1;
-} */
-
 .userIsDragging > .overlay,
 .userIsDragging > .overlayContainer {
   opacity: 0 !important;
@@ -81,9 +77,9 @@
 .isAssemblyBlock:hover,
 .isAssemblyBlock:hover div[data-rfd-draggable-id],
 .DraggableComponent:hover div[data-rfd-draggable-id][data-cf-node-block-type^='assembly'] {
-  outline: 2px dashed var(--exp-builder-purple600) !important;
+  outline: 2px dashed var(--exp-builder-purple600);
 }
 
 .isAssemblyBlock:hover:not(:has(div[data-rfd-draggable-id]:hover)) {
-  outline: 2px solid var(--exp-builder-purple600) !important;
+  outline: 2px solid var(--exp-builder-purple600);
 }

--- a/packages/visual-editor/src/components/Dropzone/Dropzone.tsx
+++ b/packages/visual-editor/src/components/Dropzone/Dropzone.tsx
@@ -93,12 +93,29 @@ export function Dropzone({
     return null;
   }
 
-  // Don't trigger the dropzone when it's the root because then the only hit boxes that show up will be root level zones
-  // Exception 1: If it comes from the component list (because we want the component list components to work for all zones
-  // Exception 2: If it's a child of a root level zone (because we want to be able to re-order root level containers)
-
+  /**
+   * Dropzone Rules
+   *
+   * 1. A dropzone is disabled unless the mouse is hovering over it
+   *
+   * 2. Dragging a new component onto the canvas has no addtional rules
+   * besides rule #1
+   *
+   * 3. Dragging a component that is a direct descendant of the root
+   * (parentId === ROOT_ID) then only the Root Dropzone is enabled
+   *
+   * 4. Dragging a nested component (parentId !== ROOT_ID) then the Root
+   * Dropzone is disabled, all other Dropzones follow rule #1
+   *
+   * 5. Assemblies and the SingleColumn component are always disabled
+   *
+   */
   const isDropzoneEnabled = () => {
     if (node?.data.blockId === CONTENTFUL_COMPONENTS.columns.id) {
+      return false;
+    }
+
+    if (isAssembly) {
       return false;
     }
 

--- a/packages/visual-editor/src/components/Dropzone/Dropzone.tsx
+++ b/packages/visual-editor/src/components/Dropzone/Dropzone.tsx
@@ -94,7 +94,7 @@ export function Dropzone({
   }
 
   /**
-   * Dropzone Rules
+   * The Rules of Dropzones
    *
    * 1. A dropzone is disabled unless the mouse is hovering over it
    *

--- a/packages/visual-editor/src/global.css
+++ b/packages/visual-editor/src/global.css
@@ -4,7 +4,6 @@ body {
   padding: 0;
 }
 
-
 /*
  * All of these variables are tokens from Forma-36 and should not be adjusted as these
  * are global variables that may affect multiple places.


### PR DESCRIPTION
## Purpose
Assemblies (Patterns) should disable any Dropzones that are nested within itself since they are read-only.

Ticket: https://contentful.atlassian.net/browse/ALT-552

## Approach
Disable Dropzones that are of the assembly node type. Also add a better comment to outline the "Rules of Dropzones"