### PR TITLE
fix: hover outlines and default border style [ALT-323]

### DIFF
--- a/packages/core/src/definitions/styles.ts
+++ b/packages/core/src/definitions/styles.ts
@@ -110,7 +110,7 @@ export const builtInStyles: Partial<
     type: 'Text',
     group: 'style',
     description: 'The border of the section',
-    defaultValue: '1px solid rgba(0, 0, 0, 0)',
+    defaultValue: '0px solid rgba(0, 0, 0, 0)',
   },
   cfGap: {
     displayName: 'Gap',
@@ -401,7 +401,7 @@ export const singleColumnBuiltInStyles: Partial<
     type: 'Text',
     group: 'style',
     description: 'The border of the column',
-    defaultValue: '1px solid rgba(0, 0, 0, 0)',
+    defaultValue: '0px solid rgba(0, 0, 0, 0)',
   },
   cfGap: {
     displayName: 'Gap',
@@ -501,7 +501,7 @@ export const columnsBuiltInStyles: Partial<
     type: 'Text',
     group: 'style',
     description: 'The border of the columns',
-    defaultValue: '1px solid rgba(0, 0, 0, 0)',
+    defaultValue: '0px solid rgba(0, 0, 0, 0)',
   },
   cfBackgroundImageUrl: {
     displayName: 'Background image',

--- a/packages/visual-editor/src/components/Draggable/styles.module.css
+++ b/packages/visual-editor/src/components/Draggable/styles.module.css
@@ -71,7 +71,7 @@
   opacity: 0 !important;
 }
 
-.userIsDragging::before {
+.userIsDragging:before {
   outline: 2px solid transparent !important;
 }
 

--- a/packages/visual-editor/src/components/Draggable/styles.module.css
+++ b/packages/visual-editor/src/components/Draggable/styles.module.css
@@ -91,9 +91,9 @@
 .isAssemblyBlock:hover:before,
 .isAssemblyBlock:hover div[data-rfd-draggable-id]:before,
 .DraggableComponent:hover div[data-rfd-draggable-id][data-cf-node-block-type^='assembly']:before {
-  outline: 2px dashed var(--exp-builder-purple600) !important;
+  outline: 2px dashed var(--exp-builder-purple600);
 }
 
 .isAssemblyBlock:hover:not(:has(div[data-rfd-draggable-id]:hover)):before {
-  outline: 2px solid var(--exp-builder-purple600) !important;
+  outline: 2px solid var(--exp-builder-purple600);
 }

--- a/packages/visual-editor/src/components/Draggable/styles.module.css
+++ b/packages/visual-editor/src/components/Draggable/styles.module.css
@@ -3,15 +3,26 @@
   position: relative;
   transition: outline 0.2s;
   cursor: grab;
-  outline-offset: -2px;
-  outline: 2px solid transparent;
   box-sizing: border-box;
   display: flex;
 }
 
-.DraggableClone {
+.DraggableComponent:before {
+  content: "";
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  outline-offset: -2px;
+  outline: 2px solid transparent;
+  z-index: 1;
+}
+
+.DraggableClone:before {
   outline: 2px solid var(--exp-builder-blue500);
 }
+
 .DraggableComponent > * {
   pointer-events: none;
 }
@@ -24,7 +35,7 @@
   pointer-events: none !important;
 }
 
-.isSelected {
+.isSelected:before {
   outline: 2px solid transparent !important;
 }
 
@@ -60,7 +71,7 @@
   opacity: 0 !important;
 }
 
-.userIsDragging {
+.userIsDragging::before {
   outline: 2px solid transparent !important;
 }
 
@@ -68,21 +79,21 @@
   opacity: 1;
 }
 
-.DraggableComponent:hover,
-.DraggableComponent:hover div[data-rfd-draggable-id] {
+.DraggableComponent:hover:before,
+.DraggableComponent:hover div[data-rfd-draggable-id]:before {
   outline: 2px dashed var(--exp-builder-gray500);
 }
 
-.DraggableComponent:hover:not(:has(div[data-rfd-draggable-id]:hover)) {
+.DraggableComponent:hover:not(:has(div[data-rfd-draggable-id]:hover)):before {
   outline: 2px solid var(--exp-builder-gray500);
 }
 
-.isAssemblyBlock:hover,
-.isAssemblyBlock:hover div[data-rfd-draggable-id],
-.DraggableComponent:hover div[data-rfd-draggable-id][data-cf-node-block-type^='assembly'] {
-  outline: 2px dashed var(--exp-builder-purple600);
+.isAssemblyBlock:hover:before,
+.isAssemblyBlock:hover div[data-rfd-draggable-id]:before,
+.DraggableComponent:hover div[data-rfd-draggable-id][data-cf-node-block-type^='assembly']:before {
+  outline: 2px dashed var(--exp-builder-purple600) !important;
 }
 
-.isAssemblyBlock:hover:not(:has(div[data-rfd-draggable-id]:hover)) {
-  outline: 2px solid var(--exp-builder-purple600);
+.isAssemblyBlock:hover:not(:has(div[data-rfd-draggable-id]:hover)):before {
+  outline: 2px solid var(--exp-builder-purple600) !important;
 }

--- a/packages/visual-editor/src/components/Dropzone/styles.module.css
+++ b/packages/visual-editor/src/components/Dropzone/styles.module.css
@@ -9,7 +9,7 @@
   pointer-events: all;
 }
 
-.container:before {
+.container:not(.isRoot):before {
   content: "";
   position: absolute;
   top: 0;
@@ -36,8 +36,9 @@
 }
 
 .isDestination:not(.isRoot) {
-  background-color: rgba(var(--exp-builder-blue100-rgb), 0.5);
   background-image: none !important;
+  background-color: rgba(var(--exp-builder-blue100-rgb), 0.5);
+  z-index: 100;
 }
 
 .isDestination:not(.isRoot):before {

--- a/packages/visual-editor/src/components/Dropzone/styles.module.css
+++ b/packages/visual-editor/src/components/Dropzone/styles.module.css
@@ -3,19 +3,25 @@
   margin-right: auto;
   position: relative;
   height: 100%;
-  outline-offset: -2px;
-  outline: 2px solid transparent;
   width: 100%;
   background-color: transparent;
-  transition:
-    outline 0.2s,
-    background-color 0.2s;
+  transition: background-color 0.2s;
   pointer-events: all;
 }
 
-.container:not(.isRoot) {
-  outline-offset: -1px;
+.container:before {
+  content: "";
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  outline-offset: -2px;
+  outline: 2px solid transparent;
+  z-index: 1;
+  transition: outline 0.2s;
 }
+
 .isRoot,
 .isEmptyCanvas {
   flex: 1;
@@ -25,14 +31,17 @@
   min-height: 80px;
 }
 
-.isDragging:not(.isRoot) {
+.isDragging:not(.isRoot):before {
   outline: 2px dashed var(--exp-builder-gray300);
 }
 
 .isDestination:not(.isRoot) {
-  outline: 2px dashed var(--exp-builder-blue400);
   background-color: rgba(var(--exp-builder-blue100-rgb), 0.5);
-  z-index: 100;
+  background-image: none !important;
+}
+
+.isDestination:not(.isRoot):before {
+  outline: 2px dashed var(--exp-builder-blue400);
 }
 
 .hitbox {

--- a/packages/visual-editor/src/components/Dropzone/styles.module.css
+++ b/packages/visual-editor/src/components/Dropzone/styles.module.css
@@ -36,12 +36,6 @@
 }
 
 .isDestination:not(.isRoot):before {
-  content: "";
-  position: absolute;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  left: 0;
   transition: outline 0.2s, background-color 0.2s;
   outline: 2px dashed var(--exp-builder-blue400);
   background-color: rgba(var(--exp-builder-blue100-rgb), 0.5);

--- a/packages/visual-editor/src/components/Dropzone/styles.module.css
+++ b/packages/visual-editor/src/components/Dropzone/styles.module.css
@@ -16,7 +16,7 @@
   right: 0;
   bottom: 0;
   left: 0;
-  outline-offset: -2px;
+  outline-offset: -1px;
   outline: 2px solid transparent;
   z-index: 1;
   transition: outline 0.2s;

--- a/packages/visual-editor/src/components/Dropzone/styles.module.css
+++ b/packages/visual-editor/src/components/Dropzone/styles.module.css
@@ -35,14 +35,17 @@
   outline: 2px dashed var(--exp-builder-gray300);
 }
 
-.isDestination:not(.isRoot) {
-  background-image: none !important;
-  background-color: rgba(var(--exp-builder-blue100-rgb), 0.5);
-  z-index: 100;
-}
-
 .isDestination:not(.isRoot):before {
+  content: "";
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  transition: outline 0.2s, background-color 0.2s;
   outline: 2px dashed var(--exp-builder-blue400);
+  background-color: rgba(var(--exp-builder-blue100-rgb), 0.5);
+  z-index: 2;
 }
 
 .hitbox {


### PR DESCRIPTION
## Fix hover outlines on sections with backgrounds

Ticket: https://contentful.atlassian.net/browse/ALT-323

Changes visual editor hover outlines to apply on `:before` psuedo-elements so that the outlines will always render on top.

* This makes it so the hover outlines will show on structure components that have a background image or background color.

This video compares hover outlines in Test App Prod  vs locally to show that the hover outlines works on the yellow background image section and green background color section (in the second half of the video):

https://github.com/contentful/experience-builder/assets/8539634/3ad38711-fa7e-421e-aa68-cbf829665b97


## Fix 1px transparent border causing gaps between sections

Changes the default border style to 0px so that we won't have a 1px transparent border on structure components by default

* This was causing the small gap between buttons that are stacked in the canvas within separate sections/containers.
* The UI already handles setting the border initial value to 1px when a border styles are enabled on the component: https://github.com/contentful/user_interface/blob/master/src/javascripts/features/experience-builder/components/SectionStyleInput.tsx#L62

This video compares the border behavior in Test App Prod vs locally to show that there is no longer a small gap between buttons in a stack of buttons in separate sections, and when adding nested containers with background colors the child section fills the parent section completely without the parent background bleeding through due to the 1px transparent borders (in the second half of the video):

https://github.com/contentful/experience-builder/assets/8539634/3ea651f4-cf0d-4f7e-908e-0a00bbe7a353


## Fix background color when dragging into drop zones with a background image

Changes drop zone styling to apply the background color as an overlay, to work better with sections that are styled with a background color or background image:

https://github.com/contentful/experience-builder/assets/8539634/c7e966fd-0941-457f-bb8e-02503a6d9212





