### PR TITLE
fix: fetch all references with includes

### DIFF
--- a/packages/core/src/fetchers/fetchAllEntities.spec.ts
+++ b/packages/core/src/fetchers/fetchAllEntities.spec.ts
@@ -1,0 +1,87 @@
+import { entries } from '../test/__fixtures__/entities';
+import { fetchAllEntities } from './fetchAllEntities';
+
+import { describe, afterEach, it, expect, vi, Mock } from 'vitest';
+import { ContentfulClientApi } from 'contentful';
+
+const mockClient = {
+  getAssets: vi.fn(),
+  withoutLinkResolution: {
+    getEntries: vi.fn(),
+  },
+} as unknown as ContentfulClientApi<undefined>;
+
+describe('fetchAllEntities', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should fetch all entities', async () => {
+    (mockClient.withoutLinkResolution.getEntries as Mock).mockResolvedValue({
+      items: [...entries],
+      total: 100,
+    });
+
+    const params = {
+      ids: entries.map((entry) => entry.sys.id),
+      entityType: 'Entry' as 'Entry' | 'Asset',
+      client: mockClient,
+      locale: 'en-US',
+      limit: 20,
+    };
+
+    await fetchAllEntities(params);
+
+    expect(mockClient.withoutLinkResolution.getEntries).toHaveBeenCalledTimes(5);
+  });
+
+  it('should reduce limit and refetch all entities if response error is gotten', async () => {
+    (mockClient.withoutLinkResolution.getEntries as Mock)
+      .mockRejectedValueOnce(new Error('Response size too big'))
+      .mockResolvedValue({
+        items: [...entries],
+        total: 100,
+      });
+
+    const params = {
+      ids: entries.map((entry) => entry.sys.id),
+      entityType: 'Entry' as 'Entry' | 'Asset',
+      client: mockClient,
+      locale: 'en-US',
+      limit: 20,
+    };
+
+    await fetchAllEntities(params);
+
+    expect(mockClient.withoutLinkResolution.getEntries).toHaveBeenLastCalledWith({
+      'sys.id[in]': params.ids,
+      locale: 'en-US',
+      skip: 90,
+      limit: 10,
+    });
+    expect(mockClient.withoutLinkResolution.getEntries).toHaveBeenCalledTimes(11);
+  });
+
+  it('should never reduce limit to less than MIN_FETCH_LIMIT', async () => {
+    (mockClient.withoutLinkResolution.getEntries as Mock).mockRejectedValue(
+      new Error('Response size too big'),
+    );
+
+    const params = {
+      ids: entries.map((entry) => entry.sys.id),
+      entityType: 'Entry' as 'Entry' | 'Asset',
+      client: mockClient,
+      locale: 'en-US',
+      limit: 20,
+    };
+    await fetchAllEntities(params);
+
+    expect(mockClient.withoutLinkResolution.getEntries).toHaveBeenLastCalledWith({
+      'sys.id[in]': params.ids,
+      locale: 'en-US',
+      skip: 0,
+      limit: 1,
+    });
+    expect(mockClient.withoutLinkResolution.getEntries).toHaveBeenCalledTimes(5);
+  });
+});

--- a/packages/core/src/fetchers/fetchAllEntities.spec.ts
+++ b/packages/core/src/fetchers/fetchAllEntities.spec.ts
@@ -1,5 +1,5 @@
-import { entries } from '../test/__fixtures__/entities';
-import { fetchAllEntities } from './fetchAllEntities';
+import { createAsset, createEntry } from '../test/__fixtures__/entities';
+import { fetchAllAssets, fetchAllEntries } from './fetchAllEntities';
 
 import { describe, afterEach, it, expect, vi, Mock } from 'vitest';
 import { ContentfulClientApi } from 'contentful';
@@ -11,26 +11,29 @@ const mockClient = {
   },
 } as unknown as ContentfulClientApi<undefined>;
 
-describe('fetchAllEntities', () => {
+const testEntries = [...Array(100).keys()].map((i) => createEntry(`some-entry-id-${i}`));
+const testAssets = [...Array(100).keys()].map((i) => createAsset(`some-asset-id-${i}`));
+
+describe('fetchAllEntries', () => {
   afterEach(() => {
     vi.clearAllMocks();
   });
 
   it('should fetch all entities', async () => {
     (mockClient.withoutLinkResolution.getEntries as Mock).mockResolvedValue({
-      items: [...entries],
+      items: testEntries,
       total: 100,
     });
 
     const params = {
-      ids: entries.map((entry) => entry.sys.id),
+      ids: testEntries.map((entry) => entry.sys.id),
       entityType: 'Entry' as 'Entry' | 'Asset',
       client: mockClient,
       locale: 'en-US',
       limit: 20,
     };
 
-    await fetchAllEntities(params);
+    await fetchAllEntries(params);
 
     expect(mockClient.withoutLinkResolution.getEntries).toHaveBeenCalledTimes(5);
   });
@@ -39,19 +42,19 @@ describe('fetchAllEntities', () => {
     (mockClient.withoutLinkResolution.getEntries as Mock)
       .mockRejectedValueOnce(new Error('Response size too big'))
       .mockResolvedValue({
-        items: [...entries],
+        items: testEntries,
         total: 100,
       });
 
     const params = {
-      ids: entries.map((entry) => entry.sys.id),
+      ids: testEntries.map((entry) => entry.sys.id),
       entityType: 'Entry' as 'Entry' | 'Asset',
       client: mockClient,
       locale: 'en-US',
       limit: 20,
     };
 
-    await fetchAllEntities(params);
+    await fetchAllEntries(params);
 
     expect(mockClient.withoutLinkResolution.getEntries).toHaveBeenNthCalledWith(11, {
       'sys.id[in]': params.ids,
@@ -67,15 +70,95 @@ describe('fetchAllEntities', () => {
     );
 
     const params = {
-      ids: entries.map((entry) => entry.sys.id),
+      ids: testEntries.map((entry) => entry.sys.id),
       entityType: 'Entry' as 'Entry' | 'Asset',
       client: mockClient,
       locale: 'en-US',
       limit: 20,
     };
-    await fetchAllEntities(params);
+    try {
+      await fetchAllEntries(params);
+    } catch (e) {
+      expect((e as Error).message).toEqual('Response size too big');
+    }
 
     expect(mockClient.withoutLinkResolution.getEntries).toHaveBeenNthCalledWith(5, {
+      'sys.id[in]': params.ids,
+      locale: 'en-US',
+      skip: 0,
+      limit: 1,
+    });
+  });
+});
+
+describe('fetchAllAssets', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should fetch all assets', async () => {
+    (mockClient.getAssets as Mock).mockResolvedValue({
+      items: testAssets,
+      total: 100,
+    });
+
+    const params = {
+      ids: testAssets.map((entry) => entry.sys.id),
+      entityType: 'Entry' as 'Entry' | 'Asset',
+      client: mockClient,
+      locale: 'en-US',
+      limit: 20,
+    };
+
+    await fetchAllAssets(params);
+
+    expect(mockClient.getAssets).toHaveBeenCalledTimes(5);
+  });
+
+  it('should reduce limit and refetch all entities if response error is gotten', async () => {
+    (mockClient.getAssets as Mock)
+      .mockRejectedValueOnce(new Error('Response size too big'))
+      .mockResolvedValue({
+        items: testAssets,
+        total: 100,
+      });
+
+    const params = {
+      ids: testAssets.map((entry) => entry.sys.id),
+      entityType: 'Entry' as 'Entry' | 'Asset',
+      client: mockClient,
+      locale: 'en-US',
+      limit: 20,
+    };
+
+    await fetchAllAssets(params);
+
+    expect(mockClient.getAssets).toHaveBeenNthCalledWith(11, {
+      'sys.id[in]': params.ids,
+      locale: 'en-US',
+      skip: 90,
+      limit: 10,
+    });
+  });
+
+  it('should never reduce limit to less than MIN_FETCH_LIMIT', async () => {
+    (mockClient.getAssets as Mock).mockRejectedValue(new Error('Response size too big'));
+
+    const params = {
+      ids: testAssets.map((entry) => entry.sys.id),
+      entityType: 'Entry' as 'Entry' | 'Asset',
+      client: mockClient,
+      locale: 'en-US',
+      limit: 20,
+    };
+
+    try {
+      await fetchAllAssets(params);
+    } catch (e) {
+      expect((e as Error).message).toEqual('Response size too big');
+    }
+
+    expect(mockClient.getAssets).toHaveBeenNthCalledWith(5, {
       'sys.id[in]': params.ids,
       locale: 'en-US',
       skip: 0,

--- a/packages/core/src/fetchers/fetchAllEntities.spec.ts
+++ b/packages/core/src/fetchers/fetchAllEntities.spec.ts
@@ -46,8 +46,17 @@ describe('fetchAllEntries', () => {
     const result = await fetchAllEntries(params);
 
     expect(mockClient.withoutLinkResolution.getEntries).toHaveBeenCalledTimes(5);
+    // Five pages will return those values of `includes.Entry[]`:
+    // Page 1 : `some-entry-id` , `some-entry-id-0`
+    // Page 2: `some-entry-id` , `some-entry-id-20`
+    // Page 3: `some-entry-id` , `some-entry-id-40`
+    // Page 4: `some-entry-id` , `some-entry-id-60`
+    // Page 5: `some-entry-id` , `some-entry-id-80`
+    // But the `result.includes.Entry` is expected to only return unique entries
+    // And there are only 6 uniques, as duplicates of `some-entry-id` are not returned or counted
     expect(result.includes.Entry).toHaveLength(6);
     expect(result.includes.Asset).toHaveLength(0);
+    expect(result.items).toHaveLength(100);
   });
 
   it('should reduce limit and refetch all entities if response error is gotten', async () => {
@@ -72,7 +81,7 @@ describe('fetchAllEntries', () => {
       limit: 20,
     };
 
-    await fetchAllEntries(params);
+    const result = await fetchAllEntries(params);
 
     expect(mockClient.withoutLinkResolution.getEntries).toHaveBeenNthCalledWith(11, {
       'sys.id[in]': params.ids,
@@ -80,6 +89,7 @@ describe('fetchAllEntries', () => {
       skip: 90,
       limit: 10,
     });
+    expect(result.items).toHaveLength(100);
   });
 
   it('should never reduce limit to less than MIN_FETCH_LIMIT', async () => {
@@ -134,9 +144,10 @@ describe('fetchAllAssets', () => {
       limit: 20,
     };
 
-    await fetchAllAssets(params);
+    const result = await fetchAllAssets(params);
 
     expect(mockClient.getAssets).toHaveBeenCalledTimes(5);
+    expect(result.items).toHaveLength(100);
   });
 
   it('should reduce limit and refetch all entities if response error is gotten', async () => {
@@ -161,7 +172,7 @@ describe('fetchAllAssets', () => {
       limit: 20,
     };
 
-    await fetchAllAssets(params);
+    const result = await fetchAllAssets(params);
 
     expect(mockClient.getAssets).toHaveBeenNthCalledWith(11, {
       'sys.id[in]': params.ids,
@@ -169,6 +180,7 @@ describe('fetchAllAssets', () => {
       skip: 90,
       limit: 10,
     });
+    expect(result.items).toHaveLength(100);
   });
 
   it('should never reduce limit to less than MIN_FETCH_LIMIT', async () => {

--- a/packages/core/src/fetchers/fetchAllEntities.spec.ts
+++ b/packages/core/src/fetchers/fetchAllEntities.spec.ts
@@ -53,13 +53,12 @@ describe('fetchAllEntities', () => {
 
     await fetchAllEntities(params);
 
-    expect(mockClient.withoutLinkResolution.getEntries).toHaveBeenLastCalledWith({
+    expect(mockClient.withoutLinkResolution.getEntries).toHaveBeenNthCalledWith(11, {
       'sys.id[in]': params.ids,
       locale: 'en-US',
       skip: 90,
       limit: 10,
     });
-    expect(mockClient.withoutLinkResolution.getEntries).toHaveBeenCalledTimes(11);
   });
 
   it('should never reduce limit to less than MIN_FETCH_LIMIT', async () => {
@@ -76,12 +75,11 @@ describe('fetchAllEntities', () => {
     };
     await fetchAllEntities(params);
 
-    expect(mockClient.withoutLinkResolution.getEntries).toHaveBeenLastCalledWith({
+    expect(mockClient.withoutLinkResolution.getEntries).toHaveBeenNthCalledWith(5, {
       'sys.id[in]': params.ids,
       locale: 'en-US',
       skip: 0,
       limit: 1,
     });
-    expect(mockClient.withoutLinkResolution.getEntries).toHaveBeenCalledTimes(5);
   });
 });

--- a/packages/core/src/fetchers/fetchAllEntities.ts
+++ b/packages/core/src/fetchers/fetchAllEntities.ts
@@ -1,5 +1,6 @@
 import { Asset, ContentfulClientApi, Entry } from 'contentful';
 import { MinimalEntryCollection } from './gatherAutoFetchedReferentsFromIncludes';
+import { uniqBy } from 'lodash-es';
 
 const MIN_FETCH_LIMIT = 1;
 export const fetchAllEntries = async ({
@@ -49,7 +50,7 @@ export const fetchAllEntries = async ({
     responseIncludes?.Asset?.push(...(includes?.Asset || []));
 
     if (skip + limit < responseTotal) {
-      await fetchAllEntries({
+      return await fetchAllEntries({
         client,
         ids,
         locale,
@@ -60,9 +61,15 @@ export const fetchAllEntries = async ({
       });
     }
 
+    const dedupedEntries = uniqBy(responseIncludes?.Entry, (entry) => entry.sys.id);
+    const dedupedAssets = uniqBy(responseIncludes?.Asset, (asset) => asset.sys.id);
+
     return {
       items: responseItems,
-      includes: responseIncludes,
+      includes: {
+        Entry: dedupedEntries,
+        Asset: dedupedAssets,
+      },
     };
   } catch (error) {
     if (
@@ -118,7 +125,7 @@ export const fetchAllAssets = async ({
     responseItems.push(...(items as Asset[]));
 
     if (skip + limit < responseTotal) {
-      await fetchAllAssets({
+      return await fetchAllAssets({
         client,
         ids,
         locale,

--- a/packages/core/src/fetchers/fetchAllEntities.ts
+++ b/packages/core/src/fetchers/fetchAllEntities.ts
@@ -49,6 +49,15 @@ export const fetchAllEntries = async ({
     responseIncludes?.Entry?.push(...(includes?.Entry || []));
     responseIncludes?.Asset?.push(...(includes?.Asset || []));
 
+    // E.g Total entries = 99
+    // First fetch => { skip: 0, limit: 50, total: 99 } => 50 Entries fetched in Page 0
+    // Total Entries fetched = 50, 49 remaining
+
+    // 0(skip) + 50(limit) < 99(total) => Fetch again
+    // Second fetch => { skip: 50, limit: 50, total: 99 } => 49 Entries fetched in Page 1
+    // Total Entries fetched = 50(Page 0) + 49(Page 1) = 99, 0 remaining
+
+    // 50(skip) + 50(limit) > 99(total) => Stop fetching
     if (skip + limit < responseTotal) {
       return await fetchAllEntries({
         client,

--- a/packages/core/src/fetchers/fetchAllEntities.ts
+++ b/packages/core/src/fetchers/fetchAllEntities.ts
@@ -1,4 +1,5 @@
-import { ContentfulClientApi, Entry } from 'contentful';
+import { ContentfulClientApi, Entry, EntryCollection } from 'contentful';
+import { MinimalEntryCollection } from './gatherAutoFetchedReferentsFromIncludes';
 
 const MIN_FETCH_LIMIT = 1;
 
@@ -39,6 +40,7 @@ export const fetchAllEntities = async ({
     if (!ids.length || !client) {
       return {
         items: [],
+        ...(entityType === 'Entry' && { includes: [] }),
       };
     }
 
@@ -49,6 +51,7 @@ export const fetchAllEntities = async ({
     if (!response) {
       return {
         items: responseItems,
+        ...(entityType === 'Entry' && { includes: [] }),
       };
     }
 
@@ -68,6 +71,7 @@ export const fetchAllEntities = async ({
 
     return {
       items: responseItems,
+      ...(entityType === 'Entry' && { includes: (response as MinimalEntryCollection).includes }),
     };
   } catch (error) {
     if (

--- a/packages/core/src/fetchers/fetchAllEntities.ts
+++ b/packages/core/src/fetchers/fetchAllEntities.ts
@@ -1,0 +1,87 @@
+import { ContentfulClientApi, Entry } from 'contentful';
+
+const MIN_FETCH_LIMIT = 10;
+
+const fetchEntities = async ({
+  entityType,
+  client,
+  query,
+}: {
+  entityType: 'Entry' | 'Asset';
+  client: ContentfulClientApi<undefined>;
+  query: { 'sys.id[in]': string[]; locale: string; limit: number; skip: number };
+}) => {
+  if (entityType === 'Asset') {
+    return client.getAssets({ ...query });
+  }
+
+  return client.getEntries({ ...query });
+};
+
+export const fetchAllEntities = async ({
+  client,
+  entityType,
+  ids,
+  locale,
+  skip = 0,
+  limit = 100,
+  responseItems = [],
+}: {
+  client: ContentfulClientApi<undefined>;
+  entityType: 'Entry' | 'Asset';
+  ids: string[];
+  locale: string;
+  skip?: number;
+  limit?: number;
+  responseItems?: Entry[];
+}) => {
+  try {
+    if (!ids.length) {
+      return {
+        items: [],
+      };
+    }
+
+    const query = { 'sys.id[in]': ids, locale, limit, skip };
+    const response = await fetchEntities({ entityType, client, query });
+    responseItems.push(...(response.items as Entry[]));
+
+    if (skip + limit < response.total) {
+      await fetchAllEntities({
+        client,
+        entityType,
+        ids,
+        locale,
+        skip: skip + limit,
+        limit,
+        responseItems,
+      });
+    }
+
+    return {
+      items: responseItems,
+    };
+  } catch (e) {
+    if (
+      e instanceof Error &&
+      e.name === 'BadRequest' &&
+      e.message.includes('size too big') &&
+      limit > MIN_FETCH_LIMIT
+    ) {
+      const newLimit = Math.max(MIN_FETCH_LIMIT, Math.floor(limit / 2));
+      return fetchAllEntities({
+        client,
+        entityType,
+        ids,
+        locale,
+        skip,
+        limit: newLimit,
+        responseItems,
+      });
+    }
+
+    return {
+      items: responseItems,
+    };
+  }
+};

--- a/packages/core/src/fetchers/fetchAllEntities.ts
+++ b/packages/core/src/fetchers/fetchAllEntities.ts
@@ -47,7 +47,9 @@ export const fetchAllEntities = async ({
     const response = await fetchEntities({ entityType, client, query });
 
     if (!response) {
-      return responseItems;
+      return {
+        items: responseItems,
+      };
     }
 
     responseItems.push(...(response.items as Entry[]));

--- a/packages/core/src/fetchers/fetchAllEntities.ts
+++ b/packages/core/src/fetchers/fetchAllEntities.ts
@@ -1,4 +1,4 @@
-import { ContentfulClientApi, Entry, EntryCollection } from 'contentful';
+import { ContentfulClientApi, Entry } from 'contentful';
 import { MinimalEntryCollection } from './gatherAutoFetchedReferentsFromIncludes';
 
 const MIN_FETCH_LIMIT = 1;

--- a/packages/core/src/fetchers/fetchReferencedEntities.spec.ts
+++ b/packages/core/src/fetchers/fetchReferencedEntities.spec.ts
@@ -73,7 +73,7 @@ describe('fetchReferencedEntities', () => {
     }
   });
 
-  it.only('should fetch referenced entities', async () => {
+  it('should fetch referenced entities', async () => {
     (mockClient.getAssets as Mock).mockResolvedValue({ items: assets });
 
     (mockClient.withoutLinkResolution.getEntries as Mock).mockResolvedValue({ items: entries });

--- a/packages/core/src/fetchers/fetchReferencedEntities.spec.ts
+++ b/packages/core/src/fetchers/fetchReferencedEntities.spec.ts
@@ -73,7 +73,7 @@ describe('fetchReferencedEntities', () => {
     }
   });
 
-  it('should fetch referenced entities', async () => {
+  it.only('should fetch referenced entities', async () => {
     (mockClient.getAssets as Mock).mockResolvedValue({ items: assets });
 
     (mockClient.withoutLinkResolution.getEntries as Mock).mockResolvedValue({ items: entries });
@@ -87,6 +87,8 @@ describe('fetchReferencedEntities', () => {
     });
 
     expect(mockClient.getAssets).toHaveBeenCalledWith({
+      limit: 100,
+      skip: 0,
       locale: 'en-US',
       'sys.id[in]': assets.map((asset) => asset.sys.id),
     });
@@ -94,6 +96,8 @@ describe('fetchReferencedEntities', () => {
     expect(mockClient.withoutLinkResolution.getEntries).toHaveBeenCalledWith({
       locale: 'en-US',
       'sys.id[in]': entries.map((entry) => entry.sys.id),
+      limit: 100,
+      skip: 0,
     });
 
     expect(res).toEqual({

--- a/packages/core/src/fetchers/fetchReferencedEntities.ts
+++ b/packages/core/src/fetchers/fetchReferencedEntities.ts
@@ -6,7 +6,7 @@ import {
   MinimalEntryCollection,
   gatherAutoFetchedReferentsFromIncludes,
 } from './gatherAutoFetchedReferentsFromIncludes';
-import { fetchAllEntities } from './fetchAllEntities';
+import { fetchAllEntries, fetchAllAssets } from './fetchAllEntities';
 
 type FetchReferencedEntitiesArgs = {
   client: ContentfulClientApi<undefined>;
@@ -56,8 +56,8 @@ export const fetchReferencedEntities = async ({
   }
 
   const [entriesResponse, assetsResponse] = (await Promise.all([
-    fetchAllEntities({ client, entityType: 'Entry', ids: entryIds, locale }),
-    fetchAllEntities({ client, entityType: 'Asset', ids: assetIds, locale }),
+    fetchAllEntries({ client, ids: entryIds, locale }),
+    fetchAllAssets({ client, ids: assetIds, locale }),
   ])) as unknown as [MinimalEntryCollection, AssetCollection];
 
   const { autoFetchedReferentAssets, autoFetchedReferentEntries } =

--- a/packages/core/src/fetchers/fetchReferencedEntities.ts
+++ b/packages/core/src/fetchers/fetchReferencedEntities.ts
@@ -6,6 +6,7 @@ import {
   MinimalEntryCollection,
   gatherAutoFetchedReferentsFromIncludes,
 } from './gatherAutoFetchedReferentsFromIncludes';
+import { fetchAllEntities } from './fetchAllEntities';
 
 type FetchReferencedEntitiesArgs = {
   client: ContentfulClientApi<undefined>;
@@ -55,10 +56,8 @@ export const fetchReferencedEntities = async ({
   }
 
   const [entriesResponse, assetsResponse] = (await Promise.all([
-    entryIds.length > 0
-      ? client.withoutLinkResolution.getEntries({ 'sys.id[in]': entryIds, locale })
-      : { items: [], includes: [] },
-    assetIds.length > 0 ? client.getAssets({ 'sys.id[in]': assetIds, locale }) : { items: [] },
+    fetchAllEntities({ client, entityType: 'Entry', ids: entryIds, locale }),
+    fetchAllEntities({ client, entityType: 'Asset', ids: assetIds, locale }),
   ])) as unknown as [MinimalEntryCollection, AssetCollection];
 
   const { autoFetchedReferentAssets, autoFetchedReferentEntries } =
@@ -66,7 +65,7 @@ export const fetchReferencedEntities = async ({
 
   // Using client getEntries resolves all linked entry references, so we do not need to resolve entries in usedComponents
   const allResolvedEntries = [
-    ...((entriesResponse.items ?? []) as Entry[]),
+    ...((entriesResponse?.items ?? []) as Entry[]),
     ...((experienceEntry.fields.usedComponents as ExperienceEntry[]) || []),
     ...autoFetchedReferentEntries,
   ];

--- a/packages/core/src/test/__fixtures__/entities.ts
+++ b/packages/core/src/test/__fixtures__/entities.ts
@@ -1,5 +1,8 @@
 import { Asset, AssetFile, Entry } from 'contentful';
-import { merge } from 'lodash-es';
+import { merge } from 'lodash.merge';
+import type { PartialDeep } from 'type-fest';
+
+export type Override<T extends object> = PartialDeep<T>;
 
 export const entityIds = {
   ENTRY1: 'entry1',
@@ -121,7 +124,7 @@ export const assets: Asset[] = [
 ];
 
 export const entities: Array<Entry | Asset> = [...entries, ...assets];
-export const createEntry = (id: string, overrides?: Override<Entry>): Entry => {
+export const createEntry = (id: string, overrides?: PartialDeep<Entry>): Entry => {
   return merge(
     {
       sys: {
@@ -162,7 +165,7 @@ export const createEntry = (id: string, overrides?: Override<Entry>): Entry => {
   );
 };
 
-export const createAsset = (id: string, overrides?: Override<Entry>): Entry => {
+export const createAsset = (id: string, overrides?: PartialDeep<Asset>): Asset => {
   return merge(
     {
       sys: {

--- a/packages/core/src/test/__fixtures__/entities.ts
+++ b/packages/core/src/test/__fixtures__/entities.ts
@@ -1,4 +1,5 @@
 import { Asset, AssetFile, Entry } from 'contentful';
+import { merge } from 'lodash-es';
 
 export const entityIds = {
   ENTRY1: 'entry1',
@@ -120,3 +121,77 @@ export const assets: Asset[] = [
 ];
 
 export const entities: Array<Entry | Asset> = [...entries, ...assets];
+export const createEntry = (id: string, overrides?: Override<Entry>): Entry => {
+  return merge(
+    {
+      sys: {
+        id,
+        type: 'Entry',
+        contentType: {
+          sys: {
+            id: 'bar',
+            type: 'Link',
+            linkType: 'ContentType',
+          },
+        },
+        createdAt: '2020-01-01T00:00:00.000Z',
+        updatedAt: '2020-01-01T00:00:00.000Z',
+        revision: 10,
+        space: {
+          sys: {
+            type: 'Link',
+            linkType: 'Space',
+            id: 'cfexampleapi',
+          },
+        },
+        environment: {
+          sys: {
+            id: 'master',
+            type: 'Link',
+            linkType: 'Environment',
+          },
+        },
+        locale: 'en-US',
+      },
+      fields: {},
+      metadata: {
+        tags: [],
+      },
+    },
+    overrides,
+  );
+};
+
+export const createAsset = (id: string, overrides?: Override<Entry>): Entry => {
+  return merge(
+    {
+      sys: {
+        id,
+        type: 'Asset',
+        createdAt: '2020-01-01T00:00:00.000Z',
+        updatedAt: '2020-01-01T00:00:00.000Z',
+        revision: 10,
+        space: {
+          sys: {
+            type: 'Link',
+            linkType: 'Space',
+            id: 'cfexampleapi',
+          },
+        },
+        environment: {
+          sys: {
+            id: 'master',
+            type: 'Link',
+            linkType: 'Environment',
+          },
+        },
+        locale: 'en-US',
+      },
+      fields: {},
+      metadata: {
+        tags: [],
+      },
+    },
+    overrides,
+  );
+};

--- a/packages/core/src/test/__fixtures__/entities.ts
+++ b/packages/core/src/test/__fixtures__/entities.ts
@@ -1,8 +1,6 @@
 import { Asset, AssetFile, Entry } from 'contentful';
-import { merge } from 'lodash.merge';
+import merge from 'lodash.merge';
 import type { PartialDeep } from 'type-fest';
-
-export type Override<T extends object> = PartialDeep<T>;
 
 export const entityIds = {
   ENTRY1: 'entry1',

--- a/packages/experience-builder-sdk/src/hooks/useFetchById.spec.ts
+++ b/packages/experience-builder-sdk/src/hooks/useFetchById.spec.ts
@@ -69,11 +69,15 @@ describe('useFetchById', () => {
       });
 
       expect(clientMock.withoutLinkResolution.getEntries).toHaveBeenNthCalledWith(1, {
+        limit: 100,
+        skip: 0,
         'sys.id[in]': entries.map((entry) => entry.sys.id),
         locale: localeCode,
       });
 
       expect(clientMock.getAssets).toHaveBeenCalledWith({
+        limit: 100,
+        skip: 0,
         'sys.id[in]': assets.map((asset) => asset.sys.id),
         locale: localeCode,
       });

--- a/packages/experience-builder-sdk/src/hooks/useFetchBySlug.spec.ts
+++ b/packages/experience-builder-sdk/src/hooks/useFetchBySlug.spec.ts
@@ -77,6 +77,8 @@ describe('useFetchBySlug', () => {
       });
 
       expect(clientMock.withoutLinkResolution.getEntries).toHaveBeenNthCalledWith(1, {
+        limit: 100,
+        skip: 0,
         'sys.id[in]': entries.map((entry) => entry.sys.id),
         locale: localeCode,
       });

--- a/packages/experience-builder-sdk/src/hooks/useFetchBySlug.spec.ts
+++ b/packages/experience-builder-sdk/src/hooks/useFetchBySlug.spec.ts
@@ -84,6 +84,8 @@ describe('useFetchBySlug', () => {
       });
 
       expect(clientMock.getAssets).toHaveBeenCalledWith({
+        limit: 100,
+        skip: 0,
         'sys.id[in]': assets.map((asset) => asset.sys.id),
         locale: localeCode,
       });


### PR DESCRIPTION
## Purpose
Fetch all references with includes

https://github.com/contentful/experience-builder/assets/30434146/1ecc9c3d-d1bc-42b4-84e7-b42ec9f03922

With Deep Binding

https://github.com/contentful/experience-builder/assets/30434146/6995a186-42a1-4f1e-8f7c-1eb8ec82238e


## Approach

<!--

Three important notes on Pull Requests:
- In general, you should ask yourself whether this code change will improve or worsen the overall code quality. Any new tech debt will probably never be cleaned up.
- Please remember that newly introduced logic should be validated and protected through testing.
- Take a look at PR guides such as Google's [Google’s Code Review Guidelines](https://google.github.io/eng-practices/) and [Blockly - Writing a Good Pull Request](https://developers.google.com/blockly/guides/contribute/get-started/write_a_good_pr)

-->
