### PR TITLE
refactor(experience-builder-sdk): synchronous style calculation

### DIFF
--- a/packages/experience-builder-sdk/src/hooks/useStyleTag.spec.ts
+++ b/packages/experience-builder-sdk/src/hooks/useStyleTag.spec.ts
@@ -1,0 +1,57 @@
+import { CSSProperties } from 'react';
+import { renderHook } from '@testing-library/react';
+import { useStyleTag } from './useStyleTag';
+
+describe('useStyleTag', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  describe('when given an empty set of styles', () => {
+    it('should yield an empty class name', () => {
+      const { result } = renderHook(() => useStyleTag({ styles: {} }));
+
+      expect(result.current.className).toStrictEqual('');
+    });
+  });
+
+  describe('when styles are given', () => {
+    const styles: CSSProperties = { display: 'grid', color: 'snow' };
+
+    it('should yield a non-empty class name in its first render pass', () => {
+      const { result } = renderHook(() => useStyleTag({ styles }));
+
+      // expects format "cfstyles-" + 32 char suffix (MD5)
+      expect(result.current.className).toMatch(/^cfstyles-\w{32}$/);
+    });
+
+    describe('when given a nodeId', () => {
+      it('should check for an existing style tag in the document', () => {
+        const innerHTMLSetterMock = jest.fn();
+        const querySelectorSpy = jest.spyOn(document, 'querySelector').mockReturnValueOnce({
+          set innerHTML(v: string) {
+            innerHTMLSetterMock(v);
+          },
+        } as unknown as HTMLElement);
+
+        const { result } = renderHook(() => useStyleTag({ styles, nodeId: 'id-of-node' }));
+
+        expect(querySelectorSpy).toHaveBeenCalledWith(
+          `[data-cf-styles="${result.current.className}"]`,
+        );
+        expect(innerHTMLSetterMock).toHaveBeenCalledWith(expect.any(String));
+      });
+    });
+
+    describe('when no nodeId is present', () => {
+      it('should create a new style tag', () => {
+        const appendChildSpy = jest.spyOn(document.head, 'appendChild');
+
+        renderHook(() => useStyleTag({ styles }));
+
+        expect(appendChildSpy).toHaveBeenCalledWith(expect.any(HTMLStyleElement));
+        expect(appendChildSpy.mock.lastCall?.[0]).toHaveAttribute('data-cf-styles');
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Purpose

Styling in Experiences is currently a process that happens solely client-side. The hook used to inject styles, `useStyleTag`, uses a combination of state/effect to create the correct style rules and append them to the document head. Since React runs effects after DOM is updated, this approach has meant that there is always at least one render pass where the output is unstyled.

## Approach

<!--

Three important notes on Pull Requests:
- In general, you should ask yourself whether this code change will improve or worsen the overall code quality. Any new tech debt will probably never be cleaned up.
- Please remember that newly introduced logic should be validated and protected through testing.
- Take a look at PR guides such as Google's [Google’s Code Review Guidelines](https://google.github.io/eng-practices/) and [Blockly - Writing a Good Pull Request](https://developers.google.com/blockly/guides/contribute/get-started/write_a_good_pr)

-->

Given that none of the work that `useStyleTag` does is asynchronous, we can refactor it process such that:

- Styles are memoised, rather than stateful; this better reflects the fact that they are a product of props rather than something the hook itself can change over time.
- Styles are appended the DOM using a layout effect. Given that these run before paint, this means that styles are immediately available for newly mounted components.
