### PR TITLE
fix(visual-editor): throw error when component registration not found in useComponent hook [ALT-515]

### DIFF
--- a/packages/visual-editor/src/components/Dropzone/useComponent.ts
+++ b/packages/visual-editor/src/components/Dropzone/useComponent.ts
@@ -1,6 +1,5 @@
 import React from 'react';
 import type {
-  ComponentRegistration,
   ExperienceTreeNode,
   ResolveDesignValueType,
 } from '@contentful/experiences-core/types';
@@ -43,19 +42,21 @@ export const useComponent = ({
   }, [areEntitiesFetched, rawNode, entityStore]);
 
   const componentRegistration = useMemo(() => {
-    const registration = componentRegistry.get(node.data.blockId as string);
+    let registration = componentRegistry.get(node.data.blockId as string);
 
     if (node.type === ASSEMBLY_NODE_TYPE && !registration) {
-      return createAssemblyRegistration({
+      registration = createAssemblyRegistration({
         definitionId: node.data.blockId as string,
         component: Assembly,
-      }) as ComponentRegistration;
-    } else if (!registration) {
+      });
+    }
+
+    if (!registration) {
       throw Error(
         `Component registration not found for component with id: "${node.data.blockId}". The component might of been removed. To proceed, remove the component manually from the layers tab.`,
       );
     }
-    return registration as ComponentRegistration;
+    return registration;
   }, [node]);
 
   const componentId = node.data.id;

--- a/packages/visual-editor/src/components/Dropzone/useComponent.ts
+++ b/packages/visual-editor/src/components/Dropzone/useComponent.ts
@@ -42,11 +42,11 @@ export const useComponent = ({
   }, [areEntitiesFetched, rawNode, entityStore]);
 
   const componentRegistration = useMemo(() => {
-    let registration = componentRegistry.get(node.data.blockId as string);
+    let registration = componentRegistry.get(node.data.blockId!);
 
     if (node.type === ASSEMBLY_NODE_TYPE && !registration) {
       registration = createAssemblyRegistration({
-        definitionId: node.data.blockId as string,
+        definitionId: node.data.blockId!,
         component: Assembly,
       });
     }


### PR DESCRIPTION
## Purpose

Attempting to prevent the SDK error `Cannot read properties of undefined (reading 'definition')` in the useComponent hook.

I don't know of a way to reproduce the issue that triggers this error. However, I think the problem stems from type casting the result of this call to `createAssemblyRegistration` which can return `undefined` but would not be caught by the branch that throws an error.

Ticket: https://contentful.atlassian.net/browse/ALT-654
