### PR TITLE
chore: remove links to old docs in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,10 @@
 # Welcome!
 
-This repository represents a set of packages, related to the [Experience Builder product](https://www.contentful.com/help/experience-builder-best-practices/).
+This repository represents a set of packages, related to the [Studio Experiences](https://www.contentful.com/developers/docs/experiences/what-are-experiences/) product.
 
 ## Documentation
 
-Please refer to our [our Wiki page](https://github.com/contentful/experience-builder/wiki) for various technical documentation.
-
-## Packages
-
-- [@contentful/experience-builder](https://github.com/contentful/experience-builder/tree/main/packages/experience-builder-sdk) - the SDK
+Please refer to our [Documentation](https://www.contentful.com/developers/docs/experiences/) to learn more about it.
 
 ## Local Development
 


### PR DESCRIPTION
Renamed "Experience Builder" to "Studio Expeirences"

Links pointing to the old documentation or wiki pages have been replaced with the link with latest docs