### PR TITLE
feat: add borderRadius type for design tokens

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -231,6 +231,7 @@ export type DesignTokensDefinition = {
   sizing?: Record<string, string>;
   color?: Record<string, string>;
   border?: Record<string, { width: string; style: 'solid' | 'dashed' | 'dotted'; color: string }>;
+  borderRadius?: Record<string, string>;
   fontSize?: Record<string, string>;
   lineHeight?: Record<string, string>;
   letterSpacing?: Record<string, string>;


### PR DESCRIPTION
## Purpose
add borderRadius type for design tokens
<img width="332" alt="Screenshot 2024-03-19 at 4 19 44 PM" src="https://github.com/contentful/experience-builder/assets/124832189/f91f6139-b649-4efe-a6f3-82ab5d77de33">
