### PR TITLE
fix(components): rich text formatting [ALT-585]

### DIFF
--- a/packages/components/src/components/RichText/RichText.css
+++ b/packages/components/src/components/RichText/RichText.css
@@ -1,3 +1,11 @@
 .cf-richtext {
   white-space: pre-line;
 }
+
+.cf-richtext > *:first-child {
+  margin-top: 0;
+}
+
+.cf-richtext > *:last-child {
+  margin-bottom: 0;
+}

--- a/packages/components/src/components/RichText/RichText.cy.tsx
+++ b/packages/components/src/components/RichText/RichText.cy.tsx
@@ -17,21 +17,21 @@ describe('RichText', () => {
 
   it('mounts', () => {
     cy.mount(<RichText value={document} />);
-    cy.get('p').contains('abc');
+    cy.get('span').contains('abc');
   });
 
   it('additional props should be passed to the rich text', () => {
     cy.mount(<RichText value={document} data-foo="bar" />);
-    cy.get('p').should('have.attr', 'data-foo', 'bar');
+    cy.get('span').should('have.attr', 'data-foo', 'bar');
   });
 
   it('when className is provided, it should be added to the rich text', () => {
     cy.mount(<RichText value={document} className="custom-class" />);
-    cy.get('p').should('have.class', 'custom-class');
+    cy.get('span').should('have.class', 'custom-class');
   });
 
   it('has a default class of "cf-richtext"', () => {
     cy.mount(<RichText value={document} />);
-    cy.get('p').should('have.class', 'cf-richtext');
+    cy.get('span').should('have.class', 'cf-richtext');
   });
 });

--- a/packages/components/src/components/RichText/RichText.tsx
+++ b/packages/components/src/components/RichText/RichText.tsx
@@ -35,18 +35,15 @@ export interface RichTextProps extends Omit<React.HTMLAttributes<HTMLElement>, '
 }
 
 export const RichText: React.FC<RichTextProps> = ({ as = 'p', className, value, ...props }) => {
-  const classes = combineClasses('cf-richtext', className);
   const Tag = as;
 
-  return documentToReactComponents(value, {
-    renderNode: {
-      [BLOCKS.PARAGRAPH]: (_node, children) => {
-        return (
-          <Tag className={classes} {...props}>
-            {children}
-          </Tag>
-        );
-      },
-    },
-  });
+  return (
+    <span className={combineClasses('cf-richtext', className)} {...props}>
+      {documentToReactComponents(value, {
+        renderNode: {
+          [BLOCKS.PARAGRAPH]: (_node, children) => <Tag>{children}</Tag>,
+        },
+      })}
+    </span>
+  );
 };


### PR DESCRIPTION
## Purpose

Ticket: https://contentful.atlassian.net/browse/ALT-585

Adds a wrapping `<span>` around the document in the RichText component.
* Previously the component `props` were being spread to each paragraph node, which was causing an issue with rendering.

![Screenshot 2024-03-29 at 9 15 50 AM](https://github.com/contentful/experience-builder/assets/8539634/2f5a420f-de21-4f84-a742-cd4c84995954)

I also added a couple of styles to remove the margin-top from the first element, and remove the margin-bottom from the last element in the RichText editor.
* This way the top and bottom margin's are not forced, and the user can control the exact amount of margins they want using the design sidebar.

![Screenshot 2024-03-29 at 9 21 24 AM](https://github.com/contentful/experience-builder/assets/8539634/51571d87-9b08-4ebe-af53-98e8b1606b46)
