### PR TITLE
fix(components): change image object fit to default to undefined instead of none []

### DIFF
--- a/packages/core/src/definitions/styles.ts
+++ b/packages/core/src/definitions/styles.ts
@@ -192,7 +192,6 @@ export const optionalBuiltInStyles: VariableDefinitions = {
     defaultValue: {
       width: DEFAULT_IMAGE_WIDTH,
       height: '100%',
-      objectFit: 'none',
       objectPosition: 'center center',
       quality: '100',
       targetSize: DEFAULT_IMAGE_WIDTH,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -337,7 +337,7 @@ export type ImageOptions = {
   format?: string;
   width: string;
   height: string;
-  objectFit: ImageObjectFitOption;
+  objectFit?: ImageObjectFitOption;
   objectPosition: ImageObjectPositionOption;
   quality: string;
   targetSize: string;


### PR DESCRIPTION
## Purpose
Defaulting the image component to object fit none lead to unexpected behavior so we are opting to make objectFit undefined as an initial value so that it has no styling effect by default.
