### PR TITLE
fix(visual-editor): component re-select on breakpoint change [ALT-508]

### DIFF
--- a/packages/visual-editor/src/hooks/useEditorSubscriber.ts
+++ b/packages/visual-editor/src/hooks/useEditorSubscriber.ts
@@ -292,6 +292,10 @@ export function useEditorSubscriber() {
           break;
         }
         case INCOMING_EVENTS.CanvasResized: {
+          const { selectedNodeId } = payload;
+          if (selectedNodeId) {
+            sendSelectedComponentCoordinates(selectedNodeId);
+          }
           break;
         }
         case INCOMING_EVENTS.HoverComponent: {


### PR DESCRIPTION
## Purpose
The CanvasResized event would communicate the selected node ID and request for updated coordinates which was not being handled before and would cause issues with selected components and breakpoint changes.

Ticket: https://contentful.atlassian.net/browse/ALT-508