### PR TITLE
fix: changes for Image Object Fit options [ALT-511]

### DIFF
--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -176,10 +176,3 @@ export enum PostMessageMethods {
 }
 
 export const SUPPORTED_IMAGE_FORMATS = ['jpg', 'png', 'webp', 'gif', 'avif'] as const;
-export const SUPPORTED_IMAGE_OBJECT_FIT = [
-  'fill',
-  'contain',
-  'cover',
-  'none',
-  'scale-down',
-] as const;

--- a/packages/core/src/definitions/styles.ts
+++ b/packages/core/src/definitions/styles.ts
@@ -229,7 +229,7 @@ export const optionalBuiltInStyles: Partial<
     type: 'Text',
     group: 'style',
     description: 'Specify how an image should fit its container',
-    defaultValue: 'fill',
+    defaultValue: 'none',
   },
   cfImageObjectPosition: {
     displayName: 'Image Position',

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -220,7 +220,7 @@ export type StyleProps = {
   cfImageAsset: OptimizedImageAsset | string;
   cfImageFormat: string;
   cfImageHeight: string;
-  cfImageObjectFit: string;
+  cfImageObjectFit: 'none' | 'contain' | 'cover';
   cfImageObjectPosition:
     | 'left'
     | 'right'

--- a/packages/core/src/utils/styleUtils/stylesUtils.ts
+++ b/packages/core/src/utils/styleUtils/stylesUtils.ts
@@ -14,7 +14,7 @@ import {
   CompositionComponentNode,
 } from '@/types';
 import { isContentfulStructureComponent } from '../components';
-import { EMPTY_CONTAINER_HEIGHT, SUPPORTED_IMAGE_OBJECT_FIT } from '../../constants';
+import { EMPTY_CONTAINER_HEIGHT } from '../../constants';
 
 const toCSSAttribute = (key: string) => {
   let val = key.replace(/[A-Z]/g, (m) => '-' + m.toLowerCase());

--- a/packages/core/src/utils/styleUtils/stylesUtils.ts
+++ b/packages/core/src/utils/styleUtils/stylesUtils.ts
@@ -102,7 +102,7 @@ export const buildCfStyles = ({
     textTransform: cfTextTransform,
     textDecoration: cfTextUnderline ? 'underline' : 'none',
     boxSizing: 'border-box',
-    objectFit: cfImageObjectFit as (typeof SUPPORTED_IMAGE_OBJECT_FIT)[number],
+    objectFit: cfImageObjectFit,
     objectPosition: cfImageObjectPosition,
   };
 };


### PR DESCRIPTION
## Purpose

I decided to remove the `SUPPORTED_IMAGE_OBJECT_FIT` constant and use an object for the display names and values of each image object fit option in the UI:
* https://github.com/contentful/user_interface/blob/185408186abbfca07ac4dcb1326ed9faab035fb9/src/javascripts/features/experience-builder/components/StyleSectionComponents/ImageOptions/ImageFitSection.tsx#L14-L18

This makes the implementation a little more consistent with other style props such as Image Alignment options which follow this implementation:
* https://github.com/contentful/user_interface/blob/185408186abbfca07ac4dcb1326ed9faab035fb9/src/javascripts/features/experience-builder/components/StyleSectionComponents/ImageOptions/ImageAlignmentInput.tsx#L26-L36