### PR TITLE
fix: activate original dropzone when moving root-level components [ALT-746]

### DIFF
--- a/packages/core/src/utils/styleUtils/stylesUtils.ts
+++ b/packages/core/src/utils/styleUtils/stylesUtils.ts
@@ -100,7 +100,7 @@ export const buildCfStyles = (
 };
 /**
  * Container/section default behavior:
- * Default height => height: EMPTY_CONTAINER_HEIGHT (120px)
+ * Default height => height: EMPTY_CONTAINER_HEIGHT
  * If a container component has children => height: 'fit-content'
  */
 export const calculateNodeDefaultHeight = ({

--- a/packages/visual-editor/src/components/Dropzone/Hitboxes.tsx
+++ b/packages/visual-editor/src/components/Dropzone/Hitboxes.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import styles from './styles.module.css';
 import { useTreeStore } from '@/store/tree';
 import { getItemDepthFromNode } from '@/utils/getItem';
@@ -22,38 +22,27 @@ const Hitboxes: React.FC<Props> = ({ zoneId, parentZoneId, isEmptyZone }) => {
     () => getItemDepthFromNode({ id: parentZoneId }, tree.root),
     [tree, parentZoneId],
   );
-  const [fetchDomRect, setFetchDomRect] = useState(Date.now());
-  const { zones, hoveringZone } = useZoneStore();
+  const zones = useZoneStore((state) => state.zones);
+  const hoveringZone = useZoneStore((state) => state.hoveringZone);
   const isHoveringZone = hoveringZone === zoneId;
-
-  useEffect(() => {
-    /**
-     * A bit hacky but we need to wait a very small amount
-     * of time to fetch the dom getBoundingClientRect once a
-     * drag starts because we need pre-drag styles like padding
-     * applied before we calculate positions of hitboxes
-     */
-    setTimeout(() => {
-      setFetchDomRect(Date.now());
-    }, 50);
-  }, [isDraggingOnCanvas]);
 
   const hitboxContainer = useMemo(() => {
     return document.querySelector('[data-ctfl-hitboxes]');
   }, []);
 
   const domRect = useMemo(() => {
+    if (!isDraggingOnCanvas) return;
     return document.querySelector(`[${CTFL_ZONE_ID}="${zoneId}"]`)?.getBoundingClientRect();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [zoneId, fetchDomRect]);
+  }, [zoneId, isDraggingOnCanvas]);
 
   // Use the size of the cloned dragging element to offset the position of the hitboxes
   // So that when dragging causes a dropzone to expand, the hitboxes will be in the correct position
   const offsetRect = useMemo(() => {
-    if (isEmptyZone || !isHoveringZone) return;
+    if (!isDraggingOnCanvas || isEmptyZone || !isHoveringZone) return;
     return document.querySelector(`[${CTFL_DRAGGING_ELEMENT}]`)?.getBoundingClientRect();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isEmptyZone, isHoveringZone, fetchDomRect]);
+  }, [isEmptyZone, isHoveringZone, isDraggingOnCanvas]);
 
   const zoneDirection = zones[parentZoneId]?.direction || 'vertical';
   const isVertical = zoneDirection === 'vertical';

--- a/packages/visual-editor/src/components/Dropzone/useComponentProps.ts
+++ b/packages/visual-editor/src/components/Dropzone/useComponentProps.ts
@@ -206,7 +206,6 @@ export const useComponentProps = ({
       }),
       ...(userIsDragging &&
         isContentfulStructureComponent(node?.data.blockId) &&
-        node?.data.blockId !== CONTENTFUL_COMPONENTS.divider.id &&
         node?.data.blockId !== CONTENTFUL_COMPONENTS.columns.id && {
           padding: addExtraDropzonePadding(componentStyles.padding?.toString() || '0 0 0 0'),
         }),

--- a/packages/visual-editor/src/components/RootRenderer/TestDNDContainer.tsx
+++ b/packages/visual-editor/src/components/RootRenderer/TestDNDContainer.tsx
@@ -4,6 +4,7 @@ import {
   DropResult,
   OnBeforeDragStartResponder,
   OnDragEndResponder,
+  OnDragStartResponder,
   OnDragUpdateResponder,
   ResponderProvided,
 } from '@hello-pangea/dnd';
@@ -12,12 +13,14 @@ import React from 'react';
 interface TestDNDContainerProps extends React.PropsWithChildren {
   onDragUpdate: OnDragUpdateResponder;
   onBeforeDragStart: OnBeforeDragStartResponder;
+  onDragStart: OnDragStartResponder;
   onDragEnd: OnDragEndResponder;
 }
 
 const TestDNDContainer: React.FC<TestDNDContainerProps> = ({
   onDragEnd,
   onBeforeDragStart,
+  onDragStart,
   onDragUpdate,
   children,
 }) => {
@@ -30,6 +33,7 @@ const TestDNDContainer: React.FC<TestDNDContainerProps> = ({
       source: draggedItem.source,
     };
     onBeforeDragStart(start);
+    onDragStart(start, {} as ResponderProvided);
   };
 
   const handleDrag = (event: React.DragEvent<HTMLDivElement>) => {

--- a/packages/visual-editor/src/hooks/useDraggablePosition.ts
+++ b/packages/visual-editor/src/hooks/useDraggablePosition.ts
@@ -35,5 +35,5 @@ export default function useDraggablePosition({ draggableId, draggableRef, positi
     el.style.top = `${top}px`;
     el.style.width = `${domRect.width}px`;
     el.style.height = `${domRect.height}px`;
-  }, [draggableRef, draggableId, draggingId, position, preDragDomRect, isDraggingOnCanvas]);
+  }, [draggableRef, draggableId, isDraggingOnCanvas, draggingId, position, preDragDomRect]);
 }

--- a/packages/visual-editor/src/hooks/useDraggablePosition.ts
+++ b/packages/visual-editor/src/hooks/useDraggablePosition.ts
@@ -1,5 +1,5 @@
 import { useDraggedItemStore } from '@/store/draggedItem';
-import { DraggablePosition } from '@/types/constants';
+import { CTFL_DRAGGING_ELEMENT, DraggablePosition } from '@/types/constants';
 import { MutableRefObject, useEffect } from 'react';
 
 interface Params {
@@ -14,7 +14,8 @@ export default function useDraggablePosition({ draggableId, draggableRef, positi
   const preDragDomRect = useDraggedItemStore((state) => state.domRect);
 
   useEffect(() => {
-    const el: HTMLElement | null = draggableRef?.current;
+    const el: HTMLElement | null =
+      draggableRef?.current ?? document.querySelector(`[${CTFL_DRAGGING_ELEMENT}]`);
 
     if (!isDraggingOnCanvas || draggingId !== draggableId || !el) {
       return;
@@ -34,5 +35,5 @@ export default function useDraggablePosition({ draggableId, draggableRef, positi
     el.style.top = `${top}px`;
     el.style.width = `${domRect.width}px`;
     el.style.height = `${domRect.height}px`;
-  }, [draggableRef, draggableId, isDraggingOnCanvas, draggingId, position, preDragDomRect]);
+  }, [draggableRef, draggableId, draggingId, position, preDragDomRect, isDraggingOnCanvas]);
 }

--- a/packages/visual-editor/src/hooks/useDraggablePosition.ts
+++ b/packages/visual-editor/src/hooks/useDraggablePosition.ts
@@ -15,7 +15,8 @@ export default function useDraggablePosition({ draggableId, draggableRef, positi
 
   useEffect(() => {
     const el: HTMLElement | null =
-      draggableRef?.current ?? document.querySelector(`[${CTFL_DRAGGING_ELEMENT}]`);
+      draggableRef?.current ??
+      document.querySelector(`[${CTFL_DRAGGING_ELEMENT}][data-cf-node-id="${draggableId}"]`);
 
     if (!isDraggingOnCanvas || draggingId !== draggableId || !el) {
       return;

--- a/packages/visual-editor/src/utils/getHitboxStyles.ts
+++ b/packages/visual-editor/src/utils/getHitboxStyles.ts
@@ -66,7 +66,7 @@ export const getHitboxStyles = ({
       return {
         width: WIDTH,
         height: height - HEIGHT,
-        left: right + offsetWidth - calcOffsetDepth(zoneDepth) - WIDTH / 2,
+        left: right + offsetWidth + calcOffsetDepth(zoneDepth) - WIDTH / 2,
         top: top + HEIGHT / 2 - scrollY,
         zIndex: 100 + zoneDepth,
       };
@@ -91,7 +91,7 @@ export const getHitboxStyles = ({
       return {
         width: width - DRAGGABLE_WIDTH * 2,
         height,
-        left: left + (DRAGGABLE_WIDTH * 2) / 2,
+        left: left + DRAGGABLE_WIDTH,
         top: top - scrollY,
         zIndex: 1000 + zoneDepth,
       };


### PR DESCRIPTION
## Purpose

This change fixes Issue 2 in [ALT-746](https://contentful.atlassian.net/browse/ALT-746) 🐛

I found that the issue was a result of setting the drag state via calling `setDraggingOnCanvas(true)` in the DNDProvider's `onBeforeCapture` - which is before the dimensions have been captured from the DOM based on the [docs](https://github.com/hello-pangea/dnd/blob/main/docs/guides/responders.md#life-cycle-%EF%B8%8F)

To fix the main issue, I moved this call to set the drag state in DNDProvider's `onBeforeDragStart` responder instead so that it won't happen until the DND capture phase has completed.

After that change, the dropzone where the root-level component was picked up from starts activating as expected when moving the dragged component around and then trying to move it back to its original location.

A new issue started happening -- when picking up a component on the canvas the `useDraggablePosition` hook was not adjusting the dragged component position to match the mouse coordinates offset as expected.  I made a small change in that hook to correct that.

https://github.com/contentful/experience-builder/assets/8539634/bbf5d06e-2086-4ff6-9101-44f171f52c10

Another thing to call out -- the blue Placeholder that renders when a dropzone activates does not render when moving a root-level component back to its original location. I looked into that and believe it's because the Placeholder is [part of the DraggableComponent](https://github.com/contentful/experience-builder/blob/55621c603646d8ac1c3da8083881fca5d4c9da5f/packages/visual-editor/src/components/Draggable/DraggableComponent.tsx#L117) which is picked up when dragging. So basically, the blue dropzone Placeholder is no longer on the canvas when you are dragging the component that it relates to.

I'm not exactly sure how to resolve that so I'll open a separate ticket for it.


[ALT-746]: https://contentful.atlassian.net/browse/ALT-746?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ