### PR TITLE
fix(canvas-interactions): properly clear deselected component on canvas []

### DIFF
--- a/packages/visual-editor/src/components/RootRenderer/RootRenderer.tsx
+++ b/packages/visual-editor/src/components/RootRenderer/RootRenderer.tsx
@@ -13,6 +13,7 @@ import { useEditorSubscriber } from '@/hooks/useEditorSubscriber';
 import { DNDProvider } from './DNDProvider';
 import { sendMessage } from '@contentful/experiences-core';
 import { OUTGOING_EVENTS } from '@contentful/experiences-core/constants';
+import { useEditorStore } from '@/store/editor';
 
 interface Props {
   onChange?: (data: ExperienceTree) => void;
@@ -24,6 +25,7 @@ export const RootRenderer: React.FC<Props> = ({ onChange }) => {
   const dragItem = useDraggedItemStore((state) => state.componentId);
   const userIsDragging = useDraggedItemStore((state) => state.isDraggingOnCanvas);
   const breakpoints = useTreeStore((state) => state.breakpoints);
+  const setSelectedNodeId = useEditorStore((state) => state.setSelectedNodeId);
   const draggableSourceId = useDraggedItemStore((state) => state.draggedItem?.source.droppableId);
   const draggingNewComponent = !!draggableSourceId?.startsWith(COMPONENT_LIST_ID);
   const containerRef = useRef<HTMLDivElement>(null);
@@ -58,6 +60,7 @@ export const RootRenderer: React.FC<Props> = ({ onChange }) => {
     sendMessage(OUTGOING_EVENTS.ComponentSelected, {
       selectedId: '',
     });
+    setSelectedNodeId('');
   };
 
   const handleResizeCanvas = useCallback(() => {

--- a/packages/visual-editor/src/components/RootRenderer/RootRenderer.tsx
+++ b/packages/visual-editor/src/components/RootRenderer/RootRenderer.tsx
@@ -33,35 +33,27 @@ export const RootRenderer: React.FC<Props> = ({ onChange }) => {
   const [containerStyles, setContainerStyles] = useState<CSSProperties>({});
   const tree = useTreeStore((state) => state.tree);
 
-  useEffect(() => {
-    if (onChange) onChange(tree);
-  }, [tree, onChange]);
+  const handleClickOutside = useCallback(
+    (e: MouseEvent) => {
+      const element = e.target as HTMLElement;
 
-  useEffect(() => {
-    document.addEventListener('click', handleClickOutside);
-    return () => {
-      document.removeEventListener('click', handleClickOutside);
-    };
-  }, []);
+      const isRoot = element.getAttribute('data-ctfl-zone-id') === ROOT_ID;
+      const clickedOnCanvas = element.closest(`[data-ctfl-root]`);
 
-  const handleClickOutside = (e: MouseEvent) => {
-    const element = e.target as HTMLElement;
+      if (clickedOnCanvas && !isRoot) {
+        return;
+      }
 
-    const isRoot = element.getAttribute('data-ctfl-zone-id') === ROOT_ID;
-    const clickedOnCanvas = element.closest(`[data-ctfl-root]`);
-
-    if (clickedOnCanvas && !isRoot) {
-      return;
-    }
-
-    sendMessage(OUTGOING_EVENTS.OutsideCanvasClick, {
-      outsideCanvasClick: true,
-    });
-    sendMessage(OUTGOING_EVENTS.ComponentSelected, {
-      selectedId: '',
-    });
-    setSelectedNodeId('');
-  };
+      sendMessage(OUTGOING_EVENTS.OutsideCanvasClick, {
+        outsideCanvasClick: true,
+      });
+      sendMessage(OUTGOING_EVENTS.ComponentSelected, {
+        selectedId: '',
+      });
+      setSelectedNodeId('');
+    },
+    [setSelectedNodeId],
+  );
 
   const handleResizeCanvas = useCallback(() => {
     const parentElement = containerRef.current?.parentElement;
@@ -96,6 +88,17 @@ export const RootRenderer: React.FC<Props> = ({ onChange }) => {
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [containerRef.current]);
+
+  useEffect(() => {
+    if (onChange) onChange(tree);
+  }, [tree, onChange]);
+
+  useEffect(() => {
+    document.addEventListener('click', handleClickOutside);
+    return () => {
+      document.removeEventListener('click', handleClickOutside);
+    };
+  }, [handleClickOutside]);
 
   useEffect(() => {
     handleResizeCanvas();


### PR DESCRIPTION
## Purpose
https://github.com/contentful/experience-builder/pull/481 caused a small regression where selecting a component, deselecting it, and then reselecting the component would end up in a broken select state.

This small change ensures we properly clear the selected component so that reselecting works properly
