### PR TITLE
fix(experience-builder-sdk): children variable for text content [ALT-636]

### DIFF
--- a/packages/experience-builder-sdk/src/blocks/preview/CompositionBlock.tsx
+++ b/packages/experience-builder-sdk/src/blocks/preview/CompositionBlock.tsx
@@ -191,6 +191,6 @@ export const CompositionBlock = ({
       ...omit(nodeProps, stylesToRemove, ['cfHyperlink', 'cfOpenInNewTab']),
       className,
     },
-    children,
+    children ?? (typeof nodeProps.children === 'string' ? nodeProps.children : null),
   );
 };


### PR DESCRIPTION
## Purpose

This change allows the `children` variable to be used for content, as long as the component definition does not have also have `children: true` enabled (which registers a drop-zone container for nesting children components)

Ticket: https://contentful.atlassian.net/browse/ALT-636

![Screenshot 2024-03-20 at 2 26 21 PM](https://github.com/contentful/experience-builder/assets/8539634/f3d7162c-97ef-44ed-b3ec-e2db7d76ec28)

Now the `children` variable can render the bound content in live mode:

![Screenshot 2024-03-20 at 2 26 43 PM](https://github.com/contentful/experience-builder/assets/8539634/0c6ebb20-2cb9-4127-9bf5-6c87de21f141)


