### PR TITLE
fix(canvas-interactions): do not render hitboxes for single column [ALT-571]

### DIFF
--- a/packages/visual-editor/src/components/Dropzone/EditorBlock.tsx
+++ b/packages/visual-editor/src/components/Dropzone/EditorBlock.tsx
@@ -99,7 +99,7 @@ export const EditorBlock: React.FC<EditorBlockProps> = ({
           onClick={onClick}
           definition={definition}
         />
-        {isStructureComponent && userIsDragging && (
+        {isStructureComponent && !isSingleColumn && userIsDragging && (
           <Hitboxes
             parentZoneId={zoneId}
             zoneId={componentId}
@@ -126,7 +126,7 @@ export const EditorBlock: React.FC<EditorBlockProps> = ({
       wrapperProps={wrapperProps}
       onClick={onClick}>
       {elementToRender()}
-      {isStructureComponent && userIsDragging && (
+      {isStructureComponent && !isSingleColumn && userIsDragging && (
         <Hitboxes
           parentZoneId={zoneId}
           zoneId={componentId}

--- a/packages/visual-editor/src/types/constants.ts
+++ b/packages/visual-editor/src/types/constants.ts
@@ -12,7 +12,7 @@ export const CTFL_DRAGGABLE_ID = 'data-ctfl-draggable-id';
 export const CTFL_DRAGGING_ELEMENT = 'data-ctfl-dragging-element';
 
 export const HITBOX = {
-  WIDTH: 80,
+  WIDTH: 70,
   HEIGHT: 20,
   INITIAL_OFFSET: 10,
   OFFSET_INCREMENT: 8,


### PR DESCRIPTION
## Purpose
The columns component does not allow dragging components in-between columns to add new columns. This is only handled via the column presets option in the design tab.

Because of this, we should not render hitboxes for the SingleColumn since they serve no purpose and only cause issues when many columns are added to the columns component. These hitboxes would overlap each other and end up making it seem like a user could not drop a component inside a column because that dropzone would never get enabled.
