### PR TITLE
fix: empty state canvas now says add components to begin

### DIFF
--- a/packages/visual-editor/src/components/EmptyContainer/EmptyContainer.tsx
+++ b/packages/visual-editor/src/components/EmptyContainer/EmptyContainer.tsx
@@ -61,7 +61,7 @@ export const EmptyContainer = ({ isDragging }: EmptyContainerProps) => {
         />
       </svg>
 
-      <span className={styles.label}>Add elements to begin</span>
+      <span className={styles.label}>Add components to begin</span>
     </div>
   );
 };


### PR DESCRIPTION
## Purpose
Empty canvas now says `Add components to begin` rather than `elements`
<img width="1315" alt="Screenshot 2024-03-11 at 10 13 09 AM" src="https://github.com/contentful/experience-builder/assets/124832189/67388595-4be5-4c3d-a771-a69e905c61e1">
