### PR TITLE
fix: fetch all referenced entities 

### DIFF
--- a/packages/core/src/fetchers/fetchAllEntities.spec.ts
+++ b/packages/core/src/fetchers/fetchAllEntities.spec.ts
@@ -1,0 +1,87 @@
+import { entries } from '../test/__fixtures__/entities';
+import { fetchAllEntities } from './fetchAllEntities';
+
+import { describe, afterEach, it, expect, vi, Mock } from 'vitest';
+import { ContentfulClientApi } from 'contentful';
+
+const mockClient = {
+  getAssets: vi.fn(),
+  withoutLinkResolution: {
+    getEntries: vi.fn(),
+  },
+} as unknown as ContentfulClientApi<undefined>;
+
+describe('fetchAllEntities', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should fetch all entities', async () => {
+    (mockClient.withoutLinkResolution.getEntries as Mock).mockResolvedValue({
+      items: [...entries],
+      total: 100,
+    });
+
+    const params = {
+      ids: entries.map((entry) => entry.sys.id),
+      entityType: 'Entry' as 'Entry' | 'Asset',
+      client: mockClient,
+      locale: 'en-US',
+      limit: 20,
+    };
+
+    await fetchAllEntities(params);
+
+    expect(mockClient.withoutLinkResolution.getEntries).toHaveBeenCalledTimes(5);
+  });
+
+  it('should reduce limit and refetch all entities if response error is gotten', async () => {
+    (mockClient.withoutLinkResolution.getEntries as Mock)
+      .mockRejectedValueOnce(new Error('Response size too big'))
+      .mockResolvedValue({
+        items: [...entries],
+        total: 100,
+      });
+
+    const params = {
+      ids: entries.map((entry) => entry.sys.id),
+      entityType: 'Entry' as 'Entry' | 'Asset',
+      client: mockClient,
+      locale: 'en-US',
+      limit: 20,
+    };
+
+    await fetchAllEntities(params);
+
+    expect(mockClient.withoutLinkResolution.getEntries).toHaveBeenLastCalledWith({
+      'sys.id[in]': params.ids,
+      locale: 'en-US',
+      skip: 90,
+      limit: 10,
+    });
+    expect(mockClient.withoutLinkResolution.getEntries).toHaveBeenCalledTimes(11);
+  });
+
+  it('should never reduce limit to less than MIN_FETCH_LIMIT', async () => {
+    (mockClient.withoutLinkResolution.getEntries as Mock).mockRejectedValue(
+      new Error('Response size too big'),
+    );
+
+    const params = {
+      ids: entries.map((entry) => entry.sys.id),
+      entityType: 'Entry' as 'Entry' | 'Asset',
+      client: mockClient,
+      locale: 'en-US',
+      limit: 20,
+    };
+    await fetchAllEntities(params);
+
+    expect(mockClient.withoutLinkResolution.getEntries).toHaveBeenLastCalledWith({
+      'sys.id[in]': params.ids,
+      locale: 'en-US',
+      skip: 0,
+      limit: 1,
+    });
+    expect(mockClient.withoutLinkResolution.getEntries).toHaveBeenCalledTimes(5);
+  });
+});

--- a/packages/core/src/fetchers/fetchAllEntities.spec.ts
+++ b/packages/core/src/fetchers/fetchAllEntities.spec.ts
@@ -53,13 +53,12 @@ describe('fetchAllEntities', () => {
 
     await fetchAllEntities(params);
 
-    expect(mockClient.withoutLinkResolution.getEntries).toHaveBeenLastCalledWith({
+    expect(mockClient.withoutLinkResolution.getEntries).toHaveBeenNthCalledWith(11, {
       'sys.id[in]': params.ids,
       locale: 'en-US',
       skip: 90,
       limit: 10,
     });
-    expect(mockClient.withoutLinkResolution.getEntries).toHaveBeenCalledTimes(11);
   });
 
   it('should never reduce limit to less than MIN_FETCH_LIMIT', async () => {
@@ -76,12 +75,11 @@ describe('fetchAllEntities', () => {
     };
     await fetchAllEntities(params);
 
-    expect(mockClient.withoutLinkResolution.getEntries).toHaveBeenLastCalledWith({
+    expect(mockClient.withoutLinkResolution.getEntries).toHaveBeenNthCalledWith(5, {
       'sys.id[in]': params.ids,
       locale: 'en-US',
       skip: 0,
       limit: 1,
     });
-    expect(mockClient.withoutLinkResolution.getEntries).toHaveBeenCalledTimes(5);
   });
 });

--- a/packages/core/src/fetchers/fetchAllEntities.ts
+++ b/packages/core/src/fetchers/fetchAllEntities.ts
@@ -1,0 +1,87 @@
+import { ContentfulClientApi, Entry } from 'contentful';
+
+const MIN_FETCH_LIMIT = 10;
+
+const fetchEntities = async ({
+  entityType,
+  client,
+  query,
+}: {
+  entityType: 'Entry' | 'Asset';
+  client: ContentfulClientApi<undefined>;
+  query: { 'sys.id[in]': string[]; locale: string; limit: number; skip: number };
+}) => {
+  if (entityType === 'Asset') {
+    return client.getAssets({ ...query });
+  }
+
+  return client.getEntries({ ...query });
+};
+
+export const fetchAllEntities = async ({
+  client,
+  entityType,
+  ids,
+  locale,
+  skip = 0,
+  limit = 100,
+  responseItems = [],
+}: {
+  client: ContentfulClientApi<undefined>;
+  entityType: 'Entry' | 'Asset';
+  ids: string[];
+  locale: string;
+  skip?: number;
+  limit?: number;
+  responseItems?: Entry[];
+}) => {
+  try {
+    if (!ids.length) {
+      return {
+        items: [],
+      };
+    }
+
+    const query = { 'sys.id[in]': ids, locale, limit, skip };
+    const response = await fetchEntities({ entityType, client, query });
+    responseItems.push(...(response.items as Entry[]));
+
+    if (skip + limit < response.total) {
+      await fetchAllEntities({
+        client,
+        entityType,
+        ids,
+        locale,
+        skip: skip + limit,
+        limit,
+        responseItems,
+      });
+    }
+
+    return {
+      items: responseItems,
+    };
+  } catch (e) {
+    if (
+      e instanceof Error &&
+      e.name === 'BadRequest' &&
+      e.message.includes('size too big') &&
+      limit > MIN_FETCH_LIMIT
+    ) {
+      const newLimit = Math.max(MIN_FETCH_LIMIT, Math.floor(limit / 2));
+      return fetchAllEntities({
+        client,
+        entityType,
+        ids,
+        locale,
+        skip,
+        limit: newLimit,
+        responseItems,
+      });
+    }
+
+    return {
+      items: responseItems,
+    };
+  }
+};

--- a/packages/core/src/fetchers/fetchAllEntities.ts
+++ b/packages/core/src/fetchers/fetchAllEntities.ts
@@ -47,7 +47,9 @@ export const fetchAllEntities = async ({
     const response = await fetchEntities({ entityType, client, query });
 
     if (!response) {
-      return responseItems;
+      return {
+        items: responseItems,
+      };
     }
 
     responseItems.push(...(response.items as Entry[]));

--- a/packages/core/src/fetchers/fetchReferencedEntities.spec.ts
+++ b/packages/core/src/fetchers/fetchReferencedEntities.spec.ts
@@ -73,7 +73,7 @@ describe('fetchReferencedEntities', () => {
     }
   });
 
-  it.only('should fetch referenced entities', async () => {
+  it('should fetch referenced entities', async () => {
     (mockClient.getAssets as Mock).mockResolvedValue({ items: assets });
 
     (mockClient.withoutLinkResolution.getEntries as Mock).mockResolvedValue({ items: entries });

--- a/packages/core/src/fetchers/fetchReferencedEntities.spec.ts
+++ b/packages/core/src/fetchers/fetchReferencedEntities.spec.ts
@@ -73,7 +73,7 @@ describe('fetchReferencedEntities', () => {
     }
   });
 
-  it('should fetch referenced entities', async () => {
+  it.only('should fetch referenced entities', async () => {
     (mockClient.getAssets as Mock).mockResolvedValue({ items: assets });
 
     (mockClient.withoutLinkResolution.getEntries as Mock).mockResolvedValue({ items: entries });
@@ -87,6 +87,8 @@ describe('fetchReferencedEntities', () => {
     });
 
     expect(mockClient.getAssets).toHaveBeenCalledWith({
+      limit: 100,
+      skip: 0,
       locale: 'en-US',
       'sys.id[in]': assets.map((asset) => asset.sys.id),
     });
@@ -94,6 +96,8 @@ describe('fetchReferencedEntities', () => {
     expect(mockClient.withoutLinkResolution.getEntries).toHaveBeenCalledWith({
       locale: 'en-US',
       'sys.id[in]': entries.map((entry) => entry.sys.id),
+      limit: 100,
+      skip: 0,
     });
 
     expect(res).toEqual({

--- a/packages/core/src/fetchers/fetchReferencedEntities.ts
+++ b/packages/core/src/fetchers/fetchReferencedEntities.ts
@@ -6,6 +6,7 @@ import {
   MinimalEntryCollection,
   gatherAutoFetchedReferentsFromIncludes,
 } from './gatherAutoFetchedReferentsFromIncludes';
+import { fetchAllEntities } from './fetchAllEntities';
 
 type FetchReferencedEntitiesArgs = {
   client: ContentfulClientApi<undefined>;
@@ -55,10 +56,8 @@ export const fetchReferencedEntities = async ({
   }
 
   const [entriesResponse, assetsResponse] = (await Promise.all([
-    entryIds.length > 0
-      ? client.withoutLinkResolution.getEntries({ 'sys.id[in]': entryIds, locale })
-      : { items: [], includes: [] },
-    assetIds.length > 0 ? client.getAssets({ 'sys.id[in]': assetIds, locale }) : { items: [] },
+    fetchAllEntities({ client, entityType: 'Entry', ids: entryIds, locale }),
+    fetchAllEntities({ client, entityType: 'Asset', ids: assetIds, locale }),
   ])) as unknown as [MinimalEntryCollection, AssetCollection];
 
   const { autoFetchedReferentAssets, autoFetchedReferentEntries } =
@@ -66,7 +65,7 @@ export const fetchReferencedEntities = async ({
 
   // Using client getEntries resolves all linked entry references, so we do not need to resolve entries in usedComponents
   const allResolvedEntries = [
-    ...((entriesResponse.items ?? []) as Entry[]),
+    ...((entriesResponse?.items ?? []) as Entry[]),
     ...((experienceEntry.fields.usedComponents as ExperienceEntry[]) || []),
     ...autoFetchedReferentEntries,
   ];

--- a/packages/experience-builder-sdk/src/hooks/useFetchById.spec.ts
+++ b/packages/experience-builder-sdk/src/hooks/useFetchById.spec.ts
@@ -69,11 +69,15 @@ describe('useFetchById', () => {
       });
 
       expect(clientMock.withoutLinkResolution.getEntries).toHaveBeenNthCalledWith(1, {
+        limit: 100,
+        skip: 0,
         'sys.id[in]': entries.map((entry) => entry.sys.id),
         locale: localeCode,
       });
 
       expect(clientMock.getAssets).toHaveBeenCalledWith({
+        limit: 100,
+        skip: 0,
         'sys.id[in]': assets.map((asset) => asset.sys.id),
         locale: localeCode,
       });

--- a/packages/experience-builder-sdk/src/hooks/useFetchBySlug.spec.ts
+++ b/packages/experience-builder-sdk/src/hooks/useFetchBySlug.spec.ts
@@ -77,6 +77,8 @@ describe('useFetchBySlug', () => {
       });
 
       expect(clientMock.withoutLinkResolution.getEntries).toHaveBeenNthCalledWith(1, {
+        limit: 100,
+        skip: 0,
         'sys.id[in]': entries.map((entry) => entry.sys.id),
         locale: localeCode,
       });

--- a/packages/experience-builder-sdk/src/hooks/useFetchBySlug.spec.ts
+++ b/packages/experience-builder-sdk/src/hooks/useFetchBySlug.spec.ts
@@ -84,6 +84,8 @@ describe('useFetchBySlug', () => {
       });
 
       expect(clientMock.getAssets).toHaveBeenCalledWith({
+        limit: 100,
+        skip: 0,
         'sys.id[in]': assets.map((asset) => asset.sys.id),
         locale: localeCode,
       });


### PR DESCRIPTION
## Purpose
Previously we only fetched 100 referenced entities. So for experiences with more than 100 entities bound, we only render 100 entities.

This PR fetches all bound entities in chunks of 100. 

If we encounter a response too big error during fetch, we reduce the limit and try fetching again.


https://github.com/contentful/experience-builder/assets/30434146/0b86e386-76ca-4e31-a07c-68ea0e628dc2


## Approach

<!--

Three important notes on Pull Requests:
- In general, you should ask yourself whether this code change will improve or worsen the overall code quality. Any new tech debt will probably never be cleaned up.
- Please remember that newly introduced logic should be validated and protected through testing.
- Take a look at PR guides such as Google's [Google’s Code Review Guidelines](https://google.github.io/eng-practices/) and [Blockly - Writing a Good Pull Request](https://developers.google.com/blockly/guides/contribute/get-started/write_a_good_pr)

-->
