### PR TITLE
fix: don't track errors thrown from imported components [SPA-1995]

### DIFF
--- a/packages/experience-builder-sdk/src/components/ErrorBoundary.tsx
+++ b/packages/experience-builder-sdk/src/components/ErrorBoundary.tsx
@@ -3,8 +3,6 @@ import { sendMessage } from '@contentful/experiences-core';
 import '../styles/ErrorBoundary.css';
 import { OUTGOING_EVENTS } from '@contentful/experiences-core/constants';
 
-class ImportedComponentError extends Error {}
-
 export class ErrorBoundary extends React.Component<
   { children: ReactElement },
   { hasError: boolean; error: Error | null; errorInfo: ErrorInfo | null; showErrorDetails: boolean }
@@ -20,7 +18,7 @@ export class ErrorBoundary extends React.Component<
 
   componentDidCatch(error: Error, errorInfo: ErrorInfo) {
     this.setState({ error, errorInfo });
-    if (!(error instanceof ImportedComponentError)) {
+    if (error.name !== 'ImportedComponentError') {
       sendMessage(OUTGOING_EVENTS.CanvasError, error);
     } else {
       throw error;
@@ -64,18 +62,6 @@ export class ErrorBoundary extends React.Component<
         </div>
       );
     }
-    return this.props.children;
-  }
-}
-
-export class ImportedComponentErrorBoundary extends React.Component<{ children: ReactElement }> {
-  componentDidCatch(error: Error, _errorInfo: ErrorInfo) {
-    const err = new ImportedComponentError(error.message);
-    err.stack = error.stack;
-    throw err;
-  }
-
-  render() {
     return this.props.children;
   }
 }

--- a/packages/visual-editor/src/components/Dropzone/ImportedComponentErrorBoundary.tsx
+++ b/packages/visual-editor/src/components/Dropzone/ImportedComponentErrorBoundary.tsx
@@ -1,0 +1,20 @@
+import React, { ErrorInfo, ReactElement } from 'react';
+
+class ImportedComponentError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ImportedComponentError';
+  }
+}
+
+export class ImportedComponentErrorBoundary extends React.Component<{ children: ReactElement }> {
+  componentDidCatch(error: Error, _errorInfo: ErrorInfo) {
+    const err = new ImportedComponentError(error.message);
+    err.stack = error.stack;
+    throw err;
+  }
+
+  render() {
+    return this.props.children;
+  }
+}

--- a/packages/visual-editor/src/components/Dropzone/useComponent.ts
+++ b/packages/visual-editor/src/components/Dropzone/useComponent.ts
@@ -13,6 +13,7 @@ import { componentRegistry, createAssemblyRegistration } from '@/store/registrie
 import { useEntityStore } from '@/store/entityStore';
 import type { RenderDropzoneFunction } from './Dropzone.types';
 import { NoWrapDraggableProps } from '@components/Draggable/DraggableChildComponent';
+import { ImportedComponentErrorBoundary } from './ImportedComponentErrorBoundary';
 
 type UseComponentProps = {
   node: ExperienceTreeNode;
@@ -78,7 +79,12 @@ export const useComponent = ({
     : node.type === ASSEMBLY_NODE_TYPE
       ? // Assembly.tsx requires renderDropzone and editorMode as well
         () => React.createElement(componentRegistration.component, componentProps)
-      : () => React.createElement(componentRegistration.component, otherComponentProps);
+      : () =>
+          React.createElement(
+            ImportedComponentErrorBoundary,
+            null,
+            React.createElement(componentRegistration.component, otherComponentProps),
+          );
 
   return {
     node,


### PR DESCRIPTION
## Purpose

Wrap custom component in their own error boundary to make it possible to separate errors coming from imported components vs our own SDK code.