### PR TITLE
fix: locale switching does update content in canvas [SPA-1949]

### DIFF
--- a/packages/visual-editor/src/components/VisualEditorRoot.tsx
+++ b/packages/visual-editor/src/components/VisualEditorRoot.tsx
@@ -4,30 +4,14 @@ import { RootRenderer } from './RootRenderer/RootRenderer';
 import SimulateDnD from '@/utils/simulateDnD';
 import { OUTGOING_EVENTS } from '@contentful/experiences-core/constants';
 import { useInitializeEditor } from '@/hooks/useInitializeEditor';
-import { useEntityStore } from '@/store/entityStore';
-import { useEditorStore } from '@/store/editor';
 import { useZoneStore } from '@/store/zone';
 import { CTFL_ZONE_ID, NEW_COMPONENT_ID } from '@/types/constants';
 import { useDraggedItemStore } from '@/store/draggedItem';
 
 export const VisualEditorRoot = () => {
   const initialized = useInitializeEditor();
-  const locale = useEditorStore((state) => state.locale);
   const setMousePosition = useDraggedItemStore((state) => state.setMousePosition);
-  const entityStore = useEntityStore((state) => state.entityStore);
   const setHoveringZone = useZoneStore((state) => state.setHoveringZone);
-  const resetEntityStore = useEntityStore((state) => state.resetEntityStore);
-
-  useEffect(() => {
-    if (!locale) {
-      return;
-    }
-    if (entityStore.locale === locale) {
-      return;
-    }
-
-    resetEntityStore(locale);
-  }, [locale, resetEntityStore, entityStore.locale]);
 
   useEffect(() => {
     const onMouseMove = (e: MouseEvent) => {

--- a/packages/visual-editor/src/store/entityStore.ts
+++ b/packages/visual-editor/src/store/entityStore.ts
@@ -9,7 +9,10 @@ export interface EntityState {
   areEntitiesFetched: boolean;
   // updaters
   setEntitiesFetched: (fetched: boolean) => void;
-  resetEntityStore: (locale: string, entities?: EditorModeEntityStore['entities']) => void;
+  resetEntityStore: (
+    locale: string,
+    entities?: EditorModeEntityStore['entities'],
+  ) => EditorModeEntityStore;
 }
 
 export const useEntityStore = create<EntityState>((set) => ({
@@ -19,13 +22,16 @@ export const useEntityStore = create<EntityState>((set) => ({
   setEntitiesFetched(fetched) {
     set({ areEntitiesFetched: fetched });
   },
-  resetEntityStore(locale, entities = []) {
+  resetEntityStore(locale, entities = []): EditorModeEntityStore {
     console.debug(
       `[experiences-sdk-react] Resetting entity store because the locale changed to '${locale}'.`,
     );
+    const newEntityStore = new EditorModeEntityStore({ locale, entities });
     set({
-      entityStore: new EditorModeEntityStore({ locale, entities }),
+      entityStore: newEntityStore,
       areEntitiesFetched: false,
     });
+
+    return newEntityStore;
   },
 }));


### PR DESCRIPTION
## Purpose
Remove useEffect in VisualEditorRoot as it was resetting entity store reactively. Which in some case ends up having empty canvas.