### PR TITLE
fix: build a single index.d.ts file instead of preserving modules

### DIFF
--- a/packages/validators/rollup.config.mjs
+++ b/packages/validators/rollup.config.mjs
@@ -28,7 +28,7 @@ export default [
   //typings
   {
     input: 'src/index.ts',
-    output: [{ dir: 'dist', format: 'esm', preserveModules: true }],
+    output: [{ dir: 'dist', format: 'esm' }],
     plugins: [
       dts({
         tsconfig: './tsconfig.json',
@@ -38,7 +38,7 @@ export default [
   },
   {
     input: 'src/types.ts',
-    output: [{ dir: 'dist', format: 'esm', preserveModules: true }],
+    output: [{ dir: 'dist', format: 'esm' }],
     plugins: [
       dts({
         tsconfig: './tsconfig.json',


### PR DESCRIPTION
## Purpose
Build a single index.d.ts file instead of preserving modules.

## Approach
Update rollup config to generate a single types file to avoid the error described below:

With preserving modules before, each file would generate its own `.d.ts` file in the `/dist` folder which led to an weird error where the `componentDefinitions.d.ts` would not declare the `ComponentDefinitionSchema` variable:
<img width="1021" alt="Screenshot 2024-03-20 at 12 04 07" src="https://github.com/contentful/experience-builder/assets/2773012/2d9a52da-0aa1-46f6-b5d1-12ad1ce8be76">

causing an error in the package:

<img width="1619" alt="Screenshot 2024-03-20 at 12 03 54" src="https://github.com/contentful/experience-builder/assets/2773012/c9e0dd0d-64ff-4af4-95d3-1d8fad35e3ce">

The error was only observed once we tried to install the package in content_api.

With the new approach ComponentDefinitionSchema is declared in index.d.ts:
<img width="1091" alt="Screenshot 2024-03-20 at 12 10 11" src="https://github.com/contentful/experience-builder/assets/2773012/f7699a8d-9aec-4dca-a530-6308e00f5279">
