### PR TITLE
fix(canvas-interactions): selecting a component in nextjs app-router [ALT-629]

### DIFF
--- a/packages/visual-editor/src/components/RootRenderer/RootRenderer.tsx
+++ b/packages/visual-editor/src/components/RootRenderer/RootRenderer.tsx
@@ -42,9 +42,21 @@ export const RootRenderer: React.FC<Props> = ({ onChange }) => {
     };
   }, []);
 
-  const handleClickOutside = () => {
+  const handleClickOutside = (e: MouseEvent) => {
+    const element = e.target as HTMLElement;
+
+    const isRoot = element.getAttribute('data-ctfl-zone-id') === ROOT_ID;
+    const clickedOnCanvas = element.closest(`[data-ctfl-root]`);
+
+    if (clickedOnCanvas && !isRoot) {
+      return;
+    }
+
     sendMessage(OUTGOING_EVENTS.OutsideCanvasClick, {
       outsideCanvasClick: true,
+    });
+    sendMessage(OUTGOING_EVENTS.ComponentSelected, {
+      selectedId: '',
     });
   };
 

--- a/packages/visual-editor/src/hooks/useSelectedInstanceCoordinates.ts
+++ b/packages/visual-editor/src/hooks/useSelectedInstanceCoordinates.ts
@@ -15,9 +15,11 @@ export const useSelectedInstanceCoordinates = ({ node }: { node: ExperienceTreeN
       return;
     }
 
+    // Allows the drop animation to finish before
+    // calculating the components coordinates
     setTimeout(() => {
       sendSelectedComponentCoordinates(node.data.id);
-    }, 200);
+    }, 10);
   }, [node, selectedNodeId]);
 
   const selectedElement = node.data.id


### PR DESCRIPTION
## Purpose
Based on the fix, I'm not sure why an app-router NextJS app was the only type of site causing this bug but essentially, our `handleClickOutside` fn was not properly checking if a click was actually outside of the canvas or not.

This resulted in every click first selecting the component, the event bubbling up, and then the `handleClickOutside` fn causing the component to immediately deselect. We have `e.stopPropagation()` on children of the canvas but I guess NextJS app-router behaves differently with an onClick event listener? Not entirely sure, but this code does feel more safeguarded for outside canvas clicks compared to before.

Also reduced the timeout for component select since our drop animation is removed.
