### PR TITLE
fix: do not attempt to send components via postMessage

### DIFF
--- a/packages/experience-builder-sdk/src/core/componentRegistry.ts
+++ b/packages/experience-builder-sdk/src/core/componentRegistry.ts
@@ -160,7 +160,9 @@ export const optionalBuiltInComponents = [
 
 export const sendRegisteredComponentsMessage = () => {
   // Send the definitions (without components) via the connection message to the experience builder
-  const registeredDefinitions = Array.from(componentRegistry.values());
+  const registeredDefinitions = Array.from(componentRegistry.values()).map(
+    ({ definition }) => definition,
+  );
 
   sendMessage(OUTGOING_EVENTS.RegisteredComponents, {
     definitions: registeredDefinitions,


### PR DESCRIPTION
## Purpose

I noticed that if I called `defineComponents` function more than once, I would get the following error

<img width="939" alt="Screenshot 2024-03-21 at 13 38 57" src="https://github.com/contentful/experience-builder/assets/4171202/6e908425-dce3-42ce-9ee9-265ef07c799f">

Notice that the part of visible payload looks like a react component function.

Turns out that we were not properly filtering the component registry and instead of component definitions, were attempting to send the entire registry object

Steps to reproduce:
* call `defineComponents` function twice