### PR TITLE
fix: add cfImageSizes variable to structure components [ALT-514]

### DIFF
--- a/packages/core/src/definitions/components.ts
+++ b/packages/core/src/definitions/components.ts
@@ -1,9 +1,9 @@
 import type { ComponentDefinition } from '@/types';
 import { CONTENTFUL_COMPONENT_CATEGORY, CONTENTFUL_COMPONENTS } from '@/constants';
 import {
-  builtInStyles,
   columnsBuiltInStyles,
   containerBuiltInStyles,
+  sectionBuiltInStyles,
   singleColumnBuiltInStyles,
 } from './styles';
 
@@ -12,7 +12,7 @@ export const sectionDefinition: ComponentDefinition = {
   name: CONTENTFUL_COMPONENTS.section.name,
   category: CONTENTFUL_COMPONENT_CATEGORY,
   children: true,
-  variables: builtInStyles,
+  variables: sectionBuiltInStyles,
   tooltip: {
     description:
       'Create a new full width section of your experience by dragging this element onto the canvas. Elements and patterns can be added into a section.',

--- a/packages/core/src/definitions/styles.ts
+++ b/packages/core/src/definitions/styles.ts
@@ -353,6 +353,13 @@ export const optionalBuiltInStyles: Partial<
   },
 };
 
+export const sectionBuiltInStyles: Partial<
+  Record<ContainerStyleVariableName, ComponentDefinitionVariable<'Text' | 'Boolean' | 'Media'>>
+> = {
+  ...builtInStyles,
+  cfImageSizes: optionalBuiltInStyles.cfImageSizes,
+};
+
 export const containerBuiltInStyles: Partial<
   Record<ContainerStyleVariableName, ComponentDefinitionVariable<'Text' | 'Boolean' | 'Media'>>
 > = {
@@ -371,6 +378,7 @@ export const containerBuiltInStyles: Partial<
     description: 'The margin of the container',
     defaultValue: '0 Auto 0 Auto',
   },
+  cfImageSizes: optionalBuiltInStyles.cfImageSizes,
 };
 
 export const singleColumnBuiltInStyles: Partial<
@@ -510,6 +518,7 @@ export const singleColumnBuiltInStyles: Partial<
     defaultValue: false,
     group: 'style',
   },
+  cfImageSizes: optionalBuiltInStyles.cfImageSizes,
 };
 
 export const columnsBuiltInStyles: Partial<
@@ -615,4 +624,5 @@ export const columnsBuiltInStyles: Partial<
     defaultValue: '2',
     group: 'style',
   },
+  cfImageSizes: optionalBuiltInStyles.cfImageSizes,
 };


### PR DESCRIPTION
## Purpose

Adding the `cfImageSizes` variable to structure component definitions.

This variable is used for the Target Image Width input in the design sidebar when adding a Background Image to structure components.

![Screenshot 2024-03-05 at 3 50 59 PM](https://github.com/contentful/experience-builder/assets/8539634/08e164d0-523c-48c8-85bb-f96dd7785880)
