### PR TITLE
Release@next

### DIFF
--- a/packages/experience-builder-sdk/src/components/ErrorBoundary.tsx
+++ b/packages/experience-builder-sdk/src/components/ErrorBoundary.tsx
@@ -3,8 +3,6 @@ import { sendMessage } from '@contentful/experiences-core';
 import '../styles/ErrorBoundary.css';
 import { OUTGOING_EVENTS } from '@contentful/experiences-core/constants';
 
-class ImportedComponentError extends Error {}
-
 export class ErrorBoundary extends React.Component<
   { children: ReactElement },
   { hasError: boolean; error: Error | null; errorInfo: ErrorInfo | null; showErrorDetails: boolean }
@@ -20,7 +18,7 @@ export class ErrorBoundary extends React.Component<
 
   componentDidCatch(error: Error, errorInfo: ErrorInfo) {
     this.setState({ error, errorInfo });
-    if (!(error instanceof ImportedComponentError)) {
+    if (error.name !== 'ImportedComponentError') {
       sendMessage(OUTGOING_EVENTS.CanvasError, error);
     } else {
       throw error;
@@ -64,18 +62,6 @@ export class ErrorBoundary extends React.Component<
         </div>
       );
     }
-    return this.props.children;
-  }
-}
-
-export class ImportedComponentErrorBoundary extends React.Component<{ children: ReactElement }> {
-  componentDidCatch(error: Error, _errorInfo: ErrorInfo) {
-    const err = new ImportedComponentError(error.message);
-    err.stack = error.stack;
-    throw err;
-  }
-
-  render() {
     return this.props.children;
   }
 }

--- a/packages/visual-editor/src/components/Dropzone/ImportedComponentErrorBoundary.tsx
+++ b/packages/visual-editor/src/components/Dropzone/ImportedComponentErrorBoundary.tsx
@@ -1,0 +1,20 @@
+import React, { ErrorInfo, ReactElement } from 'react';
+
+class ImportedComponentError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ImportedComponentError';
+  }
+}
+
+export class ImportedComponentErrorBoundary extends React.Component<{ children: ReactElement }> {
+  componentDidCatch(error: Error, _errorInfo: ErrorInfo) {
+    const err = new ImportedComponentError(error.message);
+    err.stack = error.stack;
+    throw err;
+  }
+
+  render() {
+    return this.props.children;
+  }
+}

--- a/packages/visual-editor/src/components/Dropzone/useComponent.ts
+++ b/packages/visual-editor/src/components/Dropzone/useComponent.ts
@@ -13,6 +13,7 @@ import { componentRegistry, createAssemblyRegistration } from '@/store/registrie
 import { useEntityStore } from '@/store/entityStore';
 import type { RenderDropzoneFunction } from './Dropzone.types';
 import { NoWrapDraggableProps } from '@components/Draggable/DraggableChildComponent';
+import { ImportedComponentErrorBoundary } from './ImportedComponentErrorBoundary';
 
 type UseComponentProps = {
   node: ExperienceTreeNode;
@@ -78,7 +79,12 @@ export const useComponent = ({
     : node.type === ASSEMBLY_NODE_TYPE
       ? // Assembly.tsx requires renderDropzone and editorMode as well
         () => React.createElement(componentRegistration.component, componentProps)
-      : () => React.createElement(componentRegistration.component, otherComponentProps);
+      : () =>
+          React.createElement(
+            ImportedComponentErrorBoundary,
+            null,
+            React.createElement(componentRegistration.component, otherComponentProps),
+          );
 
   return {
     node,

--- a/packages/visual-editor/src/components/RootRenderer/RootRenderer.tsx
+++ b/packages/visual-editor/src/components/RootRenderer/RootRenderer.tsx
@@ -4,7 +4,7 @@ import { Dropzone } from '../Dropzone/Dropzone';
 import DraggableContainer from '../Draggable/DraggableComponentList';
 import type { ExperienceTree } from '@contentful/experiences-core/types';
 
-import { COMPONENT_LIST_ID, DRAGGABLE_HEIGHT, ROOT_ID } from '@/types/constants';
+import { DRAGGABLE_HEIGHT, ROOT_ID } from '@/types/constants';
 import { useTreeStore } from '@/store/tree';
 import { useDraggedItemStore } from '@/store/draggedItem';
 import styles from './render.module.css';
@@ -26,8 +26,6 @@ export const RootRenderer: React.FC<Props> = ({ onChange }) => {
   const userIsDragging = useDraggedItemStore((state) => state.isDraggingOnCanvas);
   const breakpoints = useTreeStore((state) => state.breakpoints);
   const setSelectedNodeId = useEditorStore((state) => state.setSelectedNodeId);
-  const draggableSourceId = useDraggedItemStore((state) => state.draggedItem?.source.droppableId);
-  const draggingNewComponent = !!draggableSourceId?.startsWith(COMPONENT_LIST_ID);
   const containerRef = useRef<HTMLDivElement>(null);
   const { resolveDesignValue } = useBreakpoints(breakpoints);
   const [containerStyles, setContainerStyles] = useState<CSSProperties>({});
@@ -108,23 +106,10 @@ export const RootRenderer: React.FC<Props> = ({ onChange }) => {
   return (
     <DNDProvider>
       {dragItem && <DraggableContainer id={dragItem} />}
-
       <div data-ctfl-root className={styles.container} ref={containerRef} style={containerStyles}>
-        {/* 
-          This hitbox is required so that users can
-          add sections to the top of the document.
-        */}
-        {userIsDragging && draggingNewComponent && (
-          <div className={styles.hitbox} data-ctfl-zone-id={ROOT_ID} />
-        )}
+        {userIsDragging && <div data-ctfl-zone-id={ROOT_ID} className={styles.hitbox} />}
         <Dropzone zoneId={ROOT_ID} resolveDesignValue={resolveDesignValue} />
-        {/* 
-          This hitbox is required so that users can
-          add sections to the bottom of the document.
-        */}
-        {userIsDragging && draggingNewComponent && (
-          <div data-ctfl-zone-id={ROOT_ID} className={styles.hitboxLower} />
-        )}
+        {userIsDragging && <div data-ctfl-zone-id={ROOT_ID} className={styles.hitboxLower} />}
       </div>
       <div data-ctfl-hitboxes />
     </DNDProvider>


### PR DESCRIPTION
## Purpose

* [fix: don't track errors thrown from imported components](https://github.com/contentful/experience-builder/commit/070360f1910c73ba0c81e2d24b9c64fb812cdf32)
* [fix(visual-editor): allow first and last root dropzones to activate when moving components](https://github.com/contentful/experience-builder/commit/090181e7f923a7146b1dc4af181c2f3c4fb3e02e)