### PR TITLE
fix(core): expect image quality to be a string with a percentage [ALT-643]

### DIFF
--- a/packages/core/src/definitions/styles.ts
+++ b/packages/core/src/definitions/styles.ts
@@ -193,7 +193,7 @@ export const optionalBuiltInStyles: VariableDefinitions = {
       width: DEFAULT_IMAGE_WIDTH,
       height: '100%',
       objectPosition: 'center center',
-      quality: '100',
+      quality: '80%',
       targetSize: DEFAULT_IMAGE_WIDTH,
     },
   },

--- a/packages/core/src/definitions/styles.ts
+++ b/packages/core/src/definitions/styles.ts
@@ -192,8 +192,6 @@ export const optionalBuiltInStyles: VariableDefinitions = {
     defaultValue: {
       width: DEFAULT_IMAGE_WIDTH,
       height: '100%',
-      objectPosition: 'center center',
-      quality: '80%',
       targetSize: DEFAULT_IMAGE_WIDTH,
     },
   },
@@ -209,7 +207,6 @@ export const optionalBuiltInStyles: VariableDefinitions = {
     defaultValue: {
       scaling: 'fill',
       alignment: 'left top',
-      quality: '100',
       targetSize: '2000px',
     },
   },

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -364,6 +364,6 @@ export type BackgroundImageOptions = {
   format?: string;
   scaling: BackgroundImageScalingOption;
   alignment: BackgroundImageAlignmentOption;
-  quality: string;
+  quality?: string;
   targetSize: string;
 };

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -338,8 +338,8 @@ export type ImageOptions = {
   width: string;
   height: string;
   objectFit?: ImageObjectFitOption;
-  objectPosition: ImageObjectPositionOption;
-  quality: string;
+  objectPosition?: ImageObjectPositionOption;
+  quality?: string;
   targetSize: string;
 };
 

--- a/packages/core/src/utils/transformers/media/getOptimizedBackgroundImageAsset.spec.ts
+++ b/packages/core/src/utils/transformers/media/getOptimizedBackgroundImageAsset.spec.ts
@@ -68,18 +68,18 @@ describe('transformImageAsset', () => {
     ]);
   });
 
-  it('when quality is 0, should return urls without quality', () => {
+  it('when quality is 0%, should return urls without quality', () => {
     file.details.image!.width = 4000;
-    const result = getOptimizedBackgroundImageAsset(file, '', 0);
+    const result = getOptimizedBackgroundImageAsset(file, '', '0%');
     expect(result.srcSet).toEqual([
       `url(https:${file.url}?w=2000) 1x`,
       `url(https:${file.url}?w=4000) 2x`,
     ]);
   });
 
-  it('when quality is 100, should return urls without quality', () => {
+  it('when quality is 100%, should return urls without quality', () => {
     file.details.image!.width = 4000;
-    const result = getOptimizedBackgroundImageAsset(file, '', 100);
+    const result = getOptimizedBackgroundImageAsset(file, '', '100%');
     expect(result.srcSet).toEqual([
       `url(https:${file.url}?w=2000) 1x`,
       `url(https:${file.url}?w=4000) 2x`,
@@ -88,7 +88,7 @@ describe('transformImageAsset', () => {
 
   it('when quality is provided, should return urls with quality', () => {
     file.details.image!.width = 4000;
-    const result = getOptimizedBackgroundImageAsset(file, '', 80);
+    const result = getOptimizedBackgroundImageAsset(file, '', '80%');
     expect(result.srcSet).toEqual([
       `url(https:${file.url}?w=2000&q=80) 1x`,
       `url(https:${file.url}?w=4000&q=80) 2x`,
@@ -97,7 +97,7 @@ describe('transformImageAsset', () => {
 
   it('when format is provided, should return urls with format', () => {
     file.details.image!.width = 4000;
-    const result = getOptimizedBackgroundImageAsset(file, '', 80, 'webp');
+    const result = getOptimizedBackgroundImageAsset(file, '', '80%', 'webp');
     expect(result.srcSet).toEqual([
       `url(https:${file.url}?w=2000&q=80&fm=webp) 1x`,
       `url(https:${file.url}?w=4000&q=80&fm=webp) 2x`,

--- a/packages/core/src/utils/transformers/media/getOptimizedBackgroundImageAsset.ts
+++ b/packages/core/src/utils/transformers/media/getOptimizedBackgroundImageAsset.ts
@@ -1,70 +1,52 @@
-import { SUPPORTED_IMAGE_FORMATS } from '@/constants';
 import { OptimizedBackgroundImageAsset } from '@/types';
 import { getOptimizedImageUrl } from './getOptimizedImageUrl';
 import { AssetFile } from 'contentful';
-
-interface AssetFileWithRequiredImage extends AssetFile {
-  details: Required<AssetFile['details']>;
-}
-type ValidFormats = (typeof SUPPORTED_IMAGE_FORMATS)[number];
+import { ValidFormats, validateParams, AssetFileWithRequiredImage } from './mediaUtils';
 
 const MAX_WIDTH_ALLOWED = 2000;
 
 export const getOptimizedBackgroundImageAsset = (
   file: AssetFile,
   widthStyle: string,
-  quality: number = 100,
+  quality: string = '100%',
   format?: ValidFormats,
 ): OptimizedBackgroundImageAsset => {
-  if (!validateParams(file, quality, format)) {
+  const qualityNumber = Number(quality.replace('%', ''));
+  if (!validateParams(file, qualityNumber, format)) {
+    throw Error('Invalid parameters');
+  }
+  if (!validateParams(file, qualityNumber, format)) {
     throw Error('Invalid parameters');
   }
   const url = file.url;
 
   const { width1x, width2x } = getWidths(widthStyle, file);
 
-  const imageUrl1x = getOptimizedImageUrl(url, width1x, quality, format);
-  const imageUrl2x = getOptimizedImageUrl(url, width2x, quality, format);
+  const imageUrl1x = getOptimizedImageUrl(url, width1x, qualityNumber, format);
+  const imageUrl2x = getOptimizedImageUrl(url, width2x, qualityNumber, format);
 
   const srcSet = [`url(${imageUrl1x}) 1x`, `url(${imageUrl2x}) 2x`];
 
-  const returnedUrlImageUrl = getOptimizedImageUrl(url, width2x, quality, format);
+  const returnedUrl = getOptimizedImageUrl(url, width2x, qualityNumber, format);
 
   const optimizedBackgroundImageAsset: OptimizedBackgroundImageAsset = {
-    url: returnedUrlImageUrl,
+    url: returnedUrl,
     srcSet,
     file,
   };
 
   return optimizedBackgroundImageAsset;
 
-  function validateParams(
-    file: AssetFile,
-    quality: number,
-    format?: ValidFormats,
-  ): file is AssetFileWithRequiredImage {
-    if (!file.details.image) {
-      throw Error('No image in file asset to transform');
+  function getWidths(widthStyle: string, file: AssetFileWithRequiredImage) {
+    let width1x = 0;
+    let width2x = 0;
+    const intrinsicImageWidth = file.details.image.width;
+    if (widthStyle.endsWith('px')) {
+      width1x = Math.min(Number(widthStyle.replace('px', '')), intrinsicImageWidth);
+    } else {
+      width1x = Math.min(MAX_WIDTH_ALLOWED, intrinsicImageWidth);
     }
-    if (quality < 0 || quality > 100) {
-      throw Error('Quality must be between 0 and 100');
-    }
-    if (format && !SUPPORTED_IMAGE_FORMATS.includes(format)) {
-      throw Error(`Format must be one of ${SUPPORTED_IMAGE_FORMATS.join(', ')}`);
-    }
-    return true;
+    width2x = Math.min(width1x * 2, intrinsicImageWidth);
+    return { width1x, width2x };
   }
 };
-
-function getWidths(widthStyle: string, file: AssetFileWithRequiredImage) {
-  let width1x = 0;
-  let width2x = 0;
-  const intrinsicImageWidth = file.details.image.width;
-  if (widthStyle.endsWith('px')) {
-    width1x = Math.min(Number(widthStyle.replace('px', '')), intrinsicImageWidth);
-  } else {
-    width1x = Math.min(MAX_WIDTH_ALLOWED, intrinsicImageWidth);
-  }
-  width2x = Math.min(width1x * 2, intrinsicImageWidth);
-  return { width1x, width2x };
-}

--- a/packages/core/src/utils/transformers/media/getOptimizedImageAsset.spec.ts
+++ b/packages/core/src/utils/transformers/media/getOptimizedImageAsset.spec.ts
@@ -87,14 +87,14 @@ describe('transformImageAsset', () => {
     expect(result.srcSet).toEqual([]);
   });
 
-  it('the url should have a width limit of 2000 and quality of 80 when the image width is larger than 2000', () => {
+  it('the url should have a width limit of 2000 and quality of 80% when the image width is larger than 2000', () => {
     file.details.image!.width = 2500;
-    const result = getOptimizedImageAsset(file, '500px', 80);
+    const result = getOptimizedImageAsset(file, '500px', '80%');
     expect(result.url).toEqual(`https:${file.url}?w=2000&q=80`);
   });
 
-  it('the url should have no width limit and quality of 80 when the image width is 800', () => {
-    const result = getOptimizedImageAsset(file, '500px', 80);
+  it('the url should have no width limit and quality of 80% when the image width is 800', () => {
+    const result = getOptimizedImageAsset(file, '500px', '80%');
     expect(result.url).toEqual(`https:${file.url}?q=80`);
   });
 
@@ -109,31 +109,31 @@ describe('transformImageAsset', () => {
   });
 
   it('when quality is passed, the quality should be on the srcSet urls', () => {
-    const result = getOptimizedImageAsset(file, '500px', 50);
+    const result = getOptimizedImageAsset(file, '500px', '50%');
     expect(result.srcSet).toEqual([
       `https:${file.url}?w=400&q=50 400w`,
       `https:${file.url}?w=800&q=50 800w`,
     ]);
   });
 
-  it('when quality is 0, the quality should not be on the srcSet urls', () => {
-    const result = getOptimizedImageAsset(file, '500px', 0);
+  it('when quality is 0%, the quality should not be on the srcSet urls', () => {
+    const result = getOptimizedImageAsset(file, '500px', '0%');
     expect(result.srcSet).toEqual([`https:${file.url}?w=400 400w`, `https:${file.url}?w=800 800w`]);
   });
 
-  it('when quality is 100, the quality should not be on the srcSet urls', () => {
-    const result = getOptimizedImageAsset(file, '500px', 100);
+  it('when quality is 100%, the quality should not be on the srcSet urls', () => {
+    const result = getOptimizedImageAsset(file, '500px', '100%');
     expect(result.srcSet).toEqual([`https:${file.url}?w=400 400w`, `https:${file.url}?w=800 800w`]);
   });
 
-  it('when quality is less than 0, should throw an error', () => {
-    expect(() => getOptimizedImageAsset(file, '500px', -1)).toThrowError(
+  it('when quality is less than 0%, should throw an error', () => {
+    expect(() => getOptimizedImageAsset(file, '500px', '-1%')).toThrowError(
       'Quality must be between 0 and 100',
     );
   });
 
-  it('when quality is more than 100, should throw an error', () => {
-    expect(() => getOptimizedImageAsset(file, '500px', 101)).toThrowError(
+  it('when quality is more than 100%, should throw an error', () => {
+    expect(() => getOptimizedImageAsset(file, '500px', '101%')).toThrowError(
       'Quality must be between 0 and 100',
     );
   });

--- a/packages/core/src/utils/transformers/media/getOptimizedImageAsset.ts
+++ b/packages/core/src/utils/transformers/media/getOptimizedImageAsset.ts
@@ -13,10 +13,11 @@ const MAX_WIDTH_ALLOWED = 4000;
 export const getOptimizedImageAsset = (
   file: AssetFile,
   sizes?: string,
-  quality: number = 100,
+  quality: string = '100%',
   format?: ValidFormats,
 ): OptimizedImageAsset => {
-  if (!validateParams(file, quality, format)) {
+  const qualityNumber = Number(quality.replace('%', ''));
+  if (!validateParams(file, qualityNumber, format)) {
     throw Error('Invalid parameters');
   }
   const url = file.url;
@@ -26,19 +27,23 @@ export const getOptimizedImageAsset = (
     Math.ceil((index + 1) * (maxWidth / numOfParts)),
   );
   const srcSet = sizes
-    ? widthParts.map((width) => `${getOptimizedImageUrl(url, width, quality, format)} ${width}w`)
+    ? widthParts.map(
+        (width) => `${getOptimizedImageUrl(url, width, qualityNumber, format)} ${width}w`,
+      )
     : [];
 
   const intrinsicImageWidth = file.details.image.width;
 
   if (intrinsicImageWidth > MAX_WIDTH_ALLOWED) {
-    srcSet.push(`${getOptimizedImageUrl(url, undefined, quality, format)} ${intrinsicImageWidth}w`);
+    srcSet.push(
+      `${getOptimizedImageUrl(url, undefined, qualityNumber, format)} ${intrinsicImageWidth}w`,
+    );
   }
 
   const returnedUrl = getOptimizedImageUrl(
     url,
     file.details.image.width > 2000 ? 2000 : undefined,
-    quality,
+    qualityNumber,
     format,
   );
 

--- a/packages/core/src/utils/transformers/media/getOptimizedImageAsset.ts
+++ b/packages/core/src/utils/transformers/media/getOptimizedImageAsset.ts
@@ -1,12 +1,7 @@
-import { SUPPORTED_IMAGE_FORMATS } from '@/constants';
 import { OptimizedImageAsset } from '@/types';
 import { AssetFile } from 'contentful';
 import { getOptimizedImageUrl } from './getOptimizedImageUrl';
-
-type ValidFormats = (typeof SUPPORTED_IMAGE_FORMATS)[number];
-interface AssetFileWithRequiredImage extends AssetFile {
-  details: Required<AssetFile['details']>;
-}
+import { ValidFormats, validateParams } from './mediaUtils';
 
 const MAX_WIDTH_ALLOWED = 4000;
 
@@ -55,21 +50,4 @@ export const getOptimizedImageAsset = (
   };
 
   return optimizedImageAsset;
-
-  function validateParams(
-    file: AssetFile,
-    quality: number,
-    format?: ValidFormats,
-  ): file is AssetFileWithRequiredImage {
-    if (!file.details.image) {
-      throw Error('No image in file asset to transform');
-    }
-    if (quality < 0 || quality > 100) {
-      throw Error('Quality must be between 0 and 100');
-    }
-    if (format && !SUPPORTED_IMAGE_FORMATS.includes(format)) {
-      throw Error(`Format must be one of ${SUPPORTED_IMAGE_FORMATS.join(', ')}`);
-    }
-    return true;
-  }
 };

--- a/packages/core/src/utils/transformers/media/mediaUtils.ts
+++ b/packages/core/src/utils/transformers/media/mediaUtils.ts
@@ -1,0 +1,25 @@
+import { SUPPORTED_IMAGE_FORMATS } from '@/constants';
+import { AssetFile } from 'contentful';
+
+export type ValidFormats = (typeof SUPPORTED_IMAGE_FORMATS)[number];
+
+export interface AssetFileWithRequiredImage extends AssetFile {
+  details: Required<AssetFile['details']>;
+}
+
+export function validateParams(
+  file: AssetFile,
+  quality: number,
+  format?: ValidFormats,
+): file is AssetFileWithRequiredImage {
+  if (!file.details.image) {
+    throw Error('No image in file asset to transform');
+  }
+  if (quality < 0 || quality > 100) {
+    throw Error('Quality must be between 0 and 100');
+  }
+  if (format && !SUPPORTED_IMAGE_FORMATS.includes(format)) {
+    throw Error(`Format must be one of ${SUPPORTED_IMAGE_FORMATS.join(', ')}`);
+  }
+  return true;
+}

--- a/packages/core/src/utils/transformers/media/transformMedia.ts
+++ b/packages/core/src/utils/transformers/media/transformMedia.ts
@@ -71,7 +71,7 @@ export const transformMedia = (
       value = getOptimizedBackgroundImageAsset(
         asset.fields.file as AssetFile,
         width as string,
-        Number(options.quality),
+        options.quality,
         options.format as (typeof SUPPORTED_IMAGE_FORMATS)[number],
       );
       return value;

--- a/packages/core/src/utils/transformers/media/transformMedia.ts
+++ b/packages/core/src/utils/transformers/media/transformMedia.ts
@@ -39,7 +39,7 @@ export const transformMedia = (
       value = getOptimizedImageAsset(
         asset.fields.file as AssetFile,
         options.targetSize as string,
-        Number(options.quality),
+        options.quality,
         options.format as (typeof SUPPORTED_IMAGE_FORMATS)[number],
       );
       return value;


### PR DESCRIPTION
After the refactoring to reduce the number of variables, image quality was being passed down to the Experience with a percentage symbol, which before it was just a string with the number in it. Updated the code to expect the percentage and remove it before converting it to a number.