### PR TITLE
chore: add aria-hidden flag to component outline [SPA-1900]

### DIFF
--- a/packages/visual-editor/src/components/Draggable/DraggableChildComponent.tsx
+++ b/packages/visual-editor/src/components/Draggable/DraggableChildComponent.tsx
@@ -95,6 +95,7 @@ export const DraggableChildComponent: React.FC<DraggableChildComponentProps> = (
           Tooltip: (
             <Tooltip
               id={id}
+              isSelected={isSelected}
               coordinates={coordinates}
               isAssemblyBlock={isAssemblyBlock}
               isContainer={isContainer}

--- a/packages/visual-editor/src/components/Draggable/DraggableComponent.tsx
+++ b/packages/visual-editor/src/components/Draggable/DraggableComponent.tsx
@@ -112,6 +112,7 @@ export const DraggableComponent: React.FC<DraggableComponentProps> = ({
             coordinates={coordinates}
             isAssemblyBlock={isAssemblyBlock}
             isContainer={isContainer}
+            isSelected={isSelected}
             label={definition.name || 'No label specified'}
           />
           <Placeholder {...placeholder} id={id} />

--- a/packages/visual-editor/src/components/Draggable/Tooltip.tsx
+++ b/packages/visual-editor/src/components/Draggable/Tooltip.tsx
@@ -9,9 +9,17 @@ interface Props {
   label: string;
   isContainer: boolean;
   isAssemblyBlock: boolean;
+  isSelected: boolean;
 }
 
-const Tooltip: React.FC<Props> = ({ coordinates, id, label, isAssemblyBlock, isContainer }) => {
+const Tooltip: React.FC<Props> = ({
+  coordinates,
+  id,
+  label,
+  isAssemblyBlock,
+  isContainer,
+  isSelected,
+}) => {
   const tooltipRef = useRef<HTMLDivElement>(null);
 
   const previewSize = '100%'; // This should be based on breakpoints and added to usememo dependency array
@@ -41,7 +49,8 @@ const Tooltip: React.FC<Props> = ({ coordinates, id, label, isAssemblyBlock, isC
       className={classNames(styles.overlay, {
         [styles.overlayContainer]: isContainer,
         [styles.overlayAssembly]: isAssemblyBlock,
-      })}>
+      })}
+      aria-hidden={!isSelected}>
       {label}
     </div>
   );


### PR DESCRIPTION
## Purpose

Help to easier identify which of the tooltips are actually rendered on the screen
