### PR TITLE
Prep repo for stable GA release - [ALT-468]

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -42,7 +42,7 @@ jobs:
       - name: List components folder
         run: ls -la packages/components
       - name: Save Build folders        
-        uses: actions/cache/save@v3
+        uses: actions/cache/save@v4
         with:
           path: |
             packages/components/styles.css

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,7 +20,7 @@ jobs:
           node-version: '20.11'
           cache: 'npm'
       - name: Restore Cypress Binary
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v4
         id: restore-cypress
         with:
           path: ~/.cache/Cypress
@@ -32,7 +32,7 @@ jobs:
         run: npm ci
       - name: Save Cypress Binary
         if: steps.restore-cypress.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v3
+        uses: actions/cache/save@v4
         with:
           path: ~/.cache/Cypress
           key: cypress-${{ runner.os }}-${{ hashFiles('./package-lock.json') }}

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -56,7 +56,7 @@ jobs:
       - name: Run CT Tests
         run: npm run test:component
       - name: Save test results to artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: test-assets
           if-no-files-found: error

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -12,14 +12,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: 'Use NodeJS 20'
         uses: actions/setup-node@v4
         with:
           node-version: '20.11'
           cache: 'npm'
       - name: Restore Cypress Binary
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v4
         id: restore-cypress
         with:
           path: ~/.cache/Cypress
@@ -30,7 +30,7 @@ jobs:
       - name: Install dependencies
         run: npm ci
       - name: Restore the build folders
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v4
         with:
           path: |
             packages/components/styles.css

--- a/.github/workflows/cleanup.yaml
+++ b/.github/workflows/cleanup.yaml
@@ -8,9 +8,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Restore the build folders
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v4
         with:
           path: |
             packages/components/styles.css
@@ -18,7 +18,7 @@ jobs:
             packages/*/build
           key: build-cache-${{ github.run_id }}-${{ github.run_attempt }}
       - name: Save build folder to artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: built-assets
           if-no-files-found: error

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -52,9 +52,21 @@ jobs:
         run: echo -e "//npm.pkg.github.com/:_authToken=${{ steps.vault.outputs.GITHUB_PACKAGES_WRITE_TOKEN }}\n@contentful:registry=https://npm.pkg.github.com" > ./.npmrc
         env:
           GITHUB_TOKEN: ${{ steps.vault.outputs.GITHUB_PACKAGES_WRITE_TOKEN }}
+      # We only want to publish if there are changes to any package. Since the lerna --force-publish flag publishes even if there are no changes
+      # we check if there are changes to the packages first, and if not, we exit early
+      - name: Changed Packages Check
+        id: changed_packages
+        run: |
+          echo "CHANGED_PACKAGES<<EOF" >> $GITHUB_OUTPUT
+          echo "CHANGED_PACKAGES=$(npx lerna changed --conventional-commits --json)" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> $GITHUB_OUTPUT
+      - name: Skip Publish if no changes
+        if: ${{ steps.changed_packages.outputs.CHANGED_PACKAGES == '' }}
+        run: echo "No changes to packages to publish, skipping publish step"
       - name: 'Version and publish'
         env:
           GITHUB_TOKEN: ${{ steps.vault.outputs.GITHUB_PACKAGES_WRITE_TOKEN }}
+        if: ${{ steps.changed_packages.outputs.CHANGED_PACKAGES != '' }}
         run: |
           git config user.name "${{ github.actor }}"
           git config user.email "${{ github.actor}}@users.noreply.github.com"

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -54,7 +54,7 @@ jobs:
           GITHUB_TOKEN: ${{ steps.vault.outputs.GITHUB_PACKAGES_WRITE_TOKEN }}
       # We only want to publish if there are changes to any package. Since the lerna --force-publish flag publishes even if there are no changes
       # we check if there are changes to the packages first, and if not, we exit early
-      - name: Changed Packages Check
+      - name: Changed packages check
         id: changed_packages
         run: |
           echo "CHANGED_PACKAGES<<EOF" >> $GITHUB_OUTPUT
@@ -72,24 +72,28 @@ jobs:
           git config user.email "${{ github.actor}}@users.noreply.github.com"
 
           if [ ${{ github.ref_name }} = development ]; then
-            npx lerna publish prerelease --exact --conventional-commits --conventional-prerelease --preid dev-$(date +%Y%m%dT%H%M)-$(git rev-parse HEAD  | cut -c1-7) --no-changelog --no-git-tag-version --dist-tag dev --no-push --yes
+            npx lerna publish prerelease --exact --conventional-commits --conventional-prerelease --force-publish --preid dev-$(date +%Y%m%dT%H%M)-$(git rev-parse HEAD  | cut -c1-7) --no-changelog --no-git-tag-version --dist-tag dev --no-push --yes
           elif [ ${{ github.ref_name }} = next ]; then
-            npx lerna publish prerelease --exact --conventional-commits --conventional-prerelease --preid alpha --yes --no-private --dist-tag latest
+            npx lerna publish prerelease --exact --conventional-commits --conventional-prerelease --force-publish --preid beta --yes --no-private --dist-tag next
           else
-            npx lerna publish --conventional-commits --conventional-graduate --yes --no-private --create-release github --dist-tag latest
+            npx lerna publish --conventional-commits --conventional-graduate --force-publish --yes --no-private --create-release github --dist-tag latest
           fi
-
-          # merge upstream package version changes to next/dev 
-
+      - name: 'Merge changes downstream'
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+        run: |
           if [ ${{ github.ref_name }} = main ]; then
             git checkout next
+            git pull
             git rebase main
             git push origin
             git checkout development
+            git pull
             git rebase next
             git push origin
           elif [ ${{ github.ref_name }} = next ]; then
             git checkout development
+            git pull
             git rebase next
             git push origin
           fi

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -14,7 +14,7 @@ jobs:
       id-token: write
     steps:
       - name: 'Checkout'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0 # Checkout all branches and tags, needed for publish
       - name: 'Use NodeJS 20'
@@ -40,7 +40,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ steps.vault.outputs.GITHUB_PACKAGES_WRITE_TOKEN }}
       - name: Restore the build folders
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v4
         with:
           path: |
             packages/components/styles.css

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -21,6 +21,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '20.11'
+          cache: 'npm'
       # Retrieve token from Vault and use in .npmrc for installing npm packages from the GitHub registry
       # See https://contentful.atlassian.net/wiki/spaces/ENG/pages/4396155213/Migrating+to+GitHub+Packages+from+npmjs?focusedCommentId=4431282518
       - name: 'Retrieve NPM Token from Vault'

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -66,6 +66,8 @@ jobs:
       - name: 'Version and publish'
         env:
           GITHUB_TOKEN: ${{ steps.vault.outputs.GITHUB_PACKAGES_WRITE_TOKEN }}
+          # GH_TOKEN needed by lerna to create releases on github
+          GH_TOKEN: ${{ steps.vault.outputs.GITHUB_PACKAGES_WRITE_TOKEN }}
         if: ${{ steps.changed_packages.outputs.CHANGED_PACKAGES != '' }}
         run: |
           git config user.name "${{ github.actor }}"

--- a/README.md
+++ b/README.md
@@ -16,6 +16,26 @@ Run the following command in the directory of the package to start the dev scrip
 npm run dev 
 ```
 
+## Branching & Release Process
+
+For each new feature, bug fix, or improvement, create a new branch based off `development` to do your work in. When ready, open up a PR to `development`, and once approved, merge it using the "Squash and merge" option. If the feature branch was a long lived branch, you might decide to do a "Create a merge commit" instead to maintain the history of the feature branch. However, try to avoid having meaningless commits in the feature branch as that will make the overall history of the repository hard to follow.
+
+When a PR is merged into `development`, the CI/CD pipeline will automatically publish a new development package under the `dev` tag.
+
+As the features/fixes in the `development` branch get ready to release, open a PR from `development` into `next`. Once approved, merge it using the "Create a merge commit" option, and have the description of the PR and the subsequent commit be "Release@next".
+
+When a PR is merged into `next`, the CI/CD pipeline will automatically publish a new package under the `beta` tag. Any changes made by the release process to the `next` branch will automatically be merged back into `development`.
+
+To release a stable build, open a PR from `next` into `main`. Once approved, merge it using the "Create a merge commit" option, and have the description of the PR and the subsequent commit be "Release@main".
+
+When a PR is merged into `main`, the CI/CD pipeline will automatically publish a new package under the `latest` tag. Any changes made by the release process to the `main` branch will automatically be merged back into `next` and `development`.
+
+To fix a critical bug that is in `main`, branch of the `main` branch. When your work is complete open a PR against `main`, and when it is approved, merge it back into `main` using the "Squash and merge" option. The change will be automatically merged back into `next` and `development`. However, if there is a merge conflict doing so, you will have to resolve it manually.
+
+## Commit Message Guidelines
+
+We follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification for our commit messages. This allows us to automatically generate changelogs and version bumps based on the commit messages. Please take care in your commit messages that make it into the main branches (`development`, `next`, and `main`) to follow this specification, as it helps with the release process.
+
 ## Troubleshooting
 
 > [!WARNING]

--- a/lerna.json
+++ b/lerna.json
@@ -1,7 +1,7 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
   "npmClient": "npm",
-  "version": "independent",
+  "version": "0.0.1-alpha.13",
   "command": {
     "version": {
       "allowBranch": ["main", "next", "development"],

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contentful/experiences-components-react",
-  "version": "0.0.1-alpha.11",
+  "version": "0.0.1-alpha.13",
   "description": "A basic set of components to use with Studio Experiences",
   "homepage": "https://github.com/contentful/experience-builder/tree/next/packages/components#readme",
   "repository": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contentful/experiences-core",
-  "version": "0.0.1-alpha.11",
+  "version": "0.0.1-alpha.13",
   "description": "",
   "main": "dist/index.js",
   "module": "dist/index.js",

--- a/packages/create-experience-builder/package.json
+++ b/packages/create-experience-builder/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@contentful/create-experience-builder",
+  "private": true,
   "version": "0.0.2-alpha.9",
   "description": "A CLI tool to get up and running with Contentful Experience Builder quickly",
   "homepage": "https://github.com/contentful/experience-builder/tree/next/packages/create-experience-builder#readme",

--- a/packages/storybook-addon/package.json
+++ b/packages/storybook-addon/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@contentful/experiences-storybook-addon",
+  "private": true,
   "version": "0.0.1-alpha.11",
   "description": "Develop Contentful experience builder components with storybook",
   "keywords": [

--- a/packages/validators/package.json
+++ b/packages/validators/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contentful/experiences-validators",
-  "version": "0.0.1-alpha.6",
+  "version": "0.0.1-alpha.13",
   "main": "./dist/index.js",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
## Purpose

This PR prepares the monorepo for the upcoming stable release.

## Approach

- The versioning of the project was changed to used fixed versioning, so each package will published using the same version number. This will help cut down confusion on which package is being used for debugging scenarios. The downside is that each package will get published wether there was a change in them or not. This shouldn't be too big of an issue, however, as the only package meant to be installed by users is `@contentful/experiences-sdk-react`.
  - The fixed versioning will also give us a changelog that will live at the root of the repo which will contain changes to all of the packages.
- The `next` branch will now do a 'beta' release instead of an 'alpha' release.
- The `main` branch will do a stable release with the latest tag.
- The readme.md was updated with info on how the branching and release process works.
- The create-experience-cli and storybook-addon packages were temporarily marked as private so they won't publish as a part of this main workflow. We'll need to add a new workflow that handles these outside of the fixed versioning scenario. These packages are out of date anyways and releasing a stable v1 of them wouldn't be helpful.
- Some actions in the github action workflows were updated to latest. These were throwing deprecation warnings in the builds because they were using an older NodeJS version. The warnings should now go away.
- Some git tags have been removed from the repo that were either not needed or would cause conflicts with upcoming releases. I suggest also removing these tags locally running the command `git fetch --prune origin "+refs/tags/*:refs/tags/*"`
- The `main` branch was updated to the latest from `next` and should be ready to merge into.

