### PR TITLE
fix(visual-editor): select component when image loads [ALT-646]

### DIFF
--- a/packages/visual-editor/src/communication/sendSelectedComponentCoordinates.ts
+++ b/packages/visual-editor/src/communication/sendSelectedComponentCoordinates.ts
@@ -28,12 +28,25 @@ export const sendSelectedComponentCoordinates = (instanceId?: string) => {
   }
 
   if (selectedElement) {
-    sendMessage(OUTGOING_EVENTS.UpdateSelectedComponentCoordinates, {
-      selectedNodeCoordinates: getElementCoordinates(selectedElement),
-      selectedAssemblyChildCoordinates: selectedAssemblyChild
-        ? getElementCoordinates(selectedAssemblyChild)
-        : null,
-      parentCoordinates: parent ? getElementCoordinates(parent) : null,
-    });
+    const sendUpdateSelectedComponentCoordinates = () => {
+      sendMessage(OUTGOING_EVENTS.UpdateSelectedComponentCoordinates, {
+        selectedNodeCoordinates: getElementCoordinates(selectedElement!),
+        selectedAssemblyChildCoordinates: selectedAssemblyChild
+          ? getElementCoordinates(selectedAssemblyChild)
+          : null,
+        parentCoordinates: parent ? getElementCoordinates(parent) : null,
+      });
+    };
+
+    const childImage = selectedElement.querySelector('img');
+    if (childImage) {
+      const handleImageLoad = () => {
+        sendUpdateSelectedComponentCoordinates();
+        childImage.removeEventListener('load', handleImageLoad);
+      };
+      childImage.addEventListener('load', handleImageLoad);
+    }
+
+    sendUpdateSelectedComponentCoordinates();
   }
 };


### PR DESCRIPTION
## Purpose

This fixes the selected component outline when changing images.

Ticket: https://contentful.atlassian.net/browse/ALT-646

https://github.com/contentful/experience-builder/assets/8539634/9ae57ece-2700-42af-99e0-c2dc4146bd5b

