### PR TITLE
refactor: fetch all references with includes

### DIFF
--- a/packages/core/src/fetchers/fetchAllEntities.spec.ts
+++ b/packages/core/src/fetchers/fetchAllEntities.spec.ts
@@ -1,0 +1,87 @@
+import { entries } from '../test/__fixtures__/entities';
+import { fetchAllEntities } from './fetchAllEntities';
+
+import { describe, afterEach, it, expect, vi, Mock } from 'vitest';
+import { ContentfulClientApi } from 'contentful';
+
+const mockClient = {
+  getAssets: vi.fn(),
+  withoutLinkResolution: {
+    getEntries: vi.fn(),
+  },
+} as unknown as ContentfulClientApi<undefined>;
+
+describe('fetchAllEntities', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should fetch all entities', async () => {
+    (mockClient.withoutLinkResolution.getEntries as Mock).mockResolvedValue({
+      items: [...entries],
+      total: 100,
+    });
+
+    const params = {
+      ids: entries.map((entry) => entry.sys.id),
+      entityType: 'Entry' as 'Entry' | 'Asset',
+      client: mockClient,
+      locale: 'en-US',
+      limit: 20,
+    };
+
+    await fetchAllEntities(params);
+
+    expect(mockClient.withoutLinkResolution.getEntries).toHaveBeenCalledTimes(5);
+  });
+
+  it('should reduce limit and refetch all entities if response error is gotten', async () => {
+    (mockClient.withoutLinkResolution.getEntries as Mock)
+      .mockRejectedValueOnce(new Error('Response size too big'))
+      .mockResolvedValue({
+        items: [...entries],
+        total: 100,
+      });
+
+    const params = {
+      ids: entries.map((entry) => entry.sys.id),
+      entityType: 'Entry' as 'Entry' | 'Asset',
+      client: mockClient,
+      locale: 'en-US',
+      limit: 20,
+    };
+
+    await fetchAllEntities(params);
+
+    expect(mockClient.withoutLinkResolution.getEntries).toHaveBeenLastCalledWith({
+      'sys.id[in]': params.ids,
+      locale: 'en-US',
+      skip: 90,
+      limit: 10,
+    });
+    expect(mockClient.withoutLinkResolution.getEntries).toHaveBeenCalledTimes(11);
+  });
+
+  it('should never reduce limit to less than MIN_FETCH_LIMIT', async () => {
+    (mockClient.withoutLinkResolution.getEntries as Mock).mockRejectedValue(
+      new Error('Response size too big'),
+    );
+
+    const params = {
+      ids: entries.map((entry) => entry.sys.id),
+      entityType: 'Entry' as 'Entry' | 'Asset',
+      client: mockClient,
+      locale: 'en-US',
+      limit: 20,
+    };
+    await fetchAllEntities(params);
+
+    expect(mockClient.withoutLinkResolution.getEntries).toHaveBeenLastCalledWith({
+      'sys.id[in]': params.ids,
+      locale: 'en-US',
+      skip: 0,
+      limit: 1,
+    });
+    expect(mockClient.withoutLinkResolution.getEntries).toHaveBeenCalledTimes(5);
+  });
+});

--- a/packages/core/src/fetchers/fetchAllEntities.spec.ts
+++ b/packages/core/src/fetchers/fetchAllEntities.spec.ts
@@ -53,13 +53,12 @@ describe('fetchAllEntities', () => {
 
     await fetchAllEntities(params);
 
-    expect(mockClient.withoutLinkResolution.getEntries).toHaveBeenLastCalledWith({
+    expect(mockClient.withoutLinkResolution.getEntries).toHaveBeenNthCalledWith(11, {
       'sys.id[in]': params.ids,
       locale: 'en-US',
       skip: 90,
       limit: 10,
     });
-    expect(mockClient.withoutLinkResolution.getEntries).toHaveBeenCalledTimes(11);
   });
 
   it('should never reduce limit to less than MIN_FETCH_LIMIT', async () => {
@@ -76,12 +75,11 @@ describe('fetchAllEntities', () => {
     };
     await fetchAllEntities(params);
 
-    expect(mockClient.withoutLinkResolution.getEntries).toHaveBeenLastCalledWith({
+    expect(mockClient.withoutLinkResolution.getEntries).toHaveBeenNthCalledWith(5, {
       'sys.id[in]': params.ids,
       locale: 'en-US',
       skip: 0,
       limit: 1,
     });
-    expect(mockClient.withoutLinkResolution.getEntries).toHaveBeenCalledTimes(5);
   });
 });

--- a/packages/core/src/fetchers/fetchAllEntities.ts
+++ b/packages/core/src/fetchers/fetchAllEntities.ts
@@ -1,4 +1,5 @@
-import { ContentfulClientApi, Entry } from 'contentful';
+import { ContentfulClientApi, Entry, EntryCollection } from 'contentful';
+import { MinimalEntryCollection } from './gatherAutoFetchedReferentsFromIncludes';
 
 const MIN_FETCH_LIMIT = 1;
 
@@ -39,6 +40,7 @@ export const fetchAllEntities = async ({
     if (!ids.length || !client) {
       return {
         items: [],
+        ...(entityType === 'Entry' && { includes: [] }),
       };
     }
 
@@ -49,6 +51,7 @@ export const fetchAllEntities = async ({
     if (!response) {
       return {
         items: responseItems,
+        ...(entityType === 'Entry' && { includes: [] }),
       };
     }
 
@@ -68,6 +71,7 @@ export const fetchAllEntities = async ({
 
     return {
       items: responseItems,
+      ...(entityType === 'Entry' && { includes: (response as MinimalEntryCollection).includes }),
     };
   } catch (error) {
     if (

--- a/packages/core/src/fetchers/fetchAllEntities.ts
+++ b/packages/core/src/fetchers/fetchAllEntities.ts
@@ -1,0 +1,87 @@
+import { ContentfulClientApi, Entry } from 'contentful';
+
+const MIN_FETCH_LIMIT = 10;
+
+const fetchEntities = async ({
+  entityType,
+  client,
+  query,
+}: {
+  entityType: 'Entry' | 'Asset';
+  client: ContentfulClientApi<undefined>;
+  query: { 'sys.id[in]': string[]; locale: string; limit: number; skip: number };
+}) => {
+  if (entityType === 'Asset') {
+    return client.getAssets({ ...query });
+  }
+
+  return client.getEntries({ ...query });
+};
+
+export const fetchAllEntities = async ({
+  client,
+  entityType,
+  ids,
+  locale,
+  skip = 0,
+  limit = 100,
+  responseItems = [],
+}: {
+  client: ContentfulClientApi<undefined>;
+  entityType: 'Entry' | 'Asset';
+  ids: string[];
+  locale: string;
+  skip?: number;
+  limit?: number;
+  responseItems?: Entry[];
+}) => {
+  try {
+    if (!ids.length) {
+      return {
+        items: [],
+      };
+    }
+
+    const query = { 'sys.id[in]': ids, locale, limit, skip };
+    const response = await fetchEntities({ entityType, client, query });
+    responseItems.push(...(response.items as Entry[]));
+
+    if (skip + limit < response.total) {
+      await fetchAllEntities({
+        client,
+        entityType,
+        ids,
+        locale,
+        skip: skip + limit,
+        limit,
+        responseItems,
+      });
+    }
+
+    return {
+      items: responseItems,
+    };
+  } catch (e) {
+    if (
+      e instanceof Error &&
+      e.name === 'BadRequest' &&
+      e.message.includes('size too big') &&
+      limit > MIN_FETCH_LIMIT
+    ) {
+      const newLimit = Math.max(MIN_FETCH_LIMIT, Math.floor(limit / 2));
+      return fetchAllEntities({
+        client,
+        entityType,
+        ids,
+        locale,
+        skip,
+        limit: newLimit,
+        responseItems,
+      });
+    }
+
+    return {
+      items: responseItems,
+    };
+  }
+};

--- a/packages/core/src/fetchers/fetchAllEntities.ts
+++ b/packages/core/src/fetchers/fetchAllEntities.ts
@@ -47,7 +47,9 @@ export const fetchAllEntities = async ({
     const response = await fetchEntities({ entityType, client, query });
 
     if (!response) {
-      return responseItems;
+      return {
+        items: responseItems,
+      };
     }
 
     responseItems.push(...(response.items as Entry[]));

--- a/packages/core/src/fetchers/fetchAllEntities.ts
+++ b/packages/core/src/fetchers/fetchAllEntities.ts
@@ -1,4 +1,4 @@
-import { ContentfulClientApi, Entry, EntryCollection } from 'contentful';
+import { ContentfulClientApi, Entry } from 'contentful';
 import { MinimalEntryCollection } from './gatherAutoFetchedReferentsFromIncludes';
 
 const MIN_FETCH_LIMIT = 1;

--- a/packages/core/src/fetchers/fetchAllEntities2.ts
+++ b/packages/core/src/fetchers/fetchAllEntities2.ts
@@ -1,0 +1,165 @@
+import {
+  Asset,
+  AssetCollection as AssetCollectionOriginal,
+  ContentfulClientApi,
+  Entry as EntryOriginal,
+  EntryCollection as EntryCollectionOriginal,
+  EntrySkeletonType,
+} from 'contentful';
+import { uniqBy } from '../utils/uniqBy';
+type UnresolvedEntryCollection = EntryCollectionOriginal<
+  EntrySkeletonType,
+  'WITHOUT_LINK_RESOLUTION'
+>;
+type EntryCollection = Pick<
+  EntryCollectionOriginal<EntrySkeletonType, 'WITHOUT_LINK_RESOLUTION'>,
+  'items' | 'includes'
+>;
+type AssetCollection = Pick<AssetCollectionOriginal, 'items'>;
+type UnresolvedEntry = EntryOriginal<EntrySkeletonType, 'WITHOUT_LINK_RESOLUTION', string>;
+
+const MIN_FETCH_LIMIT = 1;
+const DEFAULT_FETCH_LIMIT = 100;
+
+export type FetchAllEntitiesOpts = {
+  client: ContentfulClientApi<undefined>;
+  ids: string[];
+  entityType: 'Entry' | 'Asset';
+  locale: string;
+};
+
+type FetchAllEntitiesImplOpts = {
+  skip: number;
+  ids: string[];
+  limit: number;
+};
+
+const fetchEntities = async ({
+  entityType,
+  client,
+  query,
+}: {
+  entityType: 'Entry' | 'Asset';
+  client: ContentfulClientApi<undefined>;
+  query: { 'sys.id[in]': string[]; locale: string; limit: number; skip: number };
+}): Promise<UnresolvedEntryCollection | AssetCollectionOriginal> => {
+  if (entityType === 'Asset') {
+    return client.getAssets({ ...query });
+  }
+
+  return client.withoutLinkResolution.getEntries({ ...query });
+};
+
+export const fetchAllEntities = async ({
+  client,
+  ids,
+  entityType,
+  locale,
+}: FetchAllEntitiesOpts): Promise<EntryCollection | AssetCollection> => {
+  const responseItems: Array<UnresolvedEntry | Asset> = [];
+  const responseAssetsFromIncludes: Asset[] = [];
+  const responseEntriesFromIncludes: UnresolvedEntry[] = [];
+
+  if (!client) {
+    throw new Error(
+      'Failed to fetch experience entities. Required "client" parameter was not provided',
+    );
+  }
+
+  if (!ids.length) {
+    // simulate return of empty collection
+    return {
+      items: [],
+    };
+  }
+
+  const fetchAllEntitiesImpl = async ({
+    skip,
+    ids,
+    limit = 100,
+  }: {
+    skip: number;
+    ids: string[];
+    limit: number;
+  }) => {
+    const alreadyFetchedCount = skip;
+
+    // Fetch a page
+    const query = { 'sys.id[in]': ids, locale, limit, skip };
+    const response = await fetchEntities({ entityType, client, query });
+    const lastFetchedCount = response.items.length;
+
+    // Store fetched items
+    if ('Entry' === entityType) {
+      const entryResponse = response as UnresolvedEntryCollection;
+      responseItems.push(...entryResponse.items);
+      const assets = entryResponse.includes?.Asset || [];
+      const entries = entryResponse.includes?.Entry || [];
+      responseAssetsFromIncludes.push(...assets);
+      responseEntriesFromIncludes.push(...entries);
+    } else if ('Asset' === entityType) {
+      const assetResponse = response as AssetCollectionOriginal;
+      responseItems.push(...assetResponse.items);
+    } else {
+      throw new Error(`Unsupported entityType: ${entityType}`);
+    }
+
+    // If more fetches, fetch recursively
+    const hasMorePagesToFetch = alreadyFetchedCount + lastFetchedCount < response.total;
+    if (!hasMorePagesToFetch) {
+      return;
+    }
+
+    await fetchAllEntitiesImpl({
+      skip: alreadyFetchedCount + lastFetchedCount,
+      ids,
+      limit,
+    });
+  };
+
+  const fetchAllEntitiesWithFetchLimitDownsizing = async (opts: FetchAllEntitiesImplOpts) => {
+    const { skip, ids, limit } = opts;
+    try {
+      await fetchAllEntitiesImpl({
+        ids,
+        skip,
+        limit,
+      });
+    } catch (e) {
+      if (e instanceof Error && e.message.includes('size too big') && limit > MIN_FETCH_LIMIT) {
+        const newLimit = Math.max(MIN_FETCH_LIMIT, Math.floor(limit / 2));
+        await fetchAllEntitiesWithFetchLimitDownsizing({
+          skip,
+          ids,
+          limit: newLimit,
+        });
+      }
+    }
+  };
+
+  await fetchAllEntitiesWithFetchLimitDownsizing({
+    ids,
+    skip: 0,
+    limit: DEFAULT_FETCH_LIMIT,
+  });
+
+  // Deduplicate included assets and entries
+  const dedupedEntries = uniqBy(responseEntriesFromIncludes, (entry) => entry.sys.id);
+  const dedupedAssets = uniqBy(responseAssetsFromIncludes, (asset) => asset.sys.id);
+
+  if ('Entry' === entityType) {
+    return {
+      items: responseItems as UnresolvedEntry[],
+      includes: {
+        Asset: dedupedAssets,
+        Entry: dedupedEntries,
+      },
+    };
+  } else if ('Asset' === entityType) {
+    return {
+      items: responseItems as Asset[],
+    };
+  } else {
+    throw new Error(`Unsupported entityType: ${entityType}`);
+  }
+};

--- a/packages/core/src/fetchers/fetchReferencedEntities.spec.ts
+++ b/packages/core/src/fetchers/fetchReferencedEntities.spec.ts
@@ -73,7 +73,7 @@ describe('fetchReferencedEntities', () => {
     }
   });
 
-  it.only('should fetch referenced entities', async () => {
+  it('should fetch referenced entities', async () => {
     (mockClient.getAssets as Mock).mockResolvedValue({ items: assets });
 
     (mockClient.withoutLinkResolution.getEntries as Mock).mockResolvedValue({ items: entries });

--- a/packages/core/src/fetchers/fetchReferencedEntities.spec.ts
+++ b/packages/core/src/fetchers/fetchReferencedEntities.spec.ts
@@ -73,7 +73,7 @@ describe('fetchReferencedEntities', () => {
     }
   });
 
-  it('should fetch referenced entities', async () => {
+  it.only('should fetch referenced entities', async () => {
     (mockClient.getAssets as Mock).mockResolvedValue({ items: assets });
 
     (mockClient.withoutLinkResolution.getEntries as Mock).mockResolvedValue({ items: entries });
@@ -87,6 +87,8 @@ describe('fetchReferencedEntities', () => {
     });
 
     expect(mockClient.getAssets).toHaveBeenCalledWith({
+      limit: 100,
+      skip: 0,
       locale: 'en-US',
       'sys.id[in]': assets.map((asset) => asset.sys.id),
     });
@@ -94,6 +96,8 @@ describe('fetchReferencedEntities', () => {
     expect(mockClient.withoutLinkResolution.getEntries).toHaveBeenCalledWith({
       locale: 'en-US',
       'sys.id[in]': entries.map((entry) => entry.sys.id),
+      limit: 100,
+      skip: 0,
     });
 
     expect(res).toEqual({

--- a/packages/core/src/fetchers/fetchReferencedEntities.ts
+++ b/packages/core/src/fetchers/fetchReferencedEntities.ts
@@ -6,6 +6,7 @@ import {
   MinimalEntryCollection,
   gatherAutoFetchedReferentsFromIncludes,
 } from './gatherAutoFetchedReferentsFromIncludes';
+import { fetchAllEntities } from './fetchAllEntities';
 
 type FetchReferencedEntitiesArgs = {
   client: ContentfulClientApi<undefined>;
@@ -55,10 +56,8 @@ export const fetchReferencedEntities = async ({
   }
 
   const [entriesResponse, assetsResponse] = (await Promise.all([
-    entryIds.length > 0
-      ? client.withoutLinkResolution.getEntries({ 'sys.id[in]': entryIds, locale })
-      : { items: [], includes: [] },
-    assetIds.length > 0 ? client.getAssets({ 'sys.id[in]': assetIds, locale }) : { items: [] },
+    fetchAllEntities({ client, entityType: 'Entry', ids: entryIds, locale }),
+    fetchAllEntities({ client, entityType: 'Asset', ids: assetIds, locale }),
   ])) as unknown as [MinimalEntryCollection, AssetCollection];
 
   const { autoFetchedReferentAssets, autoFetchedReferentEntries } =
@@ -66,7 +65,7 @@ export const fetchReferencedEntities = async ({
 
   // Using client getEntries resolves all linked entry references, so we do not need to resolve entries in usedComponents
   const allResolvedEntries = [
-    ...((entriesResponse.items ?? []) as Entry[]),
+    ...((entriesResponse?.items ?? []) as Entry[]),
     ...((experienceEntry.fields.usedComponents as ExperienceEntry[]) || []),
     ...autoFetchedReferentEntries,
   ];

--- a/packages/core/src/utils/uniqBy.ts
+++ b/packages/core/src/utils/uniqBy.ts
@@ -1,0 +1,12 @@
+export const uniqBy = <T, U>(arr: T[], uniqKeyFn: (T) => U): T[] => {
+  const seen = new Set();
+  const excludeDuplicates = (item) => {
+    const k = uniqKeyFn(item);
+    if (seen.has(k)) {
+      return false;
+    }
+    seen.add(k);
+    return true;
+  };
+  return arr.filter(excludeDuplicates);
+};

--- a/packages/experience-builder-sdk/src/hooks/useFetchById.spec.ts
+++ b/packages/experience-builder-sdk/src/hooks/useFetchById.spec.ts
@@ -69,11 +69,15 @@ describe('useFetchById', () => {
       });
 
       expect(clientMock.withoutLinkResolution.getEntries).toHaveBeenNthCalledWith(1, {
+        limit: 100,
+        skip: 0,
         'sys.id[in]': entries.map((entry) => entry.sys.id),
         locale: localeCode,
       });
 
       expect(clientMock.getAssets).toHaveBeenCalledWith({
+        limit: 100,
+        skip: 0,
         'sys.id[in]': assets.map((asset) => asset.sys.id),
         locale: localeCode,
       });

--- a/packages/experience-builder-sdk/src/hooks/useFetchBySlug.spec.ts
+++ b/packages/experience-builder-sdk/src/hooks/useFetchBySlug.spec.ts
@@ -77,6 +77,8 @@ describe('useFetchBySlug', () => {
       });
 
       expect(clientMock.withoutLinkResolution.getEntries).toHaveBeenNthCalledWith(1, {
+        limit: 100,
+        skip: 0,
         'sys.id[in]': entries.map((entry) => entry.sys.id),
         locale: localeCode,
       });

--- a/packages/experience-builder-sdk/src/hooks/useFetchBySlug.spec.ts
+++ b/packages/experience-builder-sdk/src/hooks/useFetchBySlug.spec.ts
@@ -84,6 +84,8 @@ describe('useFetchBySlug', () => {
       });
 
       expect(clientMock.getAssets).toHaveBeenCalledWith({
+        limit: 100,
+        skip: 0,
         'sys.id[in]': assets.map((asset) => asset.sys.id),
         locale: localeCode,
       });


### PR DESCRIPTION
## Purpose

Refactoring proposal for https://github.com/contentful/experience-builder/pull/519/files

- refactor recursion
  - clearly state destination variables (`responseItems`, `responseAssetsFromIncludes` , `responseEntriesFromIncludes`)
  - make explicit gathering of: `responseItems`, `responseAssetsFromIncludes` , `responseEntriesFromIncludes`
- explicitly state TS types
  - also fixes unnecessary returning of `includes{}` 
- make downsizing of the LIMIT explicit
- add deduplication of gathered Assets and Entries
- ensure that includes.Assets and includes.Entries are aggregated on pages 2 and beyond