### PR TITLE
fix: extend validators to validate component registration on editor mode [SPA-1899]

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -13,6 +13,7 @@ import type {
   ComponentPropertyValue,
   PrimitiveValue,
   ExperienceComponentTree,
+  ComponentDefinitionPropertyType,
 } from '@contentful/experiences-validators';
 // TODO: Remove references to 'Composition'
 export type {
@@ -29,6 +30,7 @@ export type {
   UnboundValue,
   BoundValue,
   ComponentValue,
+  ComponentDefinitionPropertyType as ComponentDefinitionVariableType,
 } from '@contentful/experiences-validators';
 
 type ScrollStateKey = keyof typeof SCROLL_STATES;
@@ -51,30 +53,20 @@ export interface Link<T extends string> {
   };
 }
 
-export type ComponentDefinitionVariableType =
-  | 'Text'
-  | 'RichText'
-  | 'Number'
-  | 'Date'
-  | 'Boolean'
-  | 'Location'
-  | 'Media'
-  | 'Object';
-
 export type VariableFormats = 'URL'; // | alphaNum | base64 | email | ipAddress
 
-export type ValidationOption<T extends ComponentDefinitionVariableType> = {
+export type ValidationOption<T extends ComponentDefinitionPropertyType> = {
   value: T extends 'Text' ? string : T extends 'Number' ? number : never;
   displayName?: string;
 };
 
-export type ComponentDefinitionVariableValidation<T extends ComponentDefinitionVariableType> = {
+export type ComponentDefinitionVariableValidation<T extends ComponentDefinitionPropertyType> = {
   required?: boolean;
   in?: ValidationOption<T>[];
   format?: VariableFormats;
 };
 
-export interface ComponentDefinitionVariableBase<T extends ComponentDefinitionVariableType> {
+export interface ComponentDefinitionVariableBase<T extends ComponentDefinitionPropertyType> {
   type: T;
   validations?: ComponentDefinitionVariableValidation<T>;
   group?: 'style' | 'content';
@@ -85,7 +77,7 @@ export interface ComponentDefinitionVariableBase<T extends ComponentDefinitionVa
 }
 
 export type ComponentDefinitionVariable<
-  T extends ComponentDefinitionVariableType = ComponentDefinitionVariableType,
+  T extends ComponentDefinitionPropertyType = ComponentDefinitionPropertyType,
   // K extends ComponentDefinitionVariableArrayItemType = ComponentDefinitionVariableArrayItemType
 > =
   // T extends 'Link'
@@ -95,7 +87,7 @@ export type ComponentDefinitionVariable<
   /*:*/ ComponentDefinitionVariableBase<T>;
 
 export type ComponentDefinition<
-  T extends ComponentDefinitionVariableType = ComponentDefinitionVariableType,
+  T extends ComponentDefinitionPropertyType = ComponentDefinitionPropertyType,
 > = {
   id: string;
   name: string;

--- a/packages/experience-builder-sdk/src/core/componentRegistry.test.tsx
+++ b/packages/experience-builder-sdk/src/core/componentRegistry.test.tsx
@@ -221,4 +221,53 @@ describe('createAssemblyRegistration', () => {
     });
     expect(addComponentRegistrationMock).toHaveBeenCalled();
   });
+  describe('runRegisteredComponentValidations', () => {
+    let existingComponentRegistration: ComponentRegistration;
+    beforeEach(() => {
+      existingComponentRegistration = {
+        component: jest.fn(),
+        definition: {
+          id: 'existing-definition-id',
+          name: 'Existing Definition',
+          variables: {},
+          children: true,
+          category: ASSEMBLY_DEFAULT_CATEGORY,
+        },
+      };
+      registry.addComponentRegistration(existingComponentRegistration);
+    });
+
+    afterEach(() => {
+      registry.resetComponentRegistry();
+      jest.restoreAllMocks();
+    });
+
+    it('throws and error if component definition is invalid', () => {
+      const invalidComponentRegistration = {
+        component: jest.fn(),
+        definition: {
+          id: 'definition-id'.repeat(10),
+          name: 'Invalid Component',
+          variables: {},
+          children: true,
+          category: ASSEMBLY_DEFAULT_CATEGORY,
+        },
+      };
+      registry.addComponentRegistration(invalidComponentRegistration);
+      const errors = [
+        {
+          details: 'Property needs to match: /^[a-zA-Z0-9-_]{1,32}$/',
+          name: 'regex',
+          path: ['id'],
+        },
+      ];
+      const error = new Error(
+        `Invalid component definition for component 'Invalid Component'. Failed with errors: \n${JSON.stringify(errors, null, 2)}`,
+      );
+      expect(() => registry.runRegisteredComponentValidations()).toThrow(error);
+    });
+    it('does not throw an error if no component definition is invalid', () => {
+      expect(() => registry.runRegisteredComponentValidations()).not.toThrow(new Error());
+    });
+  });
 });

--- a/packages/experience-builder-sdk/src/core/componentRegistry.ts
+++ b/packages/experience-builder-sdk/src/core/componentRegistry.ts
@@ -20,6 +20,7 @@ import {
   columnsDefinition,
   singleColumnDefinition,
 } from '@contentful/experiences-core';
+import { validateComponentDefinition } from '@contentful/experiences-validators';
 import { withComponentWrapper } from '../utils/withComponentWrapper';
 import { SDK_VERSION } from '../constants';
 
@@ -165,6 +166,17 @@ export const sendRegisteredComponentsMessage = () => {
   });
 };
 
+export const runRegisteredComponentValidations = () => {
+  Array.from(componentRegistry.values()).map(({ definition }) => {
+    const validation = validateComponentDefinition(definition);
+    if (!validation.success) {
+      throw new Error(
+        `Invalid component definition for component '${definition.name}'. Failed with errors: \n${JSON.stringify(validation.errors, null, 2)}`,
+      );
+    }
+  });
+};
+
 export const sendConnectedEventWithRegisteredComponents = () => {
   // Send the definitions (without components) via the connection message to the experience builder
   const registeredDefinitions = Array.from(componentRegistry.values()).map(
@@ -201,6 +213,7 @@ export const defineComponents = (
   for (const registration of componentRegistrations) {
     // Fill definitions with fallbacks values
     const enrichedComponentRegistration = enrichComponentDefinition(registration);
+
     componentRegistry.set(
       enrichedComponentRegistration.definition.id,
       enrichedComponentRegistration,

--- a/packages/experience-builder-sdk/src/hooks/useInitializeVisualEditor.ts
+++ b/packages/experience-builder-sdk/src/hooks/useInitializeVisualEditor.ts
@@ -4,6 +4,7 @@ import {
   componentRegistry,
   sendConnectedEventWithRegisteredComponents,
   sendRegisteredComponentsMessage,
+  runRegisteredComponentValidations,
 } from '../core/componentRegistry';
 import { INTERNAL_EVENTS, VISUAL_EDITOR_EVENTS } from '@contentful/experiences-core/constants';
 import { designTokensRegistry } from '@contentful/experiences-core';
@@ -23,12 +24,14 @@ export const useInitializeVisualEditor = (params: InitializeVisualEditorParams) 
   // InternalEvents.COMPONENTS_REGISTERED is triggered by defineComponents function
   useEffect(() => {
     if (!hasConnectEventBeenSent.current) {
+      runRegisteredComponentValidations();
       // sending CONNECT but with the registered components now
       sendConnectedEventWithRegisteredComponents();
       hasConnectEventBeenSent.current = true;
     }
 
     const onComponentsRegistered = () => {
+      runRegisteredComponentValidations();
       sendRegisteredComponentsMessage();
     };
 

--- a/packages/validators/src/schemas/componentDefinition.ts
+++ b/packages/validators/src/schemas/componentDefinition.ts
@@ -1,0 +1,32 @@
+import { z } from 'zod';
+
+export const DefinitionPropertyTypeSchema = z.enum([
+  'Text',
+  'RichText',
+  'Number',
+  'Date',
+  'Boolean',
+  'Location',
+  'Media',
+  'Object',
+]);
+
+export const DefinitionPropertyKeySchema = z
+  .string()
+  .regex(/^[a-zA-Z0-9-_]{1,32}$/, { message: 'Attribute needs to match: /^[a-zA-Z0-9-_]{1,32}$/' });
+
+export const ComponentDefinitionSchema = z.object({
+  id: DefinitionPropertyKeySchema,
+  variables: z.record(
+    DefinitionPropertyKeySchema,
+    z.object({
+      // TODO - extend with definition of validations and defaultValue
+      displayName: z.string().optional(),
+      type: DefinitionPropertyTypeSchema,
+      description: z.string().optional(),
+      group: z.string().optional(),
+    }),
+  ),
+});
+
+export type ComponentDefinitionPropertyType = z.infer<typeof DefinitionPropertyTypeSchema>;

--- a/packages/validators/src/schemas/componentDefinition.ts
+++ b/packages/validators/src/schemas/componentDefinition.ts
@@ -13,7 +13,7 @@ export const DefinitionPropertyTypeSchema = z.enum([
 
 export const DefinitionPropertyKeySchema = z
   .string()
-  .regex(/^[a-zA-Z0-9-_]{1,32}$/, { message: 'Attribute needs to match: /^[a-zA-Z0-9-_]{1,32}$/' });
+  .regex(/^[a-zA-Z0-9-_]{1,32}$/, { message: 'Property needs to match: /^[a-zA-Z0-9-_]{1,32}$/' });
 
 export const ComponentDefinitionSchema = z.object({
   id: DefinitionPropertyKeySchema,

--- a/packages/validators/src/schemas/index.ts
+++ b/packages/validators/src/schemas/index.ts
@@ -1,1 +1,2 @@
 export { ExperienceFieldsCMAShapeSchema as Schema_2023_09_28 } from './v2023_09_28/experience';
+export { ComponentDefinitionSchema } from './componentDefinition';

--- a/packages/validators/src/schemas/v2023_09_28/experience.ts
+++ b/packages/validators/src/schemas/v2023_09_28/experience.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { SchemaVersions } from '../schemaVersions';
+import { DefinitionPropertyTypeSchema, DefinitionPropertyKeySchema } from '../componentDefinition';
 
 const uuidKeySchema = z
   .string()
@@ -31,17 +32,6 @@ const PrimitiveValueSchema = z.union([
   z.number(),
   z.record(z.any(), z.any()),
   z.undefined(),
-]);
-
-export const ComponentDefinitionPropertyTypeSchema = z.enum([
-  'Text',
-  'RichText',
-  'Number',
-  'Date',
-  'Boolean',
-  'Location',
-  'Media',
-  'Object',
 ]);
 
 const ValuesByBreakpointSchema = z.record(z.lazy(() => PrimitiveValueSchema));
@@ -98,7 +88,7 @@ const UnboundValuesSchema = z.record(
 
 // Use helper schema to define a recursive schema with its type correctly below
 const BaseComponentTreeNodeSchema = z.object({
-  definitionId: z.string(),
+  definitionId: DefinitionPropertyKeySchema,
   variables: z.record(propertyKeySchema, ComponentPropertyValueSchema),
 });
 export type ComponentTreeNode = z.infer<typeof BaseComponentTreeNodeSchema> & {
@@ -113,7 +103,7 @@ const ComponentSettingsSchema = z.object({
     z.string().regex(/^[a-zA-Z0-9-_]{1,54}$/), // Here the key is <variableName>_<nanoidId> so we need to allow for a longer length
     z.object({
       displayName: z.string().optional(),
-      type: ComponentDefinitionPropertyTypeSchema,
+      type: DefinitionPropertyTypeSchema,
       defaultValue: PrimitiveValueSchema.or(ComponentPropertyValueSchema).optional(),
       description: z.string().optional(),
       group: z.string().optional(),

--- a/packages/validators/src/types.ts
+++ b/packages/validators/src/types.ts
@@ -15,4 +15,5 @@ export type {
   BoundValue,
   ComponentValue,
 } from './schemas/latest';
+export type { ComponentDefinitionPropertyType } from './schemas/componentDefinition';
 export type { SchemaVersions } from './schemas/schemaVersions';

--- a/packages/validators/src/validators.ts
+++ b/packages/validators/src/validators.ts
@@ -1,4 +1,4 @@
-import { Schema_2023_09_28 } from './schemas';
+import { Schema_2023_09_28, ComponentDefinitionSchema } from './schemas';
 import {
   ContentfulErrorDetails,
   zodToContentfulError,
@@ -24,7 +24,7 @@ type ValidatorReturnValue = {
  */
 export const validateExperienceFields = (
   experience: any,
-  schemaVersionOverride?: SchemaVersions
+  schemaVersionOverride?: SchemaVersions,
 ): ValidatorReturnValue => {
   let schemaVersion;
   if (experience.fields.componentTree) {
@@ -62,6 +62,17 @@ export const validateExperienceFields = (
   if (!result.success) {
     return {
       success: result.success,
+      errors: result.error.issues.map(zodToContentfulError),
+    };
+  }
+  return { success: true };
+};
+
+export const validateComponentDefinition = (definition): ValidatorReturnValue => {
+  const result = ComponentDefinitionSchema.safeParse(definition);
+  if (!result.success) {
+    return {
+      success: false,
       errors: result.error.issues.map(zodToContentfulError),
     };
   }

--- a/packages/validators/test/__fixtures__/componentDefinition.ts
+++ b/packages/validators/test/__fixtures__/componentDefinition.ts
@@ -1,0 +1,10 @@
+export const componentDefinition = {
+  id: 'test-component',
+  name: 'TestComponent',
+  builtInStyles: [],
+  variables: {
+    isChecked: {
+      type: 'Boolean',
+    },
+  },
+};

--- a/packages/validators/test/validator.spec.ts
+++ b/packages/validators/test/validator.spec.ts
@@ -1,4 +1,5 @@
-import { validateExperienceFields } from '../src/validators';
+import { validateComponentDefinition, validateExperienceFields } from '../src/validators';
+import { componentDefinition } from './__fixtures__/componentDefinition';
 import { experience } from './__fixtures__/v2023_09_28/experience';
 import { describe, it, expect } from 'vitest';
 
@@ -17,5 +18,72 @@ describe('validateExperienceFields', () => {
     const result = validateExperienceFields(experience, '2023-09-28');
 
     expect(result.success).toBe(true);
+  });
+});
+
+describe('validateComponentDefinition', () => {
+  it('should validate the component definition successfully', () => {
+    const result = validateComponentDefinition(componentDefinition);
+
+    expect(result.success).toBe(true);
+  });
+
+  it('should return an error if component definition id is longer than max length', () => {
+    const unpdatedComponentDefinition = {
+      ...componentDefinition,
+      id: componentDefinition.id.repeat(10),
+    };
+
+    const result = validateComponentDefinition(unpdatedComponentDefinition);
+
+    expect(result.success).toBe(false);
+    expect(result.errors?.[0].name).toBe('regex');
+    expect(result.errors?.[0].path).toEqual(['id']);
+    expect(result.errors?.[0].details).toBe('Property needs to match: /^[a-zA-Z0-9-_]{1,32}$/');
+  });
+
+  it('should return an error if component variable key is longer than max length', () => {
+    const unpdatedComponentDefinition = {
+      ...componentDefinition,
+      variables: {
+        ['testVar'.repeat(10)]: {
+          type: 'Boolean',
+        },
+      },
+    };
+
+    const result = validateComponentDefinition(unpdatedComponentDefinition);
+
+    expect(result.success).toBe(false);
+    expect(result.errors?.[0].name).toBe('regex');
+    expect(result.errors?.[0].path).toEqual(['variables', 'testVar'.repeat(10)]);
+    expect(result.errors?.[0].details).toBe('Property needs to match: /^[a-zA-Z0-9-_]{1,32}$/');
+  });
+
+  it('should return an error if component variable key is longer than max length', () => {
+    const unpdatedComponentDefinition = {
+      ...componentDefinition,
+      variables: {
+        testVar: {
+          type: 'InvalidType',
+        },
+      },
+    };
+
+    const result = validateComponentDefinition(unpdatedComponentDefinition);
+
+    expect(result.success).toBe(false);
+    expect(result.errors?.[0].name).toBe('in');
+    expect(result.errors?.[0].path).toEqual(['variables', 'testVar', 'type']);
+    expect(result.errors?.[0].expected).toEqual([
+      'Text',
+      'RichText',
+      'Number',
+      'Date',
+      'Boolean',
+      'Location',
+      'Media',
+      'Object',
+    ]);
   });
 });


### PR DESCRIPTION
## Purpose

* Extend validations to make sure component `definitionId` doesn't not contain invalid characters and has max limit of 32
* Validate components during component registration - **only on editor mode**

## Approach
* Define a simple validator function for component registrations
* [In Editor Mode] Run the validation when a new component is registered
* throw an error if the validation fails
* Validation doesn't ran on preview/delivery mode to avoid introduction exception in the customer's website.

<!--

Three important notes on Pull Requests:
- In general, you should ask yourself whether this code change will improve or worsen the overall code quality. Any new tech debt will probably never be cleaned up.
- Please remember that newly introduced logic should be validated and protected through testing.
- Take a look at PR guides such as Google's [Google’s Code Review Guidelines](https://google.github.io/eng-practices/) and [Blockly - Writing a Good Pull Request](https://developers.google.com/blockly/guides/contribute/get-started/write_a_good_pr)

-->
