### PR TITLE
fix: remove unecessary exports from experience-builder-sdk

### DIFF
--- a/packages/experience-builder-sdk/src/index.ts
+++ b/packages/experience-builder-sdk/src/index.ts
@@ -4,13 +4,7 @@ export { ExperienceRoot } from './ExperienceRoot';
 export { useFetchById, useFetchBySlug } from './hooks';
 export { defineComponents } from './core/componentRegistry';
 export {
-  calculateNodeDefaultHeight,
-  /** @deprecated use `checkIsAssemblyNode` instead. Will be removed with SDK v5. */
-  checkIsAssembly,
-  checkIsAssemblyNode,
-  checkIsAssemblyEntry,
   defineDesignTokens,
-  supportedModes,
   VisualEditorMode,
   fetchById,
   fetchBySlug,
@@ -18,15 +12,8 @@ export {
 } from '@contentful/experiences-core';
 export {
   CONTENTFUL_COMPONENTS,
-  OUTGOING_EVENTS,
-  INCOMING_EVENTS,
-  CONTENTFUL_COMPONENT_CATEGORY,
   LATEST_SCHEMA_VERSION,
   CF_STYLE_ATTRIBUTES,
-  ASSEMBLY_BLOCK_NODE_TYPE,
-  ASSEMBLY_NODE_TYPE,
-  ASSEMBLY_NODE_TYPES,
-  SCROLL_STATES,
 } from '@contentful/experiences-core/constants';
 
 // Simple state store to store a few things that are needed across the SDK
@@ -36,9 +23,4 @@ if (typeof window !== 'undefined') {
   };
 }
 
-export type {
-  InternalSDKMode,
-  ExternalSDKMode,
-  ComponentDefinition,
-} from '@contentful/experiences-core/types';
-export { EntityStore } from '@contentful/experiences-core';
+export type { ExternalSDKMode, ComponentDefinition } from '@contentful/experiences-core/types';


### PR DESCRIPTION
## Purpose

SDK currently exports some attributes that are only meant to be used either internally or in the interface with the Web app. There is no need to export those from the SDK so I am removing them here.