### PR TITLE
refactor: replace Composition -> Experience in core SDK interfaces

### DIFF
--- a/packages/components/src/components/Assembly/Assembly.tsx
+++ b/packages/components/src/components/Assembly/Assembly.tsx
@@ -1,5 +1,5 @@
 import {
-  CompositionComponentNode,
+  ExperienceTreeNode,
   ResolveDesignValueType,
   StyleProps,
 } from '@contentful/experiences-core/types';
@@ -12,10 +12,10 @@ export type AssemblyProps<EditorMode = boolean> = EditorMode extends true
       cfHyperlink?: StyleProps['cfHyperlink'];
       cfOpenInNewTab?: StyleProps['cfOpenInNewTab'];
       editorMode?: EditorMode;
-      node: CompositionComponentNode;
+      node: ExperienceTreeNode;
       resolveDesignValue?: ResolveDesignValueType;
       renderDropzone: (
-        node: CompositionComponentNode,
+        node: ExperienceTreeNode,
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         props?: Record<string, any>,
       ) => React.ReactNode;

--- a/packages/components/src/components/Columns/ColumnTypes.ts
+++ b/packages/components/src/components/Columns/ColumnTypes.ts
@@ -1,4 +1,4 @@
-import { CompositionComponentNode } from '@contentful/experiences-core/types';
+import { ExperienceTreeNode } from '@contentful/experiences-core/types';
 import { CSSProperties, SyntheticEvent } from 'react';
 
 interface ColumnsBaseProps {
@@ -10,11 +10,8 @@ interface ColumnsBaseProps {
 interface ColumnsEditorModeProps extends ColumnsBaseProps {
   editorMode: true;
   cfColumns: string;
-  node: CompositionComponentNode;
-  renderDropzone: (
-    node: CompositionComponentNode,
-    props?: Record<string, unknown>,
-  ) => React.ReactNode;
+  node: ExperienceTreeNode;
+  renderDropzone: (node: ExperienceTreeNode, props?: Record<string, unknown>) => React.ReactNode;
 }
 
 interface ColumnsDeliveryModeProps extends ColumnsBaseProps {
@@ -23,11 +20,8 @@ interface ColumnsDeliveryModeProps extends ColumnsBaseProps {
 
 interface SingleColumnEditorModeProps extends ColumnsBaseProps {
   editorMode: true;
-  node: CompositionComponentNode;
-  renderDropzone: (
-    node: CompositionComponentNode,
-    props?: Record<string, unknown>,
-  ) => React.ReactNode;
+  node: ExperienceTreeNode;
+  renderDropzone: (node: ExperienceTreeNode, props?: Record<string, unknown>) => React.ReactNode;
   cfColumnSpan: string;
 
   wrapperClassName: string;

--- a/packages/components/src/components/ContentfulContainer/ContentfulContainerAsHyperlink.tsx
+++ b/packages/components/src/components/ContentfulContainer/ContentfulContainerAsHyperlink.tsx
@@ -2,9 +2,9 @@
 import React, { RefObject } from 'react';
 
 import type {
-  CompositionComponentNode,
-  CompositionDataSource,
-  CompositionUnboundValues,
+  ExperienceTreeNode,
+  ExperienceDataSource,
+  ExperienceUnboundValues,
   StyleProps,
 } from '@contentful/experiences-core/types';
 
@@ -14,16 +14,13 @@ import { combineClasses } from '../../utils/combineClasses';
 export type ContentfulContainerAsHyperlinkProps<EditorMode = boolean> = (EditorMode extends true
   ? {
       editorMode?: EditorMode;
-      node: CompositionComponentNode;
-      dataSource?: CompositionDataSource;
-      unboundValues?: CompositionUnboundValues;
+      node: ExperienceTreeNode;
+      dataSource?: ExperienceDataSource;
+      unboundValues?: ExperienceUnboundValues;
       resolveDesignValue?: any;
       entityStore?: RefObject<EntityStore>;
       areEntitiesFetched?: boolean;
-      renderDropzone: (
-        node: CompositionComponentNode,
-        props?: Record<string, any>,
-      ) => React.ReactNode;
+      renderDropzone: (node: ExperienceTreeNode, props?: Record<string, any>) => React.ReactNode;
     }
   : {
       editorMode: EditorMode;

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -28,7 +28,7 @@ export const OUTGOING_EVENTS = {
 
 export const INCOMING_EVENTS = {
   RequestEditorMode: 'requestEditorMode',
-  CompositionUpdated: 'componentTreeUpdated',
+  ExperienceUpdated: 'componentTreeUpdated',
   ComponentDraggingChanged: 'componentDraggingChanged',
   ComponentDragCanceled: 'componentDragCanceled',
   ComponentDragStarted: 'componentDragStarted',

--- a/packages/core/src/deep-binding/DeepReference.ts
+++ b/packages/core/src/deep-binding/DeepReference.ts
@@ -1,9 +1,9 @@
 import {
-  CompositionComponentNode,
-  CompositionDataSource,
-  CompositionNode,
+  ExperienceTreeNode,
+  ExperienceDataSource,
   DataSourceEntryValueType,
   ExperienceEntry,
+  ComponentTreeNode,
   Link,
 } from '@/types';
 import { isDeepPath, parseDataSourcePathWithL1DeepBindings } from '@/utils/pathSchema';
@@ -13,7 +13,7 @@ import { EntityStoreBase } from '@/entity/EntityStoreBase';
 
 type DeepReferenceOpts = {
   path: string;
-  dataSource: CompositionDataSource;
+  dataSource: ExperienceDataSource;
 };
 
 export class DeepReference {
@@ -83,7 +83,7 @@ export function gatherDeepReferencesFromExperienceEntry(
       definitionId: 'root',
       variables: {},
       children,
-    } as CompositionNode,
+    } as ComponentTreeNode,
     (node) => {
       if (!node.variables) return;
 
@@ -105,8 +105,8 @@ export function gatherDeepReferencesFromExperienceEntry(
 }
 
 export function gatherDeepReferencesFromTree(
-  startingNode: CompositionComponentNode,
-  dataSource: CompositionDataSource,
+  startingNode: ExperienceTreeNode,
+  dataSource: ExperienceDataSource,
 ): DeepReference[] {
   const deepReferences: Array<DeepReference> = [];
 

--- a/packages/core/src/entity/EntityStore.ts
+++ b/packages/core/src/entity/EntityStore.ts
@@ -1,6 +1,6 @@
 import type { Asset, Entry, UnresolvedLink } from 'contentful';
 import { isExperienceEntry } from '@/utils';
-import type { Composition, CompositionUnboundValues, ExperienceEntry } from '@/types';
+import type { ExperienceFields, ExperienceUnboundValues, ExperienceEntry } from '@/types';
 import { EntityStoreBase } from './EntityStoreBase';
 import { get } from '@/utils/get';
 import { transformAssetFileToUrl } from './value-transformers';
@@ -12,8 +12,8 @@ type EntityStoreArgs = {
 };
 
 export class EntityStore extends EntityStoreBase {
-  private _experienceEntry: Composition | undefined;
-  private _unboundValues: CompositionUnboundValues | undefined;
+  private _experienceEntry: ExperienceFields | undefined;
+  private _unboundValues: ExperienceUnboundValues | undefined;
 
   constructor(json: string);
   constructor({ experienceEntry, entities, locale }: EntityStoreArgs);
@@ -80,7 +80,7 @@ export class EntityStore extends EntityStoreBase {
    * the latter one is certainly just a default value while the other one is from the actual instance.
    * @param unboundValues set of unbound values defined in the assembly definition
    */
-  public addAssemblyUnboundValues(unboundValues: CompositionUnboundValues) {
+  public addAssemblyUnboundValues(unboundValues: ExperienceUnboundValues) {
     this._unboundValues = { ...unboundValues, ...(this._unboundValues ?? {}) };
   }
 

--- a/packages/core/src/test/__fixtures__/composition.ts
+++ b/packages/core/src/test/__fixtures__/composition.ts
@@ -1,8 +1,8 @@
 import { CONTENTFUL_COMPONENTS, LATEST_SCHEMA_VERSION } from '@/constants';
-import { Composition, ExperienceEntry, SchemaVersions } from '@/types';
+import { ExperienceEntry, SchemaVersions } from '@/types';
 import { entityIds } from './entities';
 
-const compositionFields: Composition = {
+const compositionFields: ExperienceEntry['fields'] = {
   title: 'Test Composition',
   slug: 'test',
   componentTree: {
@@ -81,16 +81,16 @@ export const compositionEntry: ExperienceEntry = {
     },
   },
   metadata: { tags: [] },
-  fields: compositionFields as Composition,
+  fields: compositionFields as ExperienceEntry['fields'],
 };
 
-type createCompositionEntryArgs = {
+type createExperienceEntryArgs = {
   schemaVersion: SchemaVersions;
 };
 
-export const createCompositionEntry = ({
+export const createExperienceEntry = ({
   schemaVersion = LATEST_SCHEMA_VERSION,
-}: createCompositionEntryArgs): ExperienceEntry => {
+}: createExperienceEntryArgs): ExperienceEntry => {
   return {
     sys: {
       id: 'composition-id',
@@ -176,7 +176,7 @@ export const assemblyGeneratedVariableName = 'text_uuid1Assembly';
 export const createAssemblyEntry = ({
   schemaVersion = LATEST_SCHEMA_VERSION,
   id = 'assembly-id',
-}: createCompositionEntryArgs & { id: string }) => {
+}: createExperienceEntryArgs & { id: string }) => {
   return {
     sys: {
       id,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -16,21 +16,11 @@ import type {
 } from '@contentful/experiences-validators';
 // TODO: Remove references to 'Composition'
 export type {
-  /** @deprecated the old type name will be replaced by ExperienceDataSource as of v5 */
-  ExperienceDataSource as CompositionDataSource,
   ExperienceDataSource,
-  /** @deprecated the old type name will be replaced by ExperienceUnboundValue as of v5 */
-  ExperienceUnboundValues as CompositionUnboundValues,
   ExperienceUnboundValues,
   ExperienceComponentSettings,
-  /** @deprecated the old type name will be replaced by ComponentPropertyValue as of v5 */
-  ComponentPropertyValue as CompositionComponentPropValue,
   ComponentPropertyValue,
-  /** @deprecated the old type name will be replaced by ExperienceNode as of v5 */
-  ComponentTreeNode as CompositionNode,
   ComponentTreeNode,
-  /** @deprecated the old type name will be replaced by PrimitiveValue as of v5 */
-  PrimitiveValue as CompositionVariableValueType,
   PrimitiveValue,
   ValuesByBreakpoint,
   Breakpoint,
@@ -175,15 +165,10 @@ export type ExperienceTreeNode = {
   children: ExperienceTreeNode[];
   parentId?: string;
 };
-/** @deprecated use ExperienceTreeNode instead */
-export type CompositionComponentNode = ExperienceTreeNode;
-
 /** Type of the tree data structure exchanged via postMessage between the SDK and Contentful Web app */
 export type ExperienceTree = {
   root: ExperienceTreeNode;
 };
-/** @deprecated use ExperienceTree instead */
-export type CompositionTree = ExperienceTree;
 
 export type ExternalSDKMode = 'preview' | 'delivery';
 export type InternalSDKMode = ExternalSDKMode | 'editor';
@@ -255,9 +240,6 @@ export type ExperienceFields = {
   componentSettings?: ExperienceComponentSettings;
 };
 
-/** @deprecated use ExperienceFields instead */
-export type Composition = ExperienceFields;
-
 export type RecursiveDesignTokenDefinition = {
   [key: string]: string | RecursiveDesignTokenDefinition;
 };
@@ -279,9 +261,6 @@ export type ExperienceEntry = {
   fields: ExperienceFields;
   metadata: Entry['metadata'];
 };
-
-/** @deprecated use ExperienceEntry instead */
-export type CompositionEntry = ExperienceEntry;
 
 export interface RawCoordinates {
   left: number;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -148,8 +148,9 @@ export type BindingMapByBlockId = Record<string, BindingMap>;
 
 export type DataSourceEntryValueType = Link<'Entry' | 'Asset'>;
 
-// TODO: add conditional typing magic to reduce the number of optionals
-export type CompositionComponentNode = {
+/** Type of a single node of the experience tree exchanged via postMessage between the SDK and Contentful Web app */
+export type ExperienceTreeNode = {
+  // TODO: add conditional typing magic to reduce the number of optionals
   type:
     | 'block'
     | 'root'
@@ -171,13 +172,18 @@ export type CompositionComponentNode = {
     unboundValues: ExperienceUnboundValues;
     breakpoints: Breakpoint[];
   };
-  children: CompositionComponentNode[];
+  children: ExperienceTreeNode[];
   parentId?: string;
 };
+/** @deprecated use ExperienceTreeNode instead */
+export type CompositionComponentNode = ExperienceTreeNode;
 
-export type CompositionTree = {
-  root: CompositionComponentNode;
+/** Type of the tree data structure exchanged via postMessage between the SDK and Contentful Web app */
+export type ExperienceTree = {
+  root: ExperienceTreeNode;
 };
+/** @deprecated use ExperienceTree instead */
+export type CompositionTree = ExperienceTree;
 
 export type ExternalSDKMode = 'preview' | 'delivery';
 export type InternalSDKMode = ExternalSDKMode | 'editor';
@@ -239,7 +245,7 @@ export type CSSProperties = React.CSSProperties;
 
 export type ContainerStyleVariableName = keyof StyleProps;
 
-export type Composition = {
+export type ExperienceFields = {
   title: string;
   slug: string;
   componentTree: ExperienceComponentTree;
@@ -248,6 +254,9 @@ export type Composition = {
   usedComponents?: ExperienceUsedComponents | Array<ExperienceEntry>; // This will be either an array of Entry links or an array of resolved Experience entries
   componentSettings?: ExperienceComponentSettings;
 };
+
+/** @deprecated use ExperienceFields instead */
+export type Composition = ExperienceFields;
 
 export type RecursiveDesignTokenDefinition = {
   [key: string]: string | RecursiveDesignTokenDefinition;
@@ -264,11 +273,15 @@ export type DesignTokensDefinition = {
   textColor?: Record<string, string>;
 } & RecursiveDesignTokenDefinition;
 
+/** Type of experience entry JSON data structure as returned by CPA/CDA */
 export type ExperienceEntry = {
   sys: Entry['sys'];
-  fields: Composition;
+  fields: ExperienceFields;
   metadata: Entry['metadata'];
 };
+
+/** @deprecated use ExperienceEntry instead */
+export type CompositionEntry = ExperienceEntry;
 
 export interface RawCoordinates {
   left: number;

--- a/packages/core/src/utils/breakpoints.ts
+++ b/packages/core/src/utils/breakpoints.ts
@@ -1,5 +1,5 @@
 import { getDesignTokenRegistration } from '@/registries';
-import { Breakpoint, CompositionVariableValueType, ValuesByBreakpoint } from '@/types';
+import { Breakpoint, PrimitiveValue, ValuesByBreakpoint } from '@/types';
 
 export const MEDIA_QUERY_REGEXP = /(<|>)(\d{1,})(px|cm|mm|in|pt|pc)$/;
 
@@ -21,7 +21,7 @@ const toCSSMediaQuery = ({ query }: Breakpoint): string | undefined => {
 // Remove this helper when upgrading to TypeScript 5.0 - https://github.com/microsoft/TypeScript/issues/48829
 const findLast = <T>(
   array: Array<T>,
-  predicate: Parameters<Array<T>['find']>[0]
+  predicate: Parameters<Array<T>['find']>[0],
 ): T | undefined => {
   return array.reverse().find(predicate);
 };
@@ -44,14 +44,14 @@ export const mediaQueryMatcher = (breakpoints: Breakpoint[]) => {
 
   return [mediaQueryMatchers, mediaQueryMatches] as [
     typeof mediaQueryMatchers,
-    typeof mediaQueryMatches
+    typeof mediaQueryMatches,
   ];
 };
 
 export const getActiveBreakpointIndex = (
   breakpoints: Breakpoint[],
   mediaQueryMatches: Record<string, boolean>,
-  fallbackBreakpointIndex: number
+  fallbackBreakpointIndex: number,
 ) => {
   // The breakpoints are ordered (desktop-first: descending by screen width)
   const breakpointsWithMatches = breakpoints.map(({ id }, index) => ({
@@ -71,7 +71,7 @@ export const getFallbackBreakpointIndex = (breakpoints: Breakpoint[]) => {
   // If there is none, we just take the first one in the list.
   return Math.max(
     breakpoints.findIndex(({ query }) => query === '*'),
-    0
+    0,
   );
 };
 
@@ -93,9 +93,9 @@ export const getValueForBreakpoint = (
   valuesByBreakpoint: ValuesByBreakpoint,
   breakpoints: Breakpoint[],
   activeBreakpointIndex: number,
-  variableName: string
+  variableName: string,
 ) => {
-  const eventuallyResolveDesignTokens = (value: CompositionVariableValueType) => {
+  const eventuallyResolveDesignTokens = (value: PrimitiveValue) => {
     // For some built-in design propertier, we support design tokens
     if (builtInStylesWithDesignTokens.includes(variableName)) {
       return getDesignTokenRegistration(value as string, variableName);

--- a/packages/core/src/utils/stylesUtils.spec.ts
+++ b/packages/core/src/utils/stylesUtils.spec.ts
@@ -1,4 +1,4 @@
-import { CompositionComponentNode } from '@/types';
+import { ExperienceTreeNode } from '@/types';
 import { calculateNodeDefaultHeight } from './stylesUtils';
 import { describe, it, expect } from 'vitest';
 import { CONTENTFUL_COMPONENTS, EMPTY_CONTAINER_HEIGHT } from '@/constants';
@@ -43,7 +43,7 @@ describe('calculateNodeDefaultHeight', () => {
   });
 
   it('should return "100%" when container has a non-container child', () => {
-    const childNode: CompositionComponentNode = {
+    const childNode: ExperienceTreeNode = {
       type: 'block',
       data: {
         id: 'block1',

--- a/packages/core/src/utils/stylesUtils.ts
+++ b/packages/core/src/utils/stylesUtils.ts
@@ -11,7 +11,7 @@ import {
   CSSProperties,
   StyleProps,
   CompositionVariableValueType,
-  CompositionComponentNode,
+  ExperienceTreeNode,
 } from '@/types';
 import { isContentfulStructureComponent } from './components';
 import { EMPTY_CONTAINER_HEIGHT } from '../constants';
@@ -25,7 +25,7 @@ export const buildStyleTag = ({ styles, nodeId }: { styles: CSSProperties; nodeI
       (acc, [key, value]) =>
         `${acc}
         ${toCSSAttribute(key)}: ${value};`,
-      ''
+      '',
     );
 
   const className = `cfstyles-${nodeId ? nodeId : md5(stylesStr)}`;
@@ -79,7 +79,7 @@ export const buildCfStyles = ({
     ...transformBackgroundImage(
       cfBackgroundImageUrl,
       cfBackgroundImageScaling,
-      cfBackgroundImageAlignment
+      cfBackgroundImageAlignment,
     ),
     fontSize: cfFontSize,
     fontWeight: cfTextBold ? 'bold' : cfFontWeight,
@@ -104,7 +104,7 @@ export const calculateNodeDefaultHeight = ({
   value,
 }: {
   blockId?: string;
-  children: CompositionComponentNode['children'];
+  children: ExperienceTreeNode['children'];
   value: CompositionVariableValueType;
 }) => {
   if (!blockId || !isContentfulStructureComponent(blockId) || value !== 'auto') {

--- a/packages/core/src/utils/stylesUtils.ts
+++ b/packages/core/src/utils/stylesUtils.ts
@@ -7,12 +7,7 @@ import {
   transformFill,
   transformGridColumn,
 } from './transformers';
-import {
-  CSSProperties,
-  StyleProps,
-  CompositionVariableValueType,
-  ExperienceTreeNode,
-} from '@/types';
+import { CSSProperties, StyleProps, PrimitiveValue, ExperienceTreeNode } from '@/types';
 import { isContentfulStructureComponent } from './components';
 import { EMPTY_CONTAINER_HEIGHT } from '../constants';
 
@@ -105,7 +100,7 @@ export const calculateNodeDefaultHeight = ({
 }: {
   blockId?: string;
   children: ExperienceTreeNode['children'];
-  value: CompositionVariableValueType;
+  value: PrimitiveValue;
 }) => {
   if (!blockId || !isContentfulStructureComponent(blockId) || value !== 'auto') {
     return value;

--- a/packages/core/src/utils/transformers.ts
+++ b/packages/core/src/utils/transformers.ts
@@ -1,11 +1,6 @@
 import { BLOCKS, Document as RichTextDocument } from '@contentful/rich-text-types';
 
-import {
-  StyleProps,
-  CSSProperties,
-  ComponentDefinitionVariable,
-  CompositionVariableValueType,
-} from '@/types';
+import { StyleProps, CSSProperties, ComponentDefinitionVariable, PrimitiveValue } from '@/types';
 import { Link } from 'contentful';
 
 export const transformFill = (value?: string) => (value === 'fill' ? '100%' : value);
@@ -147,7 +142,7 @@ export const transformBackgroundImage = (
 };
 
 export const transformContentValue = (
-  value: CompositionVariableValueType | Link<'Asset'>,
+  value: PrimitiveValue | Link<'Asset'>,
   variableDefinition: ComponentDefinitionVariable,
 ) => {
   if (variableDefinition.type === 'RichText') {
@@ -156,9 +151,7 @@ export const transformContentValue = (
   return value;
 };
 
-export const transformRichText = (
-  value: CompositionVariableValueType,
-): RichTextDocument | undefined => {
+export const transformRichText = (value: PrimitiveValue): RichTextDocument | undefined => {
   if (typeof value === 'string') {
     return {
       data: {},

--- a/packages/core/src/utils/utils.spec.ts
+++ b/packages/core/src/utils/utils.spec.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect } from 'vitest';
-import { CompositionComponentNode } from '@/types';
+import { ExperienceTreeNode } from '@/types';
 import { generateRandomId, getInsertionData } from '@/utils';
 
-const dropReceiverChildNode: CompositionComponentNode = {
+const dropReceiverChildNode: ExperienceTreeNode = {
   type: 'block',
   data: {
     id: 'drop-receiver-node-child',
@@ -14,7 +14,7 @@ const dropReceiverChildNode: CompositionComponentNode = {
   children: [],
 };
 
-const dropReceiverNode: CompositionComponentNode = {
+const dropReceiverNode: ExperienceTreeNode = {
   type: 'block',
   data: {
     id: 'drop-receiver-node',
@@ -26,7 +26,7 @@ const dropReceiverNode: CompositionComponentNode = {
   children: [dropReceiverChildNode],
 };
 
-const childFillerNode1: CompositionComponentNode = {
+const childFillerNode1: ExperienceTreeNode = {
   type: 'block',
   data: {
     id: 'random-child-node-1',
@@ -38,7 +38,7 @@ const childFillerNode1: CompositionComponentNode = {
   children: [],
 };
 
-const childFillerNode2: CompositionComponentNode = {
+const childFillerNode2: ExperienceTreeNode = {
   type: 'block',
   data: {
     id: 'random-child-node-1',
@@ -50,7 +50,7 @@ const childFillerNode2: CompositionComponentNode = {
   children: [],
 };
 
-const dropReceiverParentNode: CompositionComponentNode = {
+const dropReceiverParentNode: ExperienceTreeNode = {
   type: 'root',
   data: {
     id: 'tree-root',
@@ -75,7 +75,7 @@ describe('getInsertionData', () => {
         isMouseInUpperHalf: false,
         isOverTopIndicator: false,
         isOverBottomIndicator: false,
-      })
+      }),
     ).toEqual({
       node: dropReceiverParentNode,
       index: 1, // dropped before the dropReceiverNode within the dropReceiverParentNode
@@ -94,7 +94,7 @@ describe('getInsertionData', () => {
         isMouseInUpperHalf: false,
         isOverTopIndicator: false,
         isOverBottomIndicator: false,
-      })
+      }),
     ).toEqual({
       node: dropReceiverParentNode,
       index: 2, // dropped after the dropReceiverNode within the dropReceiverParentNode
@@ -113,7 +113,7 @@ describe('getInsertionData', () => {
         isMouseInUpperHalf: false,
         isOverTopIndicator: true,
         isOverBottomIndicator: false,
-      })
+      }),
     ).toEqual({
       node: dropReceiverParentNode,
       index: 1, // dropped before the dropReceiverNode within the dropReceiverParentNode
@@ -132,7 +132,7 @@ describe('getInsertionData', () => {
         isMouseInUpperHalf: false,
         isOverTopIndicator: false,
         isOverBottomIndicator: true,
-      })
+      }),
     ).toEqual({
       node: dropReceiverParentNode,
       index: 2, // dropped after the dropReceiverNode within the dropReceiverParentNode
@@ -152,7 +152,7 @@ describe('getInsertionData', () => {
           isMouseInUpperHalf: false,
           isOverTopIndicator: false,
           isOverBottomIndicator: false,
-        })
+        }),
       ).toEqual({
         node: dropReceiverNode,
         index: 0, // dropped as the new first child within the dropReceiverNode
@@ -171,7 +171,7 @@ describe('getInsertionData', () => {
           isMouseInUpperHalf: false,
           isOverTopIndicator: false,
           isOverBottomIndicator: false,
-        })
+        }),
       ).toEqual({
         node: dropReceiverNode,
         index: 1, // dropped as the new last child within the dropReceiverNode
@@ -192,7 +192,7 @@ describe('getInsertionData', () => {
           isMouseInUpperHalf: true,
           isOverTopIndicator: false,
           isOverBottomIndicator: false,
-        })
+        }),
       ).toEqual({
         node: dropReceiverNode,
         index: 0, // dropped as the new first child within the dropReceiverNode
@@ -211,7 +211,7 @@ describe('getInsertionData', () => {
           isMouseInUpperHalf: false,
           isOverTopIndicator: false,
           isOverBottomIndicator: false,
-        })
+        }),
       ).toEqual({
         node: dropReceiverNode,
         index: 1, // dropped as the new last child within the dropReceiverNode

--- a/packages/core/src/utils/utils.ts
+++ b/packages/core/src/utils/utils.ts
@@ -1,9 +1,9 @@
 import {
-  CompositionTree,
-  CompositionComponentNode,
+  ExperienceTree,
+  ExperienceTreeNode,
   StyleProps,
-  CompositionDataSource,
-  CompositionUnboundValues,
+  ExperienceDataSource,
+  ExperienceUnboundValues,
   ExperienceEntry,
   ComponentDefinition,
 } from '@/types';
@@ -11,13 +11,13 @@ import { Entry } from 'contentful';
 import { ASSEMBLY_DEFAULT_CATEGORY } from '@/constants';
 
 export const getDataFromTree = (
-  tree: CompositionTree,
+  tree: ExperienceTree,
 ): {
-  dataSource: CompositionDataSource;
-  unboundValues: CompositionUnboundValues;
+  dataSource: ExperienceDataSource;
+  unboundValues: ExperienceUnboundValues;
 } => {
-  let dataSource: CompositionDataSource = {};
-  let unboundValues: CompositionUnboundValues = {};
+  let dataSource: ExperienceDataSource = {};
+  let unboundValues: ExperienceUnboundValues = {};
   const queue = [...tree.root.children];
 
   while (queue.length) {
@@ -41,8 +41,8 @@ export const getDataFromTree = (
 };
 
 type GetInsertionDataParams = {
-  dropReceiverNode: CompositionComponentNode;
-  dropReceiverParentNode: CompositionComponentNode;
+  dropReceiverNode: ExperienceTreeNode;
+  dropReceiverParentNode: ExperienceTreeNode;
   flexDirection?: StyleProps['cfFlexDirection'];
   isMouseAtTopBorder: boolean;
   isMouseAtBottomBorder: boolean;
@@ -53,7 +53,7 @@ type GetInsertionDataParams = {
 };
 
 type InsertionData = {
-  node: CompositionComponentNode;
+  node: ExperienceTreeNode;
   index: number;
 };
 

--- a/packages/experience-builder-sdk/src/blocks/preview/CompositionBlock.spec.tsx
+++ b/packages/experience-builder-sdk/src/blocks/preview/CompositionBlock.spec.tsx
@@ -4,7 +4,7 @@ import { render } from '@testing-library/react';
 
 import { CONTENTFUL_COMPONENTS } from '@contentful/experiences-core/constants';
 import { defineComponents, resetComponentRegistry } from '../../core/componentRegistry';
-import type { CompositionNode, ExperienceEntry } from '@contentful/experiences-core/types';
+import type { ComponentTreeNode, ExperienceEntry } from '@contentful/experiences-core/types';
 import { CompositionBlock } from './CompositionBlock';
 import type { Entry } from 'contentful';
 import { compositionEntry } from '../../../test/__fixtures__/composition';
@@ -52,7 +52,7 @@ describe('CompositionBlock', () => {
   });
 
   it('renders the custom component node', () => {
-    const mockCompositionComponentNode: CompositionNode = {
+    const mockExperienceTreeNode: ComponentTreeNode = {
       definitionId: 'custom-component',
       variables: {
         text: { type: 'UnboundValue', key: 'value1' },
@@ -63,7 +63,7 @@ describe('CompositionBlock', () => {
     // Render the component with the initial text
     render(
       <CompositionBlock
-        node={mockCompositionComponentNode}
+        node={mockExperienceTreeNode}
         locale="en-US"
         entityStore={
           {
@@ -80,7 +80,7 @@ describe('CompositionBlock', () => {
   });
 
   it('renders section node', () => {
-    const sectionNode: CompositionNode = {
+    const sectionNode: ComponentTreeNode = {
       definitionId: CONTENTFUL_COMPONENTS.section.id,
       variables: {},
       children: [],
@@ -99,7 +99,7 @@ describe('CompositionBlock', () => {
   });
 
   it('renders container node', () => {
-    const containerNode: CompositionNode = {
+    const containerNode: ComponentTreeNode = {
       definitionId: CONTENTFUL_COMPONENTS.container.id,
       variables: {},
       children: [],
@@ -142,7 +142,7 @@ describe('CompositionBlock', () => {
       locale: 'en-US',
     });
 
-    const assemblyNode: CompositionNode = {
+    const assemblyNode: ComponentTreeNode = {
       definitionId: defaultAssemblyId,
       variables: {
         [assemblyGeneratedVariableName]: { type: 'UnboundValue', key: unboundValueKey },

--- a/packages/experience-builder-sdk/src/blocks/preview/CompositionBlock.tsx
+++ b/packages/experience-builder-sdk/src/blocks/preview/CompositionBlock.tsx
@@ -12,8 +12,8 @@ import {
   EMPTY_CONTAINER_HEIGHT,
 } from '@contentful/experiences-core/constants';
 import type {
-  CompositionNode,
-  CompositionVariableValueType,
+  ComponentTreeNode,
+  PrimitiveValue,
   ResolveDesignValueType,
   StyleProps,
 } from '@contentful/experiences-core/types';
@@ -34,7 +34,7 @@ import { resolveAssembly } from '../../core/preview/assemblyUtils';
 import { Assembly } from '../../components/Assembly';
 
 type CompositionBlockProps = {
-  node: CompositionNode;
+  node: ComponentTreeNode;
   locale: string;
   entityStore: EntityStore;
   resolveDesignValue: ResolveDesignValueType;
@@ -82,7 +82,7 @@ export const CompositionBlock = ({
       return {};
     }
 
-    const propMap: Record<string, CompositionVariableValueType> = {};
+    const propMap: Record<string, PrimitiveValue> = {};
 
     return Object.entries(node.variables).reduce((acc, [variableName, variable]) => {
       switch (variable.type) {
@@ -145,7 +145,7 @@ export const CompositionBlock = ({
 
   const children =
     componentRegistration.definition.children === true
-      ? node.children.map((childNode: CompositionNode, index) => {
+      ? node.children.map((childNode: ComponentTreeNode, index) => {
           return (
             <CompositionBlock
               node={childNode}

--- a/packages/experience-builder-sdk/src/blocks/preview/PreviewDeliveryRoot.test.tsx
+++ b/packages/experience-builder-sdk/src/blocks/preview/PreviewDeliveryRoot.test.tsx
@@ -3,14 +3,14 @@ import { render } from '@testing-library/react';
 import { EntityStore } from '@contentful/experiences-core';
 import { PreviewDeliveryRoot } from './PreviewDeliveryRoot';
 import type { Experience } from '@contentful/experiences-core/types';
-import { createCompositionEntry } from '../../../test/__fixtures__/composition';
+import { createExperienceEntry } from '../../../test/__fixtures__/composition';
 import { assets, entries } from '../../../test/__fixtures__/entities';
 import type { Entry } from 'contentful';
 import { compatibleVersions } from '../../constants';
 import { defineComponents, resetComponentRegistry } from '../../core/componentRegistry';
 
 const locale = 'en-US';
-const compositionEntry = createCompositionEntry({
+const compositionEntry = createExperienceEntry({
   schemaVersion: '2023-09-28',
 });
 
@@ -36,7 +36,7 @@ describe('PreviewDeliveryRoot', () => {
   });
 
   it('throws an error if experience the schema version is not compatible', () => {
-    const experienceEntryMock = createCompositionEntry({ schemaVersion: '2023-06-27' });
+    const experienceEntryMock = createExperienceEntry({ schemaVersion: '2023-06-27' });
 
     const entityStore = new EntityStore({
       experienceEntry: experienceEntryMock as unknown as Entry,

--- a/packages/experience-builder-sdk/src/core/preview/assemblyUtils.spec.ts
+++ b/packages/experience-builder-sdk/src/core/preview/assemblyUtils.spec.ts
@@ -3,13 +3,13 @@ import { compositionEntry } from '../../../test/__fixtures__/composition';
 import { createAssemblyEntry } from '../../../test/__fixtures__/assembly';
 import { assets, entries } from '../../../test/__fixtures__/entities';
 import { CONTENTFUL_COMPONENTS } from '@contentful/experiences-core/constants';
-import type { CompositionNode } from '@contentful/experiences-core/types';
+import type { ComponentTreeNode } from '@contentful/experiences-core/types';
 import { EntityStore } from '@contentful/experiences-core';
 import { resolveAssembly } from './assemblyUtils';
 
 describe('resolveAssembly', () => {
   it('should return the input node when it is not a assembly', () => {
-    const containerNode: CompositionNode = {
+    const containerNode: ComponentTreeNode = {
       definitionId: CONTENTFUL_COMPONENTS.container.id,
       variables: {},
       children: [],
@@ -26,7 +26,7 @@ describe('resolveAssembly', () => {
   });
 
   it('should return the input node when the entity store is undefined', () => {
-    const containerNode: CompositionNode = {
+    const containerNode: ComponentTreeNode = {
       definitionId: CONTENTFUL_COMPONENTS.container.id,
       variables: {},
       children: [],
@@ -40,7 +40,7 @@ describe('resolveAssembly', () => {
   });
 
   it('should return the input node when the corresponding component is not found in the entity store', () => {
-    const assemblyNode: CompositionNode = {
+    const assemblyNode: ComponentTreeNode = {
       definitionId: 'assembly-id',
       variables: {},
       children: [],
@@ -57,7 +57,7 @@ describe('resolveAssembly', () => {
     expect(result).toBe(assemblyNode);
   });
   it('should return a assembly node with children', () => {
-    const assemblyNode: CompositionNode = {
+    const assemblyNode: ComponentTreeNode = {
       definitionId: 'assembly-id',
       variables: {},
       children: [],

--- a/packages/experience-builder-sdk/src/core/preview/assemblyUtils.ts
+++ b/packages/experience-builder-sdk/src/core/preview/assemblyUtils.ts
@@ -1,17 +1,14 @@
 import { checkIsAssemblyNode, EntityStore } from '@contentful/experiences-core';
-import type {
-  CompositionComponentPropValue,
-  CompositionNode,
-} from '@contentful/experiences-core/types';
+import type { ComponentPropertyValue, ComponentTreeNode } from '@contentful/experiences-core/types';
 
 export const deserializeAssemblyNode = ({
   node,
   componentInstanceVariables,
 }: {
-  node: CompositionNode;
-  componentInstanceVariables: CompositionNode['variables'];
-}): CompositionNode => {
-  const variables: Record<string, CompositionComponentPropValue> = {};
+  node: ComponentTreeNode;
+  componentInstanceVariables: ComponentTreeNode['variables'];
+}): ComponentTreeNode => {
+  const variables: Record<string, ComponentPropertyValue> = {};
 
   for (const [variableName, variable] of Object.entries(node.variables)) {
     variables[variableName] = variable;
@@ -35,7 +32,7 @@ export const deserializeAssemblyNode = ({
     }
   }
 
-  const children: CompositionNode[] = node.children.map((child) =>
+  const children: ComponentTreeNode[] = node.children.map((child) =>
     deserializeAssemblyNode({
       node: child,
       componentInstanceVariables,
@@ -53,7 +50,7 @@ export const resolveAssembly = ({
   node,
   entityStore,
 }: {
-  node: CompositionNode;
+  node: ComponentTreeNode;
   entityStore: EntityStore;
 }) => {
   const isAssembly = checkIsAssemblyNode({

--- a/packages/experience-builder-sdk/src/hooks/useBreakpoints.ts
+++ b/packages/experience-builder-sdk/src/hooks/useBreakpoints.ts
@@ -1,7 +1,7 @@
 import type {
   ValuesByBreakpoint,
   Breakpoint,
-  CompositionVariableValueType,
+  PrimitiveValue,
   ResolveDesignValueType,
 } from '@contentful/experiences-core/types';
 import {
@@ -55,10 +55,7 @@ export const useBreakpoints = (breakpoints: Breakpoint[]) => {
   );
 
   const resolveDesignValue: ResolveDesignValueType = useCallback(
-    (
-      valuesByBreakpoint: ValuesByBreakpoint,
-      variableName: string,
-    ): CompositionVariableValueType => {
+    (valuesByBreakpoint: ValuesByBreakpoint, variableName: string): PrimitiveValue => {
       return getValueForBreakpoint(
         valuesByBreakpoint,
         breakpoints,

--- a/packages/experience-builder-sdk/test/__fixtures__/assembly.ts
+++ b/packages/experience-builder-sdk/test/__fixtures__/assembly.ts
@@ -3,7 +3,7 @@ import {
   ASSEMBLY_NODE_TYPE,
   LATEST_SCHEMA_VERSION,
 } from '@contentful/experiences-core/constants';
-import type { CompositionComponentNode, SchemaVersions } from '@contentful/experiences-core/types';
+import type { ExperienceTreeNode, SchemaVersions } from '@contentful/experiences-core/types';
 
 type createAssemblyEntryArgs = {
   schemaVersion: SchemaVersions;
@@ -107,8 +107,8 @@ export const createAssemblyNode = ({
   unboundValue = 'New year Eve',
   unboundValueKey = undefined,
   boundValueKey = undefined,
-}: createAssemblyNodeArgs): CompositionComponentNode => {
-  const node: CompositionComponentNode = {
+}: createAssemblyNodeArgs): ExperienceTreeNode => {
+  const node: ExperienceTreeNode = {
     type: ASSEMBLY_NODE_TYPE,
     data: {
       blockId,

--- a/packages/experience-builder-sdk/test/__fixtures__/composition.ts
+++ b/packages/experience-builder-sdk/test/__fixtures__/composition.ts
@@ -1,12 +1,8 @@
-import type {
-  Composition,
-  ExperienceEntry,
-  SchemaVersions,
-} from '@contentful/experiences-core/types';
+import type { ExperienceEntry, SchemaVersions } from '@contentful/experiences-core/types';
 import { entityIds } from './entities';
 import { LATEST_SCHEMA_VERSION } from '@contentful/experiences-core/constants';
 
-const compositionFields: Composition = {
+const compositionFields: ExperienceEntry['fields'] = {
   title: 'Test Composition',
   slug: 'test',
   componentTree: {
@@ -88,13 +84,13 @@ export const compositionEntry: ExperienceEntry = {
   fields: compositionFields,
 };
 
-type createCompositionEntryArgs = {
+type createExperienceEntryArgs = {
   schemaVersion: SchemaVersions;
 };
 
-export const createCompositionEntry = ({
+export const createExperienceEntry = ({
   schemaVersion = LATEST_SCHEMA_VERSION,
-}: createCompositionEntryArgs): ExperienceEntry => {
+}: createExperienceEntryArgs): ExperienceEntry => {
   return {
     sys: {
       id: 'composition-id',

--- a/packages/storybook-addon/src/context/useCompositionCanvasSubscriber.ts
+++ b/packages/storybook-addon/src/context/useCompositionCanvasSubscriber.ts
@@ -1,11 +1,11 @@
-import type { CompositionVariableValueType } from '@contentful/experiences-sdk-react';
+import type { PrimitiveValue } from '@contentful/experiences-sdk-react';
 import { useArgs } from '@storybook/manager-api';
 import { useCallback } from 'react';
 
 export function useCompositionCanvasSubscriber() {
   const [_, updateArgs] = useArgs();
 
-  const onDesignValueChanged = (variableName: string, value: CompositionVariableValueType) => {
+  const onDesignValueChanged = (variableName: string, value: PrimitiveValue) => {
     updateArgs({ [variableName]: value });
   };
 

--- a/packages/visual-editor/src/communication/onComponentDrop.ts
+++ b/packages/visual-editor/src/communication/onComponentDrop.ts
@@ -1,5 +1,5 @@
 import { sendMessage } from '@contentful/experiences-core';
-import { CompositionComponentNode } from '@contentful/experiences-core/types';
+import { ExperienceTreeNode } from '@contentful/experiences-core/types';
 import { OUTGOING_EVENTS } from '@contentful/experiences-core/constants';
 
 export const onComponentDropped = ({
@@ -9,7 +9,7 @@ export const onComponentDropped = ({
   parentType,
   parentId,
 }: {
-  node: CompositionComponentNode;
+  node: ExperienceTreeNode;
   index?: number;
   parentType?: string;
   parentBlockId?: string;

--- a/packages/visual-editor/src/components/Dropzone/Dropzone.types.ts
+++ b/packages/visual-editor/src/components/Dropzone/Dropzone.types.ts
@@ -1,6 +1,6 @@
-import { CompositionComponentNode } from '@contentful/experiences-core/types';
+import { ExperienceTreeNode } from '@contentful/experiences-core/types';
 
 export type RenderDropzoneFunction = (
-  node: CompositionComponentNode,
+  node: ExperienceTreeNode,
   props?: Record<string, unknown>,
 ) => React.JSX.Element;

--- a/packages/visual-editor/src/components/Dropzone/EditorBlock.tsx
+++ b/packages/visual-editor/src/components/Dropzone/EditorBlock.tsx
@@ -5,7 +5,7 @@ import { useSelectedInstanceCoordinates } from '@/hooks/useSelectedInstanceCoord
 import { useEditorStore } from '@/store/editor';
 import { useComponent } from './useComponent';
 import type {
-  CompositionComponentNode,
+  ExperienceTreeNode,
   ResolveDesignValueType,
 } from '@contentful/experiences-core/types';
 import {
@@ -22,7 +22,7 @@ import Hitboxes from './Hitboxes';
 
 type EditorBlockProps = {
   placeholder: PlaceholderParams;
-  node: CompositionComponentNode;
+  node: ExperienceTreeNode;
   index: number;
   userIsDragging: boolean;
   draggingNewComponent: boolean | undefined;

--- a/packages/visual-editor/src/components/Dropzone/EditorBlockClone.tsx
+++ b/packages/visual-editor/src/components/Dropzone/EditorBlockClone.tsx
@@ -2,7 +2,7 @@ import React, { CSSProperties } from 'react';
 import styles from '../Draggable/styles.module.css';
 import { useComponent } from './useComponent';
 import type {
-  CompositionComponentNode,
+  ExperienceTreeNode,
   ResolveDesignValueType,
 } from '@contentful/experiences-core/types';
 import { RenderDropzoneFunction } from './Dropzone.types';
@@ -27,7 +27,7 @@ function getStyle(style: CSSProperties = {}, snapshot?: DraggableStateSnapshot) 
 }
 
 type EditorBlockCloneProps = {
-  node: CompositionComponentNode;
+  node: ExperienceTreeNode;
   resolveDesignValue: ResolveDesignValueType;
   provided?: DraggableProvided;
   snapshot?: DraggableStateSnapshot;

--- a/packages/visual-editor/src/components/Dropzone/useComponent.ts
+++ b/packages/visual-editor/src/components/Dropzone/useComponent.ts
@@ -1,7 +1,7 @@
 import React from 'react';
 import type {
   ComponentRegistration,
-  CompositionComponentNode,
+  ExperienceTreeNode,
   ResolveDesignValueType,
 } from '@contentful/experiences-core/types';
 import { useMemo } from 'react';
@@ -16,7 +16,7 @@ import type { RenderDropzoneFunction } from './Dropzone.types';
 import { NoWrapDraggableProps } from '@components/Draggable/DraggableChildComponent';
 
 type UseComponentProps = {
-  node: CompositionComponentNode;
+  node: ExperienceTreeNode;
   resolveDesignValue: ResolveDesignValueType;
   renderDropzone: RenderDropzoneFunction;
   userIsDragging: boolean;

--- a/packages/visual-editor/src/components/Dropzone/useComponentProps.ts
+++ b/packages/visual-editor/src/components/Dropzone/useComponentProps.ts
@@ -16,8 +16,8 @@ import {
 } from '@contentful/experiences-core/constants';
 import type {
   StyleProps,
-  CompositionVariableValueType,
-  CompositionComponentNode,
+  PrimitiveValue,
+  ExperienceTreeNode,
   ResolveDesignValueType,
   ComponentRegistration,
   Link,
@@ -30,12 +30,10 @@ import { useEntityStore } from '@/store/entityStore';
 import type { RenderDropzoneFunction } from './Dropzone.types';
 import { DRAG_PADDING } from '../../types/constants';
 
-type ComponentProps =
-  | StyleProps
-  | Record<string, CompositionVariableValueType | Link<'Entry'> | Link<'Asset'>>;
+type ComponentProps = StyleProps | Record<string, PrimitiveValue | Link<'Entry'> | Link<'Asset'>>;
 
 type UseComponentProps = {
-  node: CompositionComponentNode;
+  node: ExperienceTreeNode;
   resolveDesignValue: ResolveDesignValueType;
   areEntitiesFetched: boolean;
   definition: ComponentRegistration['definition'];

--- a/packages/visual-editor/src/components/RootRenderer/RootRenderer.tsx
+++ b/packages/visual-editor/src/components/RootRenderer/RootRenderer.tsx
@@ -2,7 +2,7 @@ import React, { CSSProperties, useCallback, useRef, useState } from 'react';
 import { useEffect } from 'react';
 import { Dropzone } from '../Dropzone/Dropzone';
 import DraggableContainer from '../Draggable/DraggableComponentList';
-import type { CompositionTree } from '@contentful/experiences-core/types';
+import type { ExperienceTree } from '@contentful/experiences-core/types';
 
 import { COMPONENT_LIST_ID, DRAGGABLE_HEIGHT, ROOT_ID } from '@/types/constants';
 import { useTreeStore } from '@/store/tree';
@@ -15,7 +15,7 @@ import { sendMessage } from '@contentful/experiences-core';
 import { OUTGOING_EVENTS } from '@contentful/experiences-core/constants';
 
 interface Props {
-  onChange?: (data: CompositionTree) => void;
+  onChange?: (data: ExperienceTree) => void;
 }
 
 export const RootRenderer: React.FC<Props> = ({ onChange }) => {

--- a/packages/visual-editor/src/hooks/useBreakpoints.ts
+++ b/packages/visual-editor/src/hooks/useBreakpoints.ts
@@ -1,7 +1,7 @@
 import type {
   ValuesByBreakpoint,
   Breakpoint,
-  CompositionVariableValueType,
+  PrimitiveValue,
   ResolveDesignValueType,
 } from '@contentful/experiences-core/types';
 import {
@@ -58,10 +58,7 @@ export const useBreakpoints = (breakpoints: Breakpoint[]) => {
   );
 
   const resolveDesignValue: ResolveDesignValueType = useCallback(
-    (
-      valuesByBreakpoint: ValuesByBreakpoint,
-      variableName: string,
-    ): CompositionVariableValueType => {
+    (valuesByBreakpoint: ValuesByBreakpoint, variableName: string): PrimitiveValue => {
       return getValueForBreakpoint(
         valuesByBreakpoint,
         breakpoints,

--- a/packages/visual-editor/src/hooks/useDropzoneDirection.ts
+++ b/packages/visual-editor/src/hooks/useDropzoneDirection.ts
@@ -1,6 +1,6 @@
 import { CONTENTFUL_COMPONENTS } from '@contentful/experiences-core/constants';
 import type {
-  CompositionComponentNode,
+  ExperienceTreeNode,
   ResolveDesignValueType,
 } from '@contentful/experiences-core/types';
 import { useEffect } from 'react';
@@ -9,7 +9,7 @@ import { isContentfulStructureComponent } from '@contentful/experiences-core';
 
 interface Params {
   resolveDesignValue: ResolveDesignValueType | undefined;
-  node: CompositionComponentNode | undefined;
+  node: ExperienceTreeNode | undefined;
   zoneId: string;
 }
 

--- a/packages/visual-editor/src/hooks/useEditorSubscriber.ts
+++ b/packages/visual-editor/src/hooks/useEditorSubscriber.ts
@@ -15,12 +15,12 @@ import {
   PostMessageMethods,
 } from '@contentful/experiences-core/constants';
 import {
-  CompositionTree,
-  CompositionComponentNode,
-  CompositionComponentPropValue,
+  ExperienceTree,
+  ExperienceTreeNode,
+  ComponentPropertyValue,
   ComponentRegistration,
   Link,
-  CompositionDataSource,
+  ExperienceDataSource,
   ManagementEntity,
 } from '@contentful/experiences-core/types';
 import { sendSelectedComponentCoordinates } from '@/communication/sendSelectedComponentCoordinates';
@@ -76,7 +76,7 @@ export function useEditorSubscriber() {
    * Also manages "entity status" variables (areEntitiesFetched, isFetchingEntities)
    */
   const fetchMissingEntities = useCallback(
-    async (newDataSource: CompositionDataSource, tree: CompositionTree) => {
+    async (newDataSource: ExperienceDataSource, tree: ExperienceTree) => {
       // if we realize that there's nothing missing and nothing to fill-fetch before we do any async call,
       // then we can simply return and not lock the EntityStore at all.
       const startFetching = () => {
@@ -193,7 +193,7 @@ export function useEditorSubscriber() {
       const { payload } = eventData;
 
       switch (eventData.eventType) {
-        case INCOMING_EVENTS.CompositionUpdated: {
+        case INCOMING_EVENTS.ExperienceUpdated: {
           const {
             tree,
             locale,
@@ -201,12 +201,12 @@ export function useEditorSubscriber() {
             changedValueType,
             assemblies,
           }: {
-            tree: CompositionTree;
+            tree: ExperienceTree;
             assemblies: Link<'Entry'>[];
             locale: string;
             entitiesResolved?: boolean;
-            changedNode?: CompositionComponentNode;
-            changedValueType?: CompositionComponentPropValue['type'];
+            changedNode?: ExperienceTreeNode;
+            changedValueType?: ComponentPropertyValue['type'];
           } = payload;
 
           // Make sure to first store the assemblies before setting the tree and thus triggering a rerender

--- a/packages/visual-editor/src/hooks/useSelectedInstanceCoordinates.ts
+++ b/packages/visual-editor/src/hooks/useSelectedInstanceCoordinates.ts
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import type { CompositionComponentNode } from '@contentful/experiences-core/types';
+import type { ExperienceTreeNode } from '@contentful/experiences-core/types';
 import { sendSelectedComponentCoordinates } from '@/communication/sendSelectedComponentCoordinates';
 import { useEditorStore } from '@/store/editor';
 import { getElementCoordinates } from '@contentful/experiences-core';
@@ -7,7 +7,7 @@ import { getElementCoordinates } from '@contentful/experiences-core';
  * This hook gets the element co-ordinates of a specified element in the DOM
  * and sends the DOM Rect to the client app
  */
-export const useSelectedInstanceCoordinates = ({ node }: { node: CompositionComponentNode }) => {
+export const useSelectedInstanceCoordinates = ({ node }: { node: ExperienceTreeNode }) => {
   const selectedNodeId = useEditorStore((state) => state.selectedNodeId);
 
   useEffect(() => {

--- a/packages/visual-editor/src/store/editor.ts
+++ b/packages/visual-editor/src/store/editor.ts
@@ -1,8 +1,8 @@
 import { defineDesignTokens } from '@contentful/experiences-core';
 import type {
   ComponentRegistration,
-  CompositionDataSource,
-  CompositionUnboundValues,
+  ExperienceDataSource,
+  ExperienceUnboundValues,
   DesignTokensDefinition,
 } from '@contentful/experiences-core/types';
 import { create } from 'zustand';
@@ -15,13 +15,13 @@ export interface InitEditorParams {
   initialLocale: string;
 }
 export interface EditorStore {
-  dataSource: CompositionDataSource;
+  dataSource: ExperienceDataSource;
   locale: string | null;
   selectedNodeId: string | null;
-  unboundValues: CompositionUnboundValues;
+  unboundValues: ExperienceUnboundValues;
   // updaters
-  setDataSource: (data: CompositionDataSource) => void;
-  setUnboundValues: (values: CompositionUnboundValues) => void;
+  setDataSource: (data: ExperienceDataSource) => void;
+  setUnboundValues: (values: ExperienceUnboundValues) => void;
   setLocale: (locale: string) => void;
   setSelectedNodeId: (id: string) => void;
 

--- a/packages/visual-editor/src/store/tree.ts
+++ b/packages/visual-editor/src/store/tree.ts
@@ -1,7 +1,7 @@
 import type {
   Breakpoint,
-  CompositionComponentNode,
-  CompositionTree,
+  ExperienceTreeNode,
+  ExperienceTree,
 } from '@contentful/experiences-core/types';
 import { ROOT_ID, TreeAction } from '@/types/constants';
 import { create } from 'zustand';
@@ -18,15 +18,15 @@ import { getTreeDiffs } from '@/utils/getTreeDiff';
 import { treeVisit } from '@/utils/treeTraversal';
 import { ASSEMBLY_NODE_TYPE } from '@contentful/experiences-core/constants';
 export interface TreeStore {
-  tree: CompositionTree;
+  tree: ExperienceTree;
   breakpoints: Breakpoint[];
-  updateTree: (tree: CompositionTree) => void;
-  updateTreeForced: (tree: CompositionTree) => void;
+  updateTree: (tree: ExperienceTree) => void;
+  updateTreeForced: (tree: ExperienceTree) => void;
   updateNodesByUpdatedEntity: (entityId: string) => void;
   addChild: (
     destinationIndex: number,
     destinationParentId: string,
-    node: CompositionComponentNode,
+    node: ExperienceTreeNode,
   ) => void;
   reorderChildren: (
     destinationIndex: number,
@@ -41,7 +41,7 @@ export interface TreeStore {
   ) => void;
 }
 
-const isAssemblyNode = (node: CompositionComponentNode) => {
+const isAssemblyNode = (node: ExperienceTreeNode) => {
   return node.type === ASSEMBLY_NODE_TYPE;
 };
 

--- a/packages/visual-editor/src/types/Config.tsx
+++ b/packages/visual-editor/src/types/Config.tsx
@@ -1,4 +1,4 @@
-import type { CompositionComponentNode } from '@contentful/experiences-core/types';
+import type { ExperienceTreeNode } from '@contentful/experiences-core/types';
 
 type WithCtflProps<Props> = Props & {
   id: string;
@@ -21,7 +21,7 @@ export type ComponentConfig<
   defaultProps?: DefaultProps;
 };
 
-export type ComponentData = CompositionComponentNode;
+export type ComponentData = ExperienceTreeNode;
 
 export interface Dropzone {
   direction: 'horizontal' | 'vertical';

--- a/packages/visual-editor/src/types/treeActions.ts
+++ b/packages/visual-editor/src/types/treeActions.ts
@@ -1,4 +1,4 @@
-import { CompositionComponentNode } from '@contentful/experiences-core/types';
+import { ExperienceTreeNode } from '@contentful/experiences-core/types';
 import { TreeAction } from './constants';
 
 interface DiffBase {
@@ -15,21 +15,21 @@ export interface RemoveNode extends DiffBase {
 export interface AddNode extends DiffBase {
   type: TreeAction.ADD_NODE;
   indexToAdd: number;
-  nodeToAdd: CompositionComponentNode;
+  nodeToAdd: ExperienceTreeNode;
   parentNodeId: string;
 }
 
 export interface ReplaceNode extends DiffBase {
   type: TreeAction.REPLACE_NODE;
   originalId: string;
-  node: CompositionComponentNode;
+  node: ExperienceTreeNode;
   indexToReplace: number;
 }
 
 export interface UpdateNode extends DiffBase {
   type: TreeAction.UPDATE_NODE;
   nodeId: string;
-  node: CompositionComponentNode;
+  node: ExperienceTreeNode;
 }
 
 export interface MoveNode extends DiffBase {

--- a/packages/visual-editor/src/utils/assemblyUtils.spec.ts
+++ b/packages/visual-editor/src/utils/assemblyUtils.spec.ts
@@ -10,7 +10,7 @@ import {
   ASSEMBLY_BLOCK_NODE_TYPE,
   ASSEMBLY_NODE_TYPE,
 } from '@contentful/experiences-core/constants';
-import type { CompositionComponentNode, CompositionNode } from '@contentful/experiences-core/types';
+import type { ExperienceTreeNode, ComponentTreeNode } from '@contentful/experiences-core/types';
 import { EditorModeEntityStore } from '@contentful/experiences-core';
 import { deserializeAssemblyNode, resolveAssembly } from './assemblyUtils';
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
@@ -32,11 +32,11 @@ describe('deserializeAssemblyNode', () => {
     assembliesRegistry.clear();
   });
 
-  it('should correctly deserialize a simple CompositionNode with no variables or children', () => {
-    const node: CompositionNode = {
+  it('should correctly deserialize a simple ComponentTreeNode with no variables or children', () => {
+    const node: ComponentTreeNode = {
       definitionId: 'assembly-id',
       variables: {},
-      children: assemblyEntry.fields.componentTree.children as CompositionNode['children'],
+      children: assemblyEntry.fields.componentTree.children as ComponentTreeNode['children'],
     };
 
     const result = deserializeAssemblyNode({
@@ -135,7 +135,7 @@ describe('resolveAssembly', () => {
   });
 
   it('should return the input node when its type is not an assembly node type', () => {
-    const node: CompositionComponentNode = {
+    const node: ExperienceTreeNode = {
       type: 'block',
       data: {
         id: '1',
@@ -162,7 +162,7 @@ describe('resolveAssembly', () => {
   });
 
   it('should return the input node when assembliesRegistry does not have the componentId', () => {
-    const node: CompositionComponentNode = {
+    const node: ExperienceTreeNode = {
       type: ASSEMBLY_NODE_TYPE,
       data: {
         blockId: 'assemblyId',
@@ -184,7 +184,7 @@ describe('resolveAssembly', () => {
   });
 
   it('should return the input node when entityStore does not have componentFields', () => {
-    const node: CompositionComponentNode = {
+    const node: ExperienceTreeNode = {
       type: ASSEMBLY_NODE_TYPE,
       data: {
         assembly: {
@@ -213,7 +213,7 @@ describe('resolveAssembly', () => {
   });
 
   it('should return the input node when entityStore is null', () => {
-    const node: CompositionComponentNode = {
+    const node: ExperienceTreeNode = {
       type: ASSEMBLY_NODE_TYPE,
       data: {
         assembly: {

--- a/packages/visual-editor/src/utils/assemblyUtils.ts
+++ b/packages/visual-editor/src/utils/assemblyUtils.ts
@@ -1,11 +1,11 @@
 import { EntityStoreBase } from '@contentful/experiences-core';
 import type {
-  CompositionNode,
-  CompositionDataSource,
-  CompositionUnboundValues,
-  CompositionComponentNode,
-  CompositionComponentPropValue,
-  Composition,
+  ComponentTreeNode,
+  ExperienceDataSource,
+  ExperienceUnboundValues,
+  ExperienceTreeNode,
+  ComponentPropertyValue,
+  ExperienceFields,
 } from '@contentful/experiences-core/types';
 import type { Entry } from 'contentful';
 import {
@@ -31,21 +31,21 @@ export const deserializeAssemblyNode = ({
   componentInstanceUnboundValues,
   componentInstanceDataSource,
 }: {
-  node: CompositionNode;
+  node: ComponentTreeNode;
   nodeId: string;
   nodeLocation: string | null;
   parentId?: string;
-  assemblyDataSource: CompositionDataSource;
-  assemblyUnboundValues: CompositionUnboundValues;
+  assemblyDataSource: ExperienceDataSource;
+  assemblyUnboundValues: ExperienceUnboundValues;
   assemblyId: string;
   assemblyComponentId: string;
-  componentInstanceProps: Record<string, CompositionComponentPropValue>;
-  componentInstanceUnboundValues: CompositionUnboundValues;
-  componentInstanceDataSource: CompositionDataSource;
-}): CompositionComponentNode => {
-  const childNodeVariable: Record<string, CompositionComponentPropValue> = {};
-  const dataSource: CompositionDataSource = {};
-  const unboundValues: CompositionUnboundValues = {};
+  componentInstanceProps: Record<string, ComponentPropertyValue>;
+  componentInstanceUnboundValues: ExperienceUnboundValues;
+  componentInstanceDataSource: ExperienceDataSource;
+}): ExperienceTreeNode => {
+  const childNodeVariable: Record<string, ComponentPropertyValue> = {};
+  const dataSource: ExperienceDataSource = {};
+  const unboundValues: ExperienceUnboundValues = {};
 
   for (const [variableName, variable] of Object.entries(node.variables)) {
     childNodeVariable[variableName] = variable;
@@ -76,7 +76,7 @@ export const deserializeAssemblyNode = ({
 
   const isAssembly = assembliesRegistry.has(node.definitionId);
 
-  const children: CompositionComponentNode[] = node.children.map((child, childIndex) => {
+  const children: ExperienceTreeNode[] = node.children.map((child, childIndex) => {
     const newNodeLocation =
       nodeLocation === null ? `${childIndex}` : nodeLocation + '_' + childIndex;
     return deserializeAssemblyNode({
@@ -119,7 +119,7 @@ export const resolveAssembly = ({
   node,
   entityStore,
 }: {
-  node: CompositionComponentNode;
+  node: ExperienceTreeNode;
   entityStore: EntityStoreBase | null;
 }) => {
   if (node.type !== ASSEMBLY_NODE_TYPE) {
@@ -136,7 +136,9 @@ export const resolveAssembly = ({
     return node;
   }
 
-  const componentFields = entityStore?.getValue(assembly, ['fields']) as unknown as Composition;
+  const componentFields = entityStore?.getValue(assembly, [
+    'fields',
+  ]) as unknown as ExperienceFields;
 
   if (!componentFields) {
     console.warn(`Entry for assembly with ID '${componentId}' not found`, { entityStore });

--- a/packages/visual-editor/src/utils/createTreeNode.ts
+++ b/packages/visual-editor/src/utils/createTreeNode.ts
@@ -1,4 +1,4 @@
-import { CompositionComponentNode } from '@contentful/experiences-core/types';
+import { ExperienceTreeNode } from '@contentful/experiences-core/types';
 import { generateId } from './generate-id';
 
 interface Params {
@@ -7,7 +7,7 @@ interface Params {
 }
 
 export const createTreeNode = ({ blockId, parentId }: Params) => {
-  const node: CompositionComponentNode = {
+  const node: ExperienceTreeNode = {
     type: 'block',
     data: {
       id: generateId(blockId),

--- a/packages/visual-editor/src/utils/getItem.ts
+++ b/packages/visual-editor/src/utils/getItem.ts
@@ -1,14 +1,11 @@
-import type { CompositionComponentNode, CompositionTree } from '@contentful/experiences-core/types';
+import type { ExperienceTreeNode, ExperienceTree } from '@contentful/experiences-core/types';
 import { ROOT_ID } from '../types/constants';
 
 export type ItemSelector = {
   id: string;
 };
 
-function getItemFromTree(
-  id: string,
-  node: CompositionComponentNode,
-): CompositionComponentNode | undefined {
+function getItemFromTree(id: string, node: ExperienceTreeNode): ExperienceTreeNode | undefined {
   // Check if the current node's id matches the search id
 
   if (node.data.id === id) {
@@ -28,11 +25,7 @@ function getItemFromTree(
   return undefined;
 }
 
-function findDepthById(
-  node: CompositionComponentNode,
-  id: string,
-  currentDepth: number = 1,
-): number {
+function findDepthById(node: ExperienceTreeNode, id: string, currentDepth: number = 1): number {
   if (node.data.id === id) {
     return currentDepth;
   }
@@ -51,8 +44,8 @@ function findDepthById(
 export const getChildFromTree = (
   parentId: string,
   index: number,
-  node: CompositionComponentNode,
-): CompositionComponentNode | undefined => {
+  node: ExperienceTreeNode,
+): ExperienceTreeNode | undefined => {
   // Check if the current node's id matches the search id
 
   if (node.data.id === parentId) {
@@ -74,8 +67,8 @@ export const getChildFromTree = (
 
 export const getItem = (
   selector: ItemSelector,
-  tree: CompositionTree,
-): CompositionComponentNode | undefined => {
+  tree: ExperienceTree,
+): ExperienceTreeNode | undefined => {
   return getItemFromTree(selector.id, {
     type: 'block',
     data: {
@@ -86,9 +79,6 @@ export const getItem = (
   });
 };
 
-export const getItemDepthFromNode = (
-  selector: ItemSelector,
-  node: CompositionComponentNode,
-): number => {
+export const getItemDepthFromNode = (selector: ItemSelector, node: ExperienceTreeNode): number => {
   return findDepthById(node, selector.id);
 };

--- a/packages/visual-editor/src/utils/getTreeDiff.ts
+++ b/packages/visual-editor/src/utils/getTreeDiff.ts
@@ -1,4 +1,4 @@
-import { CompositionComponentNode, CompositionTree } from '@contentful/experiences-core/types';
+import { ExperienceTreeNode, ExperienceTree } from '@contentful/experiences-core/types';
 
 import { getItem } from './getItem';
 import { isEqual } from 'lodash-es';
@@ -8,9 +8,9 @@ import { TreeDiff } from '@/types/treeActions';
 interface MissingNodeActionParams {
   index: number;
   nodeAdded: boolean;
-  tree: CompositionTree;
-  child: CompositionComponentNode;
-  currentNode: CompositionComponentNode;
+  tree: ExperienceTree;
+  child: ExperienceTreeNode;
+  currentNode: ExperienceTreeNode;
   parentNodeId: string;
 }
 
@@ -75,9 +75,9 @@ function matchingNodeAction({
 }
 
 interface CompareNodeParams {
-  currentNode?: CompositionComponentNode;
-  updatedNode?: CompositionComponentNode;
-  originalTree: CompositionTree;
+  currentNode?: ExperienceTreeNode;
+  updatedNode?: ExperienceTreeNode;
+  originalTree: ExperienceTree;
   differences: Array<TreeDiff | null>;
 }
 
@@ -178,9 +178,9 @@ function compareNodes({
 }
 
 export function getTreeDiffs(
-  tree1: CompositionComponentNode,
-  tree2: CompositionComponentNode,
-  originalTree: CompositionTree,
+  tree1: ExperienceTreeNode,
+  tree2: ExperienceTreeNode,
+  originalTree: ExperienceTree,
 ): TreeDiff[] {
   const differences: TreeDiff[] = [];
 

--- a/packages/visual-editor/src/utils/getUnboundValues.ts
+++ b/packages/visual-editor/src/utils/getUnboundValues.ts
@@ -1,8 +1,5 @@
 import { get } from 'lodash-es';
-import type {
-  CompositionUnboundValues,
-  CompositionVariableValueType,
-} from '@contentful/experiences-core/types';
+import type { ExperienceUnboundValues, PrimitiveValue } from '@contentful/experiences-core/types';
 
 export const getUnboundValues = ({
   key,
@@ -10,10 +7,10 @@ export const getUnboundValues = ({
   unboundValues,
 }: {
   key: string;
-  fallback: CompositionVariableValueType;
-  unboundValues: CompositionUnboundValues;
-}): CompositionVariableValueType => {
+  fallback: PrimitiveValue;
+  unboundValues: ExperienceUnboundValues;
+}): PrimitiveValue => {
   const lodashPath = `${key}.value`;
 
-  return get(unboundValues, lodashPath, fallback) as CompositionVariableValueType;
+  return get(unboundValues, lodashPath, fallback) as PrimitiveValue;
 };

--- a/packages/visual-editor/src/utils/onDrop.ts
+++ b/packages/visual-editor/src/utils/onDrop.ts
@@ -1,11 +1,11 @@
 import { onComponentDropped } from '@/communication/onComponentDrop';
 import { getItem } from './getItem';
-import type { CompositionComponentNode, CompositionTree } from '@contentful/experiences-core/types';
+import type { ExperienceTreeNode, ExperienceTree } from '@contentful/experiences-core/types';
 import { generateId } from './generate-id';
 import { ROOT_ID } from '../types/constants';
 
 interface OnDropParams {
-  data: CompositionTree;
+  data: ExperienceTree;
   componentType: string;
   destinationZoneId: string;
   destinationIndex: number;
@@ -22,7 +22,7 @@ export const onDrop = ({
 
   const parentIsRoot = parentId === ROOT_ID;
 
-  const emptyComponentData: CompositionComponentNode = {
+  const emptyComponentData: ExperienceTreeNode = {
     type: 'block',
     parentId,
     children: [],

--- a/packages/visual-editor/src/utils/treeHelpers.ts
+++ b/packages/visual-editor/src/utils/treeHelpers.ts
@@ -1,11 +1,11 @@
-import type { CompositionComponentNode } from '@contentful/experiences-core/types';
+import type { ExperienceTreeNode } from '@contentful/experiences-core/types';
 import { isEqual } from 'lodash-es';
 import { getChildFromTree } from './getItem';
 
 export function updateNode(
   nodeId: string,
-  updatedNode: CompositionComponentNode,
-  node: CompositionComponentNode,
+  updatedNode: ExperienceTreeNode,
+  node: ExperienceTreeNode,
 ) {
   if (node.data.id === nodeId) {
     node.data = updatedNode.data;
@@ -16,8 +16,8 @@ export function updateNode(
 }
 export function replaceNode(
   indexToReplace: number,
-  updatedNode: CompositionComponentNode,
-  node: CompositionComponentNode,
+  updatedNode: ExperienceTreeNode,
+  node: ExperienceTreeNode,
 ) {
   if (node.data.id === updatedNode.parentId) {
     node.children = [
@@ -33,8 +33,8 @@ export function replaceNode(
 
 export function reorderChildrenNodes(
   nodeId: string,
-  updatedChildren: CompositionComponentNode[],
-  node: CompositionComponentNode,
+  updatedChildren: ExperienceTreeNode[],
+  node: ExperienceTreeNode,
 ) {
   if (node.data.id === nodeId) {
     node.children = updatedChildren;
@@ -46,9 +46,9 @@ export function reorderChildrenNodes(
 
 export function addChildToNode(
   nodeId: string,
-  oldChildren: CompositionComponentNode[],
-  updatedChildren: CompositionComponentNode[],
-  node: CompositionComponentNode,
+  oldChildren: ExperienceTreeNode[],
+  updatedChildren: ExperienceTreeNode[],
+  node: ExperienceTreeNode,
 ) {
   if (node.data.id !== nodeId) {
     node.children.forEach((childNode) =>
@@ -83,7 +83,7 @@ export function removeChildNode(
   indexToRemove: number,
   nodeId: string,
   parentNodeId: string,
-  node: CompositionComponentNode,
+  node: ExperienceTreeNode,
 ) {
   if (node.data.id === parentNodeId) {
     const childIndex = node.children.findIndex((child) => child.data.id === nodeId);
@@ -100,8 +100,8 @@ export function removeChildNode(
 export function addChildNode(
   indexToAdd: number,
   parentNodeId: string,
-  nodeToAdd: CompositionComponentNode,
-  node: CompositionComponentNode,
+  nodeToAdd: ExperienceTreeNode,
+  node: ExperienceTreeNode,
 ) {
   if (node.data.id === parentNodeId) {
     node.children = [
@@ -122,7 +122,7 @@ export function reorderChildNode(
   oldIndex: number,
   newIndex: number,
   parentNodeId: string,
-  node: CompositionComponentNode,
+  node: ExperienceTreeNode,
 ) {
   if (node.data.id === parentNodeId) {
     // Remove the child from the old position
@@ -143,7 +143,7 @@ export function reparentChildNode(
   newIndex: number,
   sourceNodeId: string,
   destinationNodeId: string,
-  node: CompositionComponentNode,
+  node: ExperienceTreeNode,
 ) {
   const nodeToMove = getChildFromTree(sourceNodeId, oldIndex, node);
 

--- a/packages/visual-editor/test/__fixtures__/assembly.ts
+++ b/packages/visual-editor/test/__fixtures__/assembly.ts
@@ -3,7 +3,7 @@ import {
   ASSEMBLY_NODE_TYPE,
   LATEST_SCHEMA_VERSION,
 } from '@contentful/experiences-core/constants';
-import type { CompositionComponentNode, SchemaVersions } from '@contentful/experiences-core/types';
+import type { ExperienceTreeNode, SchemaVersions } from '@contentful/experiences-core/types';
 
 type createAssemblyEntryArgs = {
   schemaVersion: SchemaVersions;
@@ -107,8 +107,8 @@ export const createAssemblyNode = ({
   unboundValue = 'New year Eve',
   unboundValueKey = undefined,
   boundValueKey = undefined,
-}: createAssemblyNodeArgs): CompositionComponentNode => {
-  const node: CompositionComponentNode = {
+}: createAssemblyNodeArgs): ExperienceTreeNode => {
+  const node: ExperienceTreeNode = {
     type: ASSEMBLY_NODE_TYPE,
     data: {
       blockId,

--- a/packages/visual-editor/test/__fixtures__/composition.ts
+++ b/packages/visual-editor/test/__fixtures__/composition.ts
@@ -1,12 +1,8 @@
-import type {
-  Composition,
-  ExperienceEntry,
-  SchemaVersions,
-} from '@contentful/experiences-core/types';
+import type { ExperienceEntry, SchemaVersions } from '@contentful/experiences-core/types';
 import { entityIds } from './entities';
 import { LATEST_SCHEMA_VERSION } from '@contentful/experiences-core/constants';
 
-const compositionFields: Composition = {
+const compositionFields: ExperienceEntry['fields'] = {
   title: 'Test Composition',
   slug: 'test',
   componentTree: {
@@ -88,13 +84,13 @@ export const compositionEntry: ExperienceEntry = {
   fields: compositionFields,
 };
 
-type createCompositionEntryArgs = {
+type createExperienceEntryArgs = {
   schemaVersion: SchemaVersions;
 };
 
-export const createCompositionEntry = ({
+export const createExperienceEntry = ({
   schemaVersion = LATEST_SCHEMA_VERSION,
-}: createCompositionEntryArgs): ExperienceEntry => {
+}: createExperienceEntryArgs): ExperienceEntry => {
   return {
     sys: {
       id: 'composition-id',


### PR DESCRIPTION
## Purpose
Stop using outdated terms in the SDK

## Approach
-> Replace use of term `Composition` with `Experience` in
* types.ts:

  * `CompositionComponentNode` -> `ExperienceTreeNode`
  * `CompositionTree` -> `ExperienceTree`
  * `Composition` -> `ExperienceFields`
  * `CompositionEntry` -> `ExperienceEntry`
* constants.ts
  * IncomingEvents.CompositionUpdated -> `IncomingEvents.ExperienceUpdated`

-> ~Mark old types as deprecated~ I've removed the old types completely since most of them were already deprecated and we don't want to carry newly deprecated ones past GA.
-> Replace use of deprecated types across the monorepo. Includes [there types](https://github.com/contentful/experience-builder/blob/77507499031655374717eaba3455a4131eac11b2/packages/core/src/types.ts#L19C1-L33C50) that were previously deprecated.

<!--

Three important notes on Pull Requests:
- In general, you should ask yourself whether this code change will improve or worsen the overall code quality. Any new tech debt will probably never be cleaned up.
- Please remember that newly introduced logic should be validated and protected through testing.
- Take a look at PR guides such as Google's [Google’s Code Review Guidelines](https://google.github.io/eng-practices/) and [Blockly - Writing a Good Pull Request](https://developers.google.com/blockly/guides/contribute/get-started/write_a_good_pr)

-->
