### PR TITLE
fix: allow root-level structure components to be reparented into siblings [ALT-561]

### DIFF
--- a/packages/core/src/utils/components.ts
+++ b/packages/core/src/utils/components.ts
@@ -10,7 +10,7 @@ const structureComponents = new Set([
 export const isContentfulStructureComponent = (componentId?: string) =>
   structureComponents.has(componentId ?? '');
 
-export const isComponentAllowedOnRoot = (componentId: string) =>
+export const isComponentAllowedOnRoot = (componentId?: string) =>
   isContentfulStructureComponent(componentId) || componentId === CONTENTFUL_COMPONENTS.divider.id;
 
 export const isEmptyStructureWithRelativeHeight = (

--- a/packages/visual-editor/src/components/Dropzone/EditorBlock.tsx
+++ b/packages/visual-editor/src/components/Dropzone/EditorBlock.tsx
@@ -17,7 +17,6 @@ import {
 import { DraggableChildComponent } from '@components/Draggable/DraggableChildComponent';
 import { RenderDropzoneFunction } from './Dropzone.types';
 import { PlaceholderParams } from '@components/Draggable/Placeholder';
-import { ROOT_ID } from '@/types/constants';
 import Hitboxes from './Hitboxes';
 
 type EditorBlockProps = {
@@ -35,7 +34,6 @@ export const EditorBlock: React.FC<EditorBlockProps> = ({
   node: rawNode,
   resolveDesignValue,
   renderDropzone,
-  draggingNewComponent,
   index,
   zoneId,
   userIsDragging,
@@ -57,9 +55,7 @@ export const EditorBlock: React.FC<EditorBlockProps> = ({
   const isAssemblyBlock = node.type === ASSEMBLY_BLOCK_NODE_TYPE;
   const isAssembly = node.type === ASSEMBLY_NODE_TYPE;
   const isStructureComponent = isContentfulStructureComponent(node.data.blockId);
-  const isRootComponent = zoneId === ROOT_ID;
-
-  const enableRootHitboxes = isRootComponent && !!draggingNewComponent;
+  const isEmptyZone = !node.children.length;
 
   const onClick = (e: React.SyntheticEvent<Element, Event>) => {
     e.stopPropagation();
@@ -100,11 +96,7 @@ export const EditorBlock: React.FC<EditorBlockProps> = ({
           definition={definition}
         />
         {isStructureComponent && !isSingleColumn && userIsDragging && (
-          <Hitboxes
-            parentZoneId={zoneId}
-            zoneId={componentId}
-            enableRootHitboxes={enableRootHitboxes}
-          />
+          <Hitboxes parentZoneId={zoneId} zoneId={componentId} isEmptyZone={isEmptyZone} />
         )}
       </>
     );
@@ -127,11 +119,7 @@ export const EditorBlock: React.FC<EditorBlockProps> = ({
       onClick={onClick}>
       {elementToRender()}
       {isStructureComponent && !isSingleColumn && userIsDragging && (
-        <Hitboxes
-          parentZoneId={zoneId}
-          zoneId={componentId}
-          enableRootHitboxes={enableRootHitboxes}
-        />
+        <Hitboxes parentZoneId={zoneId} zoneId={componentId} isEmptyZone={isEmptyZone} />
       )}
     </DraggableComponent>
   );

--- a/packages/visual-editor/src/components/Dropzone/Hitboxes.tsx
+++ b/packages/visual-editor/src/components/Dropzone/Hitboxes.tsx
@@ -47,6 +47,8 @@ const Hitboxes: React.FC<Props> = ({ zoneId, parentZoneId, isEmptyZone }) => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [zoneId, fetchDomRect]);
 
+  // Use the size of the cloned dragging element to offset the position of the hitboxes
+  // So that when dragging causes a dropzone to expand, the hitboxes will be in the correct position
   const offsetRect = useMemo(() => {
     if (isEmptyZone || !isHoveringZone) return;
     return document.querySelector(`[${CTFL_DRAGGING_ELEMENT}]`)?.getBoundingClientRect();

--- a/packages/visual-editor/src/components/Dropzone/Hitboxes.tsx
+++ b/packages/visual-editor/src/components/Dropzone/Hitboxes.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import styles from './styles.module.css';
 import { useTreeStore } from '@/store/tree';
 import { getItemDepthFromNode } from '@/utils/getItem';
-import { CTFL_ZONE_ID, HitboxDirection, ROOT_ID } from '@/types/constants';
+import { CTFL_DRAGGING_ELEMENT, CTFL_ZONE_ID, HitboxDirection, ROOT_ID } from '@/types/constants';
 import { useZoneStore } from '@/store/zone';
 import { useDraggedItemStore } from '@/store/draggedItem';
 import { createPortal } from 'react-dom';
@@ -11,10 +11,10 @@ import { getHitboxStyles } from '@/utils/getHitboxStyles';
 interface Props {
   parentZoneId: string;
   zoneId: string;
-  enableRootHitboxes: boolean;
+  isEmptyZone: boolean;
 }
 
-const Hitboxes: React.FC<Props> = ({ zoneId, parentZoneId, enableRootHitboxes }) => {
+const Hitboxes: React.FC<Props> = ({ zoneId, parentZoneId, isEmptyZone }) => {
   const tree = useTreeStore((state) => state.tree);
   const isDraggingOnCanvas = useDraggedItemStore((state) => state.isDraggingOnCanvas);
   const scrollY = useDraggedItemStore((state) => state.scrollY);
@@ -23,6 +23,8 @@ const Hitboxes: React.FC<Props> = ({ zoneId, parentZoneId, enableRootHitboxes })
     [tree, parentZoneId],
   );
   const [fetchDomRect, setFetchDomRect] = useState(Date.now());
+  const { zones, hoveringZone } = useZoneStore();
+  const isHoveringZone = hoveringZone === zoneId;
 
   useEffect(() => {
     /**
@@ -45,16 +47,26 @@ const Hitboxes: React.FC<Props> = ({ zoneId, parentZoneId, enableRootHitboxes })
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [zoneId, fetchDomRect]);
 
-  const zones = useZoneStore((state) => state.zones);
+  const offsetRect = useMemo(() => {
+    if (isEmptyZone || !isHoveringZone) return;
+    return document.querySelector(`[${CTFL_DRAGGING_ELEMENT}]`)?.getBoundingClientRect();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isEmptyZone, isHoveringZone, fetchDomRect]);
 
   const zoneDirection = zones[parentZoneId]?.direction || 'vertical';
   const isVertical = zoneDirection === 'vertical';
   const isRoot = parentZoneId === ROOT_ID;
-  const showRootHitboxes = isRoot && enableRootHitboxes;
 
   const getStyles = useCallback(
-    (direction: HitboxDirection) => getHitboxStyles({ direction, zoneDepth, domRect, scrollY }),
-    [zoneDepth, domRect, scrollY],
+    (direction: HitboxDirection) =>
+      getHitboxStyles({
+        direction,
+        zoneDepth,
+        domRect,
+        scrollY,
+        offsetRect,
+      }),
+    [zoneDepth, domRect, scrollY, offsetRect],
   );
 
   const ActiveHitboxes = (
@@ -66,14 +78,13 @@ const Hitboxes: React.FC<Props> = ({ zoneId, parentZoneId, enableRootHitboxes })
           isVertical ? HitboxDirection.SELF_VERTICAL : HitboxDirection.SELF_HORIZONTAL,
         )}
       />
-      {showRootHitboxes && (
+      {isRoot ? (
         <div
           data-ctfl-zone-id={parentZoneId}
           className={styles.hitbox}
           style={getStyles(HitboxDirection.BOTTOM)}
         />
-      )}
-      {!isRoot && (
+      ) : (
         <>
           <div
             data-ctfl-zone-id={parentZoneId}

--- a/packages/visual-editor/src/components/Dropzone/styles.module.css
+++ b/packages/visual-editor/src/components/Dropzone/styles.module.css
@@ -6,7 +6,7 @@
   width: 100%;
   background-color: transparent;
   transition: background-color 0.2s;
-  pointer-events: all !important;
+  pointer-events: all;
 }
 
 .container:not(.isRoot):before {
@@ -47,10 +47,5 @@
 
 .hitbox {
   position: fixed;
-  pointer-events: all !important;
-}
-
-.hitbox {
-  position: fixed;
-  pointer-events: all !important;
+  pointer-events: all;
 }

--- a/packages/visual-editor/src/utils/getHitboxStyles.ts
+++ b/packages/visual-editor/src/utils/getHitboxStyles.ts
@@ -9,13 +9,20 @@ interface Params {
   domRect?: DOMRect;
   zoneDepth: number;
   scrollY: number;
+  offsetRect?: DOMRect;
 }
 
 const calcOffsetDepth = (depth: number) => {
   return INITIAL_OFFSET - OFFSET_INCREMENT * depth;
 };
 
-export const getHitboxStyles = ({ direction, zoneDepth, domRect }: Params): CSSProperties => {
+export const getHitboxStyles = ({
+  direction,
+  zoneDepth,
+  domRect,
+  scrollY,
+  offsetRect,
+}: Params): CSSProperties => {
   if (!domRect) {
     return {
       display: 'none',
@@ -23,6 +30,7 @@ export const getHitboxStyles = ({ direction, zoneDepth, domRect }: Params): CSSP
   }
 
   const { width, height, top, left, bottom, right } = domRect;
+  const { height: offsetHeight, width: offsetWidth } = offsetRect || { height: 0, width: 0 };
 
   const MAX_SELF_HEIGHT = DRAGGABLE_HEIGHT * 2;
 
@@ -34,7 +42,7 @@ export const getHitboxStyles = ({ direction, zoneDepth, domRect }: Params): CSSP
       return {
         width,
         height: HEIGHT,
-        top: top - calcOffsetDepth(zoneDepth) - scrollY,
+        top: top + offsetHeight - calcOffsetDepth(zoneDepth) - scrollY,
         left,
         zIndex: 100 + zoneDepth,
       };
@@ -42,7 +50,7 @@ export const getHitboxStyles = ({ direction, zoneDepth, domRect }: Params): CSSP
       return {
         width,
         height: HEIGHT,
-        top: bottom + calcOffsetDepth(zoneDepth) - scrollY,
+        top: bottom + offsetHeight + calcOffsetDepth(zoneDepth) - scrollY,
         left,
         zIndex: 100 + zoneDepth,
       };
@@ -50,7 +58,7 @@ export const getHitboxStyles = ({ direction, zoneDepth, domRect }: Params): CSSP
       return {
         width: WIDTH,
         height: height - HEIGHT,
-        left: left - calcOffsetDepth(zoneDepth) - WIDTH / 2,
+        left: left + offsetWidth - calcOffsetDepth(zoneDepth) - WIDTH / 2,
         top: top + HEIGHT / 2 - scrollY,
         zIndex: 100 + zoneDepth,
       };
@@ -58,7 +66,7 @@ export const getHitboxStyles = ({ direction, zoneDepth, domRect }: Params): CSSP
       return {
         width: WIDTH,
         height: height - HEIGHT,
-        left: right - calcOffsetDepth(zoneDepth) - WIDTH / 2,
+        left: right + offsetWidth - calcOffsetDepth(zoneDepth) - WIDTH / 2,
         top: top + HEIGHT / 2 - scrollY,
         zIndex: 100 + zoneDepth,
       };


### PR DESCRIPTION
## Purpose

Ticket: https://contentful.atlassian.net/browse/ALT-561

Changes to Dropzones and Hitboxes to allow root-level structure components to be reparented other structure components on the canvas.

https://github.com/contentful/experience-builder/assets/8539634/57728ee6-3cc7-4198-96a2-98028284eef8

Video demonstrating that dropzones are activating as expected for different scenarios:
* Adding a new structure component 
* Adding a new basic component
* Moving a basic component
* Moving a structure component (the bug being fixed)
