### PR TITLE
fix: convert protocol agnostic image asset url to https [ALT-639]

### DIFF
--- a/packages/core/src/utils/transformers/media/getOptimizedBackgroundImageAsset.spec.ts
+++ b/packages/core/src/utils/transformers/media/getOptimizedBackgroundImageAsset.spec.ts
@@ -17,63 +17,81 @@ describe('transformImageAsset', () => {
   it('when width of container is not provided and image is larger than the max width, should return a srcSet with a basis width of 2000px', () => {
     file.details.image!.width = 4000;
     const result = getOptimizedBackgroundImageAsset(file, '');
-    expect(result.srcSet).toEqual([`url(${file.url}?w=2000) 1x`, `url(${file.url}?w=4000) 2x`]);
+    expect(result.srcSet).toEqual([
+      `url(https:${file.url}?w=2000) 1x`,
+      `url(https:${file.url}?w=4000) 2x`,
+    ]);
   });
 
   it('when width of container is not provided and image is larger than the max width, should return a url with a width of 4000px', () => {
     file.details.image!.width = 4000;
     const result = getOptimizedBackgroundImageAsset(file, '');
-    expect(result.url).toEqual('//images.contentful.com/abc/123/a1b2c3/myImage.jpg?w=4000');
+    expect(result.url).toEqual('https://images.contentful.com/abc/123/a1b2c3/myImage.jpg?w=4000');
   });
 
   it('when width of container is not provided and the image is smaller than the max width, should return a srcSet with a basis width of the image width, and 2x at same width', () => {
     file.details.image!.width = 1000;
     const result = getOptimizedBackgroundImageAsset(file, '');
-    expect(result.srcSet).toEqual([`url(${file.url}?w=1000) 1x`, `url(${file.url}?w=1000) 2x`]);
+    expect(result.srcSet).toEqual([
+      `url(https:${file.url}?w=1000) 1x`,
+      `url(https:${file.url}?w=1000) 2x`,
+    ]);
   });
 
   it('when width of container is not provided and the image is smaller than the max width, should return a url with a width of the image', () => {
     file.details.image!.width = 1000;
     const result = getOptimizedBackgroundImageAsset(file, '');
-    expect(result.url).toEqual('//images.contentful.com/abc/123/a1b2c3/myImage.jpg?w=1000');
+    expect(result.url).toEqual('https://images.contentful.com/abc/123/a1b2c3/myImage.jpg?w=1000');
   });
 
   it('when width of container is 1000px and image is larger than the max width, should return a srcSet with a basis width of 1000px', () => {
     file.details.image!.width = 4000;
     const result = getOptimizedBackgroundImageAsset(file, '1000px');
-    expect(result.srcSet).toEqual([`url(${file.url}?w=1000) 1x`, `url(${file.url}?w=2000) 2x`]);
+    expect(result.srcSet).toEqual([
+      `url(https:${file.url}?w=1000) 1x`,
+      `url(https:${file.url}?w=2000) 2x`,
+    ]);
   });
 
   it('when width of container is 1000px and image is larger than the max width, should return a url with a width of 2x the provided width', () => {
     file.details.image!.width = 4000;
     const result = getOptimizedBackgroundImageAsset(file, '1000px');
-    expect(result.url).toEqual('//images.contentful.com/abc/123/a1b2c3/myImage.jpg?w=2000');
+    expect(result.url).toEqual('https://images.contentful.com/abc/123/a1b2c3/myImage.jpg?w=2000');
   });
 
   it('when width of container is 1000px and image is smaller than the max width, should return a srcSet with a basis width of the image width, and 2x at same width', () => {
     file.details.image!.width = 1000;
     const result = getOptimizedBackgroundImageAsset(file, '1000px');
-    expect(result.srcSet).toEqual([`url(${file.url}?w=1000) 1x`, `url(${file.url}?w=1000) 2x`]);
+    expect(result.srcSet).toEqual([
+      `url(https:${file.url}?w=1000) 1x`,
+      `url(https:${file.url}?w=1000) 2x`,
+    ]);
   });
 
   it('when quality is 0, should return urls without quality', () => {
     file.details.image!.width = 4000;
     const result = getOptimizedBackgroundImageAsset(file, '', 0);
-    expect(result.srcSet).toEqual([`url(${file.url}?w=2000) 1x`, `url(${file.url}?w=4000) 2x`]);
+    expect(result.srcSet).toEqual([
+      `url(https:${file.url}?w=2000) 1x`,
+      `url(https:${file.url}?w=4000) 2x`,
+    ]);
   });
 
   it('when quality is 100, should return urls without quality', () => {
     file.details.image!.width = 4000;
     const result = getOptimizedBackgroundImageAsset(file, '', 100);
-    expect(result.srcSet).toEqual([`url(${file.url}?w=2000) 1x`, `url(${file.url}?w=4000) 2x`]);
+    expect(result.srcSet).toEqual([
+      `url(https:${file.url}?w=2000) 1x`,
+      `url(https:${file.url}?w=4000) 2x`,
+    ]);
   });
 
   it('when quality is provided, should return urls with quality', () => {
     file.details.image!.width = 4000;
     const result = getOptimizedBackgroundImageAsset(file, '', 80);
     expect(result.srcSet).toEqual([
-      `url(${file.url}?w=2000&q=80) 1x`,
-      `url(${file.url}?w=4000&q=80) 2x`,
+      `url(https:${file.url}?w=2000&q=80) 1x`,
+      `url(https:${file.url}?w=4000&q=80) 2x`,
     ]);
   });
 
@@ -81,8 +99,8 @@ describe('transformImageAsset', () => {
     file.details.image!.width = 4000;
     const result = getOptimizedBackgroundImageAsset(file, '', 80, 'webp');
     expect(result.srcSet).toEqual([
-      `url(${file.url}?w=2000&q=80&fm=webp) 1x`,
-      `url(${file.url}?w=4000&q=80&fm=webp) 2x`,
+      `url(https:${file.url}?w=2000&q=80&fm=webp) 1x`,
+      `url(https:${file.url}?w=4000&q=80&fm=webp) 2x`,
     ]);
   });
 });

--- a/packages/core/src/utils/transformers/media/getOptimizedImageAsset.spec.ts
+++ b/packages/core/src/utils/transformers/media/getOptimizedImageAsset.spec.ts
@@ -17,34 +17,37 @@ describe('transformImageAsset', () => {
   it('when width of image is 250, should return a srcSet with 2 parts', () => {
     file.details.image!.width = 250;
     const result = getOptimizedImageAsset(file, '500px');
-    expect(result.srcSet).toEqual([`${file.url}?w=125 125w`, `${file.url}?w=250 250w`]);
+    expect(result.srcSet).toEqual([`https:${file.url}?w=125 125w`, `https:${file.url}?w=250 250w`]);
   });
 
   it('when width of image is 500, should return a srcSet with 2 parts', () => {
     file.details.image!.width = 500;
     const result = getOptimizedImageAsset(file, '500px');
-    expect(result.srcSet).toEqual([`${file.url}?w=250 250w`, `${file.url}?w=500 500w`]);
+    expect(result.srcSet).toEqual([`https:${file.url}?w=250 250w`, `https:${file.url}?w=500 500w`]);
   });
 
   it('when width of image is 525, should return a srcSet with 2 parts', () => {
     file.details.image!.width = 525;
     const result = getOptimizedImageAsset(file, '500px');
-    expect(result.srcSet).toEqual([`${file.url}?w=263 263w`, `${file.url}?w=525 525w`]);
+    expect(result.srcSet).toEqual([`https:${file.url}?w=263 263w`, `https:${file.url}?w=525 525w`]);
   });
 
   it('when width of image is 1000, should return a srcSet with 2 parts', () => {
     file.details.image!.width = 1000;
     const result = getOptimizedImageAsset(file, '500px');
-    expect(result.srcSet).toEqual([`${file.url}?w=500 500w`, `${file.url}?w=1000 1000w`]);
+    expect(result.srcSet).toEqual([
+      `https:${file.url}?w=500 500w`,
+      `https:${file.url}?w=1000 1000w`,
+    ]);
   });
 
   it('when width of image is 1500, should return a srcSet with 3 parts', () => {
     file.details.image!.width = 1500;
     const result = getOptimizedImageAsset(file, '500px');
     expect(result.srcSet).toEqual([
-      `${file.url}?w=500 500w`,
-      `${file.url}?w=1000 1000w`,
-      `${file.url}?w=1500 1500w`,
+      `https:${file.url}?w=500 500w`,
+      `https:${file.url}?w=1000 1000w`,
+      `https:${file.url}?w=1500 1500w`,
     ]);
   });
 
@@ -52,14 +55,14 @@ describe('transformImageAsset', () => {
     file.details.image!.width = 4000;
     const result = getOptimizedImageAsset(file, '500px');
     expect(result.srcSet).toEqual([
-      `${file.url}?w=500 500w`,
-      `${file.url}?w=1000 1000w`,
-      `${file.url}?w=1500 1500w`,
-      `${file.url}?w=2000 2000w`,
-      `${file.url}?w=2500 2500w`,
-      `${file.url}?w=3000 3000w`,
-      `${file.url}?w=3500 3500w`,
-      `${file.url}?w=4000 4000w`,
+      `https:${file.url}?w=500 500w`,
+      `https:${file.url}?w=1000 1000w`,
+      `https:${file.url}?w=1500 1500w`,
+      `https:${file.url}?w=2000 2000w`,
+      `https:${file.url}?w=2500 2500w`,
+      `https:${file.url}?w=3000 3000w`,
+      `https:${file.url}?w=3500 3500w`,
+      `https:${file.url}?w=4000 4000w`,
     ]);
   });
 
@@ -67,15 +70,15 @@ describe('transformImageAsset', () => {
     file.details.image!.width = 5000;
     const result = getOptimizedImageAsset(file, '500px');
     expect(result.srcSet).toEqual([
-      `${file.url}?w=500 500w`,
-      `${file.url}?w=1000 1000w`,
-      `${file.url}?w=1500 1500w`,
-      `${file.url}?w=2000 2000w`,
-      `${file.url}?w=2500 2500w`,
-      `${file.url}?w=3000 3000w`,
-      `${file.url}?w=3500 3500w`,
-      `${file.url}?w=4000 4000w`,
-      `${file.url} 5000w`,
+      `https:${file.url}?w=500 500w`,
+      `https:${file.url}?w=1000 1000w`,
+      `https:${file.url}?w=1500 1500w`,
+      `https:${file.url}?w=2000 2000w`,
+      `https:${file.url}?w=2500 2500w`,
+      `https:${file.url}?w=3000 3000w`,
+      `https:${file.url}?w=3500 3500w`,
+      `https:${file.url}?w=4000 4000w`,
+      `https:${file.url} 5000w`,
     ]);
   });
 
@@ -87,12 +90,12 @@ describe('transformImageAsset', () => {
   it('the url should have a width limit of 2000 and quality of 80 when the image width is larger than 2000', () => {
     file.details.image!.width = 2500;
     const result = getOptimizedImageAsset(file, '500px', 80);
-    expect(result.url).toEqual(`${file.url}?w=2000&q=80`);
+    expect(result.url).toEqual(`https:${file.url}?w=2000&q=80`);
   });
 
   it('the url should have no width limit and quality of 80 when the image width is 800', () => {
     const result = getOptimizedImageAsset(file, '500px', 80);
-    expect(result.url).toEqual(`${file.url}?q=80`);
+    expect(result.url).toEqual(`https:${file.url}?q=80`);
   });
 
   it('when there is no file on the asset, should throw an error', () => {
@@ -107,17 +110,20 @@ describe('transformImageAsset', () => {
 
   it('when quality is passed, the quality should be on the srcSet urls', () => {
     const result = getOptimizedImageAsset(file, '500px', 50);
-    expect(result.srcSet).toEqual([`${file.url}?w=400&q=50 400w`, `${file.url}?w=800&q=50 800w`]);
+    expect(result.srcSet).toEqual([
+      `https:${file.url}?w=400&q=50 400w`,
+      `https:${file.url}?w=800&q=50 800w`,
+    ]);
   });
 
   it('when quality is 0, the quality should not be on the srcSet urls', () => {
     const result = getOptimizedImageAsset(file, '500px', 0);
-    expect(result.srcSet).toEqual([`${file.url}?w=400 400w`, `${file.url}?w=800 800w`]);
+    expect(result.srcSet).toEqual([`https:${file.url}?w=400 400w`, `https:${file.url}?w=800 800w`]);
   });
 
   it('when quality is 100, the quality should not be on the srcSet urls', () => {
     const result = getOptimizedImageAsset(file, '500px', 100);
-    expect(result.srcSet).toEqual([`${file.url}?w=400 400w`, `${file.url}?w=800 800w`]);
+    expect(result.srcSet).toEqual([`https:${file.url}?w=400 400w`, `https:${file.url}?w=800 800w`]);
   });
 
   it('when quality is less than 0, should throw an error', () => {
@@ -135,8 +141,8 @@ describe('transformImageAsset', () => {
   it('when format is passed, the format should be on the srcSet urls', () => {
     const result = getOptimizedImageAsset(file, '500px', undefined, 'webp');
     expect(result.srcSet).toEqual([
-      `${file.url}?w=400&fm=webp 400w`,
-      `${file.url}?w=800&fm=webp 800w`,
+      `https:${file.url}?w=400&fm=webp 400w`,
+      `https:${file.url}?w=800&fm=webp 800w`,
     ]);
   });
 

--- a/packages/core/src/utils/transformers/media/getOptimizedImageUrl.spec.ts
+++ b/packages/core/src/utils/transformers/media/getOptimizedImageUrl.spec.ts
@@ -8,7 +8,7 @@ describe('getImageUrl', () => {
     const quality = 80;
     const format = 'webp';
     const result = getOptimizedImageUrl(url, width, quality, format);
-    expect(result).toBe('//example.com/image.jpg?w=200&q=80&fm=webp');
+    expect(result).toBe('https://example.com/image.jpg?w=200&q=80&fm=webp');
   });
 
   it('when quality is below 0, quality should not be added to the url', () => {
@@ -17,7 +17,7 @@ describe('getImageUrl', () => {
     const quality = -1;
     const format = 'webp';
     const result = getOptimizedImageUrl(url, width, quality, format);
-    expect(result).toBe('//example.com/image.jpg?w=200&fm=webp');
+    expect(result).toBe('https://example.com/image.jpg?w=200&fm=webp');
   });
 
   it('when quality is 0, quality should not be added to the url', () => {
@@ -26,7 +26,7 @@ describe('getImageUrl', () => {
     const quality = 0;
     const format = 'webp';
     const result = getOptimizedImageUrl(url, width, quality, format);
-    expect(result).toBe('//example.com/image.jpg?w=200&fm=webp');
+    expect(result).toBe('https://example.com/image.jpg?w=200&fm=webp');
   });
 
   it('when quality is 100, quality should not be added to the url', () => {
@@ -35,7 +35,7 @@ describe('getImageUrl', () => {
     const quality = 100;
     const format = 'webp';
     const result = getOptimizedImageUrl(url, width, quality, format);
-    expect(result).toBe('//example.com/image.jpg?w=200&fm=webp');
+    expect(result).toBe('https://example.com/image.jpg?w=200&fm=webp');
   });
 
   it('when quality is above 100, quality should not be added to the url', () => {
@@ -44,7 +44,7 @@ describe('getImageUrl', () => {
     const quality = 101;
     const format = 'webp';
     const result = getOptimizedImageUrl(url, width, quality, format);
-    expect(result).toBe('//example.com/image.jpg?w=200&fm=webp');
+    expect(result).toBe('https://example.com/image.jpg?w=200&fm=webp');
   });
 
   it('when format is not provided, format should not be added to the url', () => {
@@ -52,7 +52,7 @@ describe('getImageUrl', () => {
     const width = 200;
     const quality = 80;
     const result = getOptimizedImageUrl(url, width, quality);
-    expect(result).toBe('//example.com/image.jpg?w=200&q=80');
+    expect(result).toBe('https://example.com/image.jpg?w=200&q=80');
   });
 
   it('when width is not provided, width should not be added to the url', () => {
@@ -60,12 +60,12 @@ describe('getImageUrl', () => {
     const quality = 80;
     const format = 'webp';
     const result = getOptimizedImageUrl(url, 0, quality, format);
-    expect(result).toBe('//example.com/image.jpg?q=80&fm=webp');
+    expect(result).toBe('https://example.com/image.jpg?q=80&fm=webp');
   });
 
   it('when no optional parameters are provided, the url should not have any query string', () => {
     const url = '//example.com/image.jpg';
     const result = getOptimizedImageUrl(url);
-    expect(result).toBe('//example.com/image.jpg');
+    expect(result).toBe('https://example.com/image.jpg');
   });
 });

--- a/packages/core/src/utils/transformers/media/getOptimizedImageUrl.ts
+++ b/packages/core/src/utils/transformers/media/getOptimizedImageUrl.ts
@@ -4,6 +4,10 @@ export function getOptimizedImageUrl(
   quality?: number,
   format?: string,
 ) {
+  if (url.startsWith('//')) {
+    url = 'https:' + url;
+  }
+
   const params = new URLSearchParams();
   if (width) {
     params.append('w', width.toString());


### PR DESCRIPTION
## Purpose

Changes the `getOptimizedImageUrl` method to specify https instead of using protocol agnostic urls that come back from the image API.

This prevents the "Mixed Content" error when running the hosted app locally on http. 

I tested images and background images with the test-app running locally, and with the hosted test-app on vercel and I'm not seeing any unexpected side effects.