### PR TITLE
feat(experiences-sdk-react)!: update basic component IDs with contentful prefix

### DIFF
--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -75,23 +75,23 @@ export const CONTENTFUL_COMPONENTS = {
     name: 'Column',
   },
   button: {
-    id: 'button',
+    id: 'contentful-button',
     name: 'Button',
   },
   heading: {
-    id: 'heading',
+    id: 'contentful-heading',
     name: 'Heading',
   },
   image: {
-    id: 'image',
+    id: 'contentful-image',
     name: 'Image',
   },
   richText: {
-    id: 'richText',
+    id: 'contentful-richText',
     name: 'Rich Text',
   },
   text: {
-    id: 'text',
+    id: 'contentful-text',
     name: 'Text',
   },
 };

--- a/packages/experience-builder-sdk/src/core/componentRegistry.ts
+++ b/packages/experience-builder-sdk/src/core/componentRegistry.ts
@@ -269,3 +269,23 @@ export const createAssemblyRegistration = ({
 
   return componentRegistry.get(definitionId);
 };
+
+/**
+ * @deprecated This method is used to maintain the basic component ids (without the prefix 'contentful-') in order to be compatible
+ * with experiences created with an older alpha version of the SDK. Components in these experiences should be migrated to use
+ * the components with the 'contentful-' prefix. To do so, load the experience in the editor, and replace any older basic components
+ * (marked with [OLD] in the UI) with the new components (without the [OLD]). This method (and functionality for the older components)
+ * will be removed in the next major release.
+ */
+export const maintainBasicComponentIdsWithoutPrefix = () => {
+  optionalBuiltInComponents.forEach((id) => {
+    if (componentRegistry.has(id) && id.startsWith('contentful-')) {
+      const registeredComponent = componentRegistry.get(id)!;
+      const newRegisteredComponent = { ...registeredComponent };
+      newRegisteredComponent.definition.name = newRegisteredComponent.definition.name + '[OLD]';
+      const newId = id.replace('contentful-', '');
+      newRegisteredComponent.definition.id = newId;
+      componentRegistry.set(newId, newRegisteredComponent);
+    }
+  });
+};

--- a/packages/experience-builder-sdk/src/core/componentRegistry.ts
+++ b/packages/experience-builder-sdk/src/core/componentRegistry.ts
@@ -281,10 +281,12 @@ export const maintainBasicComponentIdsWithoutPrefix = () => {
   optionalBuiltInComponents.forEach((id) => {
     if (componentRegistry.has(id) && id.startsWith('contentful-')) {
       const registeredComponent = componentRegistry.get(id)!;
-      const newRegisteredComponent = { ...registeredComponent };
-      newRegisteredComponent.definition.name = newRegisteredComponent.definition.name + '[OLD]';
+      const definition = registeredComponent.definition;
+      const newDefinition = cloneObject(definition);
+      newDefinition.name = newDefinition.name + '[OLD]';
       const newId = id.replace('contentful-', '');
-      newRegisteredComponent.definition.id = newId;
+      newDefinition.id = newId;
+      const newRegisteredComponent = { ...registeredComponent, definition: newDefinition };
       componentRegistry.set(newId, newRegisteredComponent);
     }
   });

--- a/packages/experience-builder-sdk/src/index.ts
+++ b/packages/experience-builder-sdk/src/index.ts
@@ -2,7 +2,7 @@ import { SDK_VERSION } from './sdkVersion';
 
 export { ExperienceRoot } from './ExperienceRoot';
 export { useFetchById, useFetchBySlug } from './hooks';
-export { defineComponents } from './core/componentRegistry';
+export { defineComponents, maintainBasicComponentIdsWithoutPrefix } from './core/componentRegistry';
 export {
   defineDesignTokens,
   VisualEditorMode,

--- a/packages/test-app/src/App.tsx
+++ b/packages/test-app/src/App.tsx
@@ -2,6 +2,9 @@ import { createBrowserRouter, RouterProvider } from 'react-router-dom';
 import Page from './Page';
 // import SpaceSelector from './components/SpaceSelector';
 import { ContentfulConfigProvider } from './utils/ContentfulConfigProvider';
+import { maintainBasicComponentIdsWithoutPrefix } from '@contentful/experiences-sdk-react';
+
+maintainBasicComponentIdsWithoutPrefix();
 
 const router = createBrowserRouter([
   {

--- a/packages/visual-editor/src/components/Dropzone/useComponent.ts
+++ b/packages/visual-editor/src/components/Dropzone/useComponent.ts
@@ -51,8 +51,8 @@ export const useComponent = ({
         component: Assembly,
       }) as ComponentRegistration;
     } else if (!registration) {
-      console.warn(
-        `[experiences-sdk-react] Component registration not found for ${node.data.blockId}`,
+      throw Error(
+        `Component registration not found for component with id: "${node.data.blockId}". The component might of been removed. To proceed, remove the component manually from the layers tab.`,
       );
     }
     return registration as ComponentRegistration;


### PR DESCRIPTION
BREAKING CHANGE:

Any existing experiences using the basic components will need to be updated. To do so, import and run the `maintainBasicComponentIdsWithoutPrefix` method and run it early on in your application (before the first `ExperienceRoot` is rendered) like so:

```tsx
import { maintainBasicComponentIdsWithoutPrefix } from '@contentful/experiences-sdk-react';
maintainBasicComponentIdsWithoutPrefix();
```

This will register a set of the basic components with the older ids and allow your experiences to continue to work. To migrate to the new components, replace any of the components marked with "[OLD]" in the editor with their newer counterparts (without the '[OLD]').

![image](https://github.com/contentful/experience-builder/assets/168135/edefb1af-8784-4bee-a5aa-b2d879478ce4)

The `maintainBasicComponentIdsWithoutPrefix` is meant to help older experiences built on a early alpha release to migrate and will be removed in the next major release.
