### PR TITLE
fix(canvas-interactions): proper placeholders based on padding and flex direction [ALT-505]

### DIFF
--- a/packages/visual-editor/src/components/Draggable/Placeholder.tsx
+++ b/packages/visual-editor/src/components/Draggable/Placeholder.tsx
@@ -15,6 +15,61 @@ interface PlaceholderProps extends PlaceholderParams {
   id: string;
 }
 
+const calcOffsetLeft = (
+  parentElement: Element | null,
+  placeholderWidth: number,
+  nodeWidth: number,
+) => {
+  if (!parentElement) {
+    return 0;
+  }
+
+  const alignItems = window.getComputedStyle(parentElement).alignItems;
+
+  if (alignItems === 'center') {
+    return -(placeholderWidth - nodeWidth) / 2;
+  }
+
+  if (alignItems === 'end') {
+    return -placeholderWidth + nodeWidth + 2;
+  }
+
+  return 0;
+};
+
+const calcOffsetTop = (
+  parentElement: Element | null,
+  placeholderHeight: number,
+  nodeHeight: number,
+) => {
+  if (!parentElement) {
+    return 0;
+  }
+
+  const alignItems = window.getComputedStyle(parentElement).alignItems;
+
+  if (alignItems === 'center') {
+    return -(placeholderHeight - nodeHeight) / 2;
+  }
+
+  if (alignItems === 'end') {
+    return -placeholderHeight + nodeHeight + 2;
+  }
+
+  return 0;
+};
+
+const getPaddingOffset = (element: Element): [number, number] => {
+  const paddingLeft = parseFloat(window.getComputedStyle(element).paddingLeft);
+  const paddingRight = parseFloat(window.getComputedStyle(element).paddingRight);
+  const paddingTop = parseFloat(window.getComputedStyle(element).paddingTop);
+  const paddingBottom = parseFloat(window.getComputedStyle(element).paddingBottom);
+
+  const horizontalOffset = paddingLeft + paddingRight;
+  const verticalOffset = paddingTop + paddingBottom;
+
+  return [horizontalOffset, verticalOffset];
+};
 /**
  * Calculate the size and position of the dropzone indicator
  * when dragging a new component onto the canvas
@@ -37,10 +92,16 @@ const calcNewComponentStyles = (params: CalcStylesParams): CSSProperties => {
   const elementSizes = element.getBoundingClientRect();
   const dropzoneSizes = dropzone.getBoundingClientRect();
 
-  const width = isHorizontal ? DRAGGABLE_WIDTH : dropzoneSizes.width;
-  const height = isHorizontal ? dropzoneSizes.height : DRAGGABLE_HEIGHT;
-  const top = isHorizontal ? -(height - elementSizes.height) / 2 : -height;
-  const left = isHorizontal ? -width : -(width - elementSizes.width) / 2;
+  const [horizontalPadding, verticalPadding] = getPaddingOffset(dropzone);
+
+  const width = isHorizontal ? DRAGGABLE_WIDTH : dropzoneSizes.width - horizontalPadding;
+  const height = isHorizontal ? dropzoneSizes.height - verticalPadding : DRAGGABLE_HEIGHT;
+  const top = isHorizontal
+    ? calcOffsetTop(element.parentElement, height, elementSizes.height)
+    : -height;
+  const left = isHorizontal
+    ? -width
+    : calcOffsetLeft(element.parentElement, width, elementSizes.width);
 
   return {
     width,
@@ -89,10 +150,16 @@ const calcMovementStyles = (params: CalcStylesParams): CSSProperties => {
   const dropzoneSizes = dropzone.getBoundingClientRect();
   const draggableSizes = draggable.getBoundingClientRect();
 
-  const width = isHorizontal ? draggableSizes.width : dropzoneSizes.width;
-  const height = isHorizontal ? dropzoneSizes.height : draggableSizes.height;
-  const top = isHorizontal ? -(height - elementSizes.height) / 2 : -height;
-  const left = isHorizontal ? -width : -(width - elementSizes.width) / 2;
+  const [horizontalPadding, verticalPadding] = getPaddingOffset(dropzone);
+
+  const width = isHorizontal ? draggableSizes.width : dropzoneSizes.width - horizontalPadding;
+  const height = isHorizontal ? dropzoneSizes.height - verticalPadding : draggableSizes.height;
+  const top = isHorizontal
+    ? calcOffsetTop(element.parentElement, height, elementSizes.height)
+    : -height;
+  const left = isHorizontal
+    ? -width
+    : calcOffsetLeft(element.parentElement, width, elementSizes.width);
 
   return {
     width,

--- a/packages/visual-editor/src/components/Draggable/styles.module.css
+++ b/packages/visual-editor/src/components/Draggable/styles.module.css
@@ -8,7 +8,7 @@
 }
 
 .DraggableComponent:before {
-  content: "";
+  content: '';
   position: absolute;
   top: 0;
   right: 0;
@@ -23,16 +23,17 @@
   outline: 2px solid var(--exp-builder-blue500);
 }
 
+.DraggableClone,
+.DraggableClone * {
+  pointer-events: none !important;
+}
+
 .DraggableComponent > * {
   pointer-events: none;
 }
 
 .isDragging {
   overflow: hidden;
-}
-
-.isDragging * {
-  pointer-events: none !important;
 }
 
 .isSelected:before {

--- a/packages/visual-editor/src/components/Draggable/styles.module.css
+++ b/packages/visual-editor/src/components/Draggable/styles.module.css
@@ -17,6 +17,7 @@
   outline-offset: -2px;
   outline: 2px solid transparent;
   z-index: 1;
+  pointer-events: none;
 }
 
 .DraggableClone:before {
@@ -28,7 +29,7 @@
   pointer-events: none !important;
 }
 
-.DraggableComponent > * {
+.DraggableComponent:not(.userIsDragging) :not(.DraggableComponent) {
   pointer-events: none;
 }
 

--- a/packages/visual-editor/src/components/Dropzone/styles.module.css
+++ b/packages/visual-editor/src/components/Dropzone/styles.module.css
@@ -6,11 +6,11 @@
   width: 100%;
   background-color: transparent;
   transition: background-color 0.2s;
-  pointer-events: all;
+  pointer-events: all !important;
 }
 
 .container:not(.isRoot):before {
-  content: "";
+  content: '';
   position: absolute;
   top: 0;
   right: 0;
@@ -20,6 +20,7 @@
   outline: 2px solid transparent;
   z-index: 1;
   transition: outline 0.2s;
+  pointer-events: none;
 }
 
 .isRoot,
@@ -36,7 +37,9 @@
 }
 
 .isDestination:not(.isRoot):before {
-  transition: outline 0.2s, background-color 0.2s;
+  transition:
+    outline 0.2s,
+    background-color 0.2s;
   outline: 2px dashed var(--exp-builder-blue400);
   background-color: rgba(var(--exp-builder-blue100-rgb), 0.5);
   z-index: 2;

--- a/packages/visual-editor/src/components/VisualEditorRoot.tsx
+++ b/packages/visual-editor/src/components/VisualEditorRoot.tsx
@@ -10,20 +10,6 @@ import { useZoneStore } from '@/store/zone';
 import { CTFL_ZONE_ID, NEW_COMPONENT_ID } from '@/types/constants';
 import { useDraggedItemStore } from '@/store/draggedItem';
 
-const findNearestDropzone = (element: HTMLElement): string | null => {
-  const zoneId = element.getAttribute(CTFL_ZONE_ID);
-
-  if (!element.parentElement) {
-    return null;
-  }
-
-  if (element.tagName === 'BODY') {
-    return null;
-  }
-
-  return zoneId ?? findNearestDropzone(element.parentElement);
-};
-
 export const VisualEditorRoot = () => {
   const initialized = useInitializeEditor();
   const locale = useEditorStore((state) => state.locale);
@@ -48,8 +34,7 @@ export const VisualEditorRoot = () => {
       setMousePosition(e.clientX, e.clientY);
 
       const target = e.target as HTMLElement;
-
-      const zoneId = findNearestDropzone(target);
+      const zoneId = target.closest(`[${CTFL_ZONE_ID}]`)?.getAttribute(CTFL_ZONE_ID);
 
       if (zoneId) {
         setHoveringZone(zoneId);


### PR DESCRIPTION
## Purpose
Placeholders were sometimes shown in the wrong location because they were not accounting for padding offsets or the flex alignment of the parent component. This PR adds logic to account for various alignments and padding values to more precisely render dropzone placeholders.

#### Additional Bug Fixes
- Not being able to enable nested dropzones because of new overlays
- Adjust usage of `pointer-events: none` for proper drag and non-drag state behavior


https://github.com/contentful/experience-builder/assets/23040747/471a5a28-b5b5-443f-aa2e-c95d8f4c2d36

