### PR TITLE
Release@main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.0.6-beta.0](https://github.com/contentful/experience-builder/compare/v1.0.5...v1.0.6-beta.0) (2024-04-18)
+
+### Bug Fixes
+
+- don't track errors thrown from imported components ([070360f](https://github.com/contentful/experience-builder/commit/070360f1910c73ba0c81e2d24b9c64fb812cdf32))
+- **visual-editor:** allow first and last root dropzones to activate when moving components [ALT-746] ([#571](https://github.com/contentful/experience-builder/issues/571)) ([090181e](https://github.com/contentful/experience-builder/commit/090181e7f923a7146b1dc4af181c2f3c4fb3e02e))
+
 ## [1.0.5](https://github.com/contentful/experience-builder/compare/v1.0.5-beta.0...v1.0.5) (2024-04-16)
 
 **Note:** Version bump only for package @contentful/experience

--- a/lerna.json
+++ b/lerna.json
@@ -1,7 +1,7 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
   "npmClient": "npm",
-  "version": "1.0.5",
+  "version": "1.0.6-beta.0",
   "command": {
     "version": {
       "allowBranch": ["main", "next", "development"],

--- a/package-lock.json
+++ b/package-lock.json
@@ -42365,7 +42365,7 @@
     },
     "packages/components": {
       "name": "@contentful/experiences-components-react",
-      "version": "1.0.5",
+      "version": "1.0.6-beta.0",
       "license": "MIT",
       "dependencies": {
         "@contentful/experiences-core": "file:../core",
@@ -42560,7 +42560,7 @@
     },
     "packages/core": {
       "name": "@contentful/experiences-core",
-      "version": "1.0.5",
+      "version": "1.0.6-beta.0",
       "license": "MIT",
       "dependencies": {
         "@contentful/experiences-validators": "file:../validators",
@@ -42763,7 +42763,7 @@
     },
     "packages/experience-builder-sdk": {
       "name": "@contentful/experiences-sdk-react",
-      "version": "1.0.5",
+      "version": "1.0.6-beta.0",
       "license": "MIT",
       "dependencies": {
         "@contentful/experiences-components-react": "file:../components",
@@ -43067,7 +43067,7 @@
     },
     "packages/validators": {
       "name": "@contentful/experiences-validators",
-      "version": "1.0.5",
+      "version": "1.0.6-beta.0",
       "dependencies": {
         "zod": "^3.22.4"
       },
@@ -43171,7 +43171,7 @@
     },
     "packages/visual-editor": {
       "name": "@contentful/experiences-visual-editor-react",
-      "version": "1.0.5",
+      "version": "1.0.6-beta.0",
       "dependencies": {
         "@contentful/experiences-components-react": "file:../components",
         "@contentful/experiences-core": "file:../core",

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.0.6-beta.0](https://github.com/contentful/experience-builder/compare/v1.0.5...v1.0.6-beta.0) (2024-04-18)
+
+**Note:** Version bump only for package @contentful/experiences-components-react
+
 ## [1.0.5](https://github.com/contentful/experience-builder/compare/v1.0.5-beta.0...v1.0.5) (2024-04-16)
 
 **Note:** Version bump only for package @contentful/experiences-components-react

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contentful/experiences-components-react",
-  "version": "1.0.5",
+  "version": "1.0.6-beta.0",
   "description": "A basic set of components to use with Studio Experiences",
   "homepage": "https://github.com/contentful/experience-builder/tree/next/packages/components#readme",
   "repository": {

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.0.6-beta.0](https://github.com/contentful/experience-builder/compare/v1.0.5...v1.0.6-beta.0) (2024-04-18)
+
+**Note:** Version bump only for package @contentful/experiences-core
+
 ## [1.0.5](https://github.com/contentful/experience-builder/compare/v1.0.5-beta.0...v1.0.5) (2024-04-16)
 
 **Note:** Version bump only for package @contentful/experiences-core

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contentful/experiences-core",
-  "version": "1.0.5",
+  "version": "1.0.6-beta.0",
   "description": "",
   "main": "dist/index.js",
   "module": "dist/index.js",

--- a/packages/experience-builder-sdk/CHANGELOG.md
+++ b/packages/experience-builder-sdk/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.0.6-beta.0](https://github.com/contentful/experience-builder/compare/v1.0.5...v1.0.6-beta.0) (2024-04-18)
+
+### Bug Fixes
+
+- don't track errors thrown from imported components ([070360f](https://github.com/contentful/experience-builder/commit/070360f1910c73ba0c81e2d24b9c64fb812cdf32))
+
 ## [1.0.5](https://github.com/contentful/experience-builder/compare/v1.0.5-beta.0...v1.0.5) (2024-04-16)
 
 **Note:** Version bump only for package @contentful/experiences-sdk-react

--- a/packages/experience-builder-sdk/package.json
+++ b/packages/experience-builder-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contentful/experiences-sdk-react",
-  "version": "1.0.5",
+  "version": "1.0.6-beta.0",
   "main": "./dist/index.js",
   "module": "./dist/index.js",
   "typings": "./dist/src/index.d.ts",

--- a/packages/experience-builder-sdk/src/components/ErrorBoundary.tsx
+++ b/packages/experience-builder-sdk/src/components/ErrorBoundary.tsx
@@ -3,8 +3,6 @@ import { sendMessage } from '@contentful/experiences-core';
 import '../styles/ErrorBoundary.css';
 import { OUTGOING_EVENTS } from '@contentful/experiences-core/constants';
 
-class ImportedComponentError extends Error {}
-
 export class ErrorBoundary extends React.Component<
   { children: ReactElement },
   { hasError: boolean; error: Error | null; errorInfo: ErrorInfo | null; showErrorDetails: boolean }
@@ -20,7 +18,7 @@ export class ErrorBoundary extends React.Component<
 
   componentDidCatch(error: Error, errorInfo: ErrorInfo) {
     this.setState({ error, errorInfo });
-    if (!(error instanceof ImportedComponentError)) {
+    if (error.name !== 'ImportedComponentError') {
       sendMessage(OUTGOING_EVENTS.CanvasError, error);
     } else {
       throw error;
@@ -64,18 +62,6 @@ export class ErrorBoundary extends React.Component<
         </div>
       );
     }
-    return this.props.children;
-  }
-}
-
-export class ImportedComponentErrorBoundary extends React.Component<{ children: ReactElement }> {
-  componentDidCatch(error: Error, _errorInfo: ErrorInfo) {
-    const err = new ImportedComponentError(error.message);
-    err.stack = error.stack;
-    throw err;
-  }
-
-  render() {
     return this.props.children;
   }
 }

--- a/packages/validators/CHANGELOG.md
+++ b/packages/validators/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.0.6-beta.0](https://github.com/contentful/experience-builder/compare/v1.0.5...v1.0.6-beta.0) (2024-04-18)
+
+**Note:** Version bump only for package @contentful/experiences-validators
+
 ## [1.0.5](https://github.com/contentful/experience-builder/compare/v1.0.5-beta.0...v1.0.5) (2024-04-16)
 
 **Note:** Version bump only for package @contentful/experiences-validators

--- a/packages/validators/package.json
+++ b/packages/validators/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contentful/experiences-validators",
-  "version": "1.0.5",
+  "version": "1.0.6-beta.0",
   "main": "./dist/index.js",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/visual-editor/CHANGELOG.md
+++ b/packages/visual-editor/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.0.6-beta.0](https://github.com/contentful/experience-builder/compare/v1.0.5...v1.0.6-beta.0) (2024-04-18)
+
+### Bug Fixes
+
+- don't track errors thrown from imported components ([070360f](https://github.com/contentful/experience-builder/commit/070360f1910c73ba0c81e2d24b9c64fb812cdf32))
+- **visual-editor:** allow first and last root dropzones to activate when moving components [ALT-746] ([#571](https://github.com/contentful/experience-builder/issues/571)) ([090181e](https://github.com/contentful/experience-builder/commit/090181e7f923a7146b1dc4af181c2f3c4fb3e02e))
+
 ## [1.0.5](https://github.com/contentful/experience-builder/compare/v1.0.5-beta.0...v1.0.5) (2024-04-16)
 
 **Note:** Version bump only for package @contentful/experiences-visual-editor-react

--- a/packages/visual-editor/package.json
+++ b/packages/visual-editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contentful/experiences-visual-editor-react",
-  "version": "1.0.5",
+  "version": "1.0.6-beta.0",
   "type": "module",
   "main": "./dist/index.js",
   "module": "./dist/index.js",

--- a/packages/visual-editor/src/components/Dropzone/ImportedComponentErrorBoundary.tsx
+++ b/packages/visual-editor/src/components/Dropzone/ImportedComponentErrorBoundary.tsx
@@ -1,0 +1,20 @@
+import React, { ErrorInfo, ReactElement } from 'react';
+
+class ImportedComponentError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ImportedComponentError';
+  }
+}
+
+export class ImportedComponentErrorBoundary extends React.Component<{ children: ReactElement }> {
+  componentDidCatch(error: Error, _errorInfo: ErrorInfo) {
+    const err = new ImportedComponentError(error.message);
+    err.stack = error.stack;
+    throw err;
+  }
+
+  render() {
+    return this.props.children;
+  }
+}

--- a/packages/visual-editor/src/components/Dropzone/useComponent.ts
+++ b/packages/visual-editor/src/components/Dropzone/useComponent.ts
@@ -13,6 +13,7 @@ import { componentRegistry, createAssemblyRegistration } from '@/store/registrie
 import { useEntityStore } from '@/store/entityStore';
 import type { RenderDropzoneFunction } from './Dropzone.types';
 import { NoWrapDraggableProps } from '@components/Draggable/DraggableChildComponent';
+import { ImportedComponentErrorBoundary } from './ImportedComponentErrorBoundary';
 
 type UseComponentProps = {
   node: ExperienceTreeNode;
@@ -78,7 +79,12 @@ export const useComponent = ({
     : node.type === ASSEMBLY_NODE_TYPE
       ? // Assembly.tsx requires renderDropzone and editorMode as well
         () => React.createElement(componentRegistration.component, componentProps)
-      : () => React.createElement(componentRegistration.component, otherComponentProps);
+      : () =>
+          React.createElement(
+            ImportedComponentErrorBoundary,
+            null,
+            React.createElement(componentRegistration.component, otherComponentProps),
+          );
 
   return {
     node,

--- a/packages/visual-editor/src/components/RootRenderer/RootRenderer.tsx
+++ b/packages/visual-editor/src/components/RootRenderer/RootRenderer.tsx
@@ -4,7 +4,7 @@ import { Dropzone } from '../Dropzone/Dropzone';
 import DraggableContainer from '../Draggable/DraggableComponentList';
 import type { ExperienceTree } from '@contentful/experiences-core/types';
 
-import { COMPONENT_LIST_ID, DRAGGABLE_HEIGHT, ROOT_ID } from '@/types/constants';
+import { DRAGGABLE_HEIGHT, ROOT_ID } from '@/types/constants';
 import { useTreeStore } from '@/store/tree';
 import { useDraggedItemStore } from '@/store/draggedItem';
 import styles from './render.module.css';
@@ -26,8 +26,6 @@ export const RootRenderer: React.FC<Props> = ({ onChange }) => {
   const userIsDragging = useDraggedItemStore((state) => state.isDraggingOnCanvas);
   const breakpoints = useTreeStore((state) => state.breakpoints);
   const setSelectedNodeId = useEditorStore((state) => state.setSelectedNodeId);
-  const draggableSourceId = useDraggedItemStore((state) => state.draggedItem?.source.droppableId);
-  const draggingNewComponent = !!draggableSourceId?.startsWith(COMPONENT_LIST_ID);
   const containerRef = useRef<HTMLDivElement>(null);
   const { resolveDesignValue } = useBreakpoints(breakpoints);
   const [containerStyles, setContainerStyles] = useState<CSSProperties>({});
@@ -108,23 +106,10 @@ export const RootRenderer: React.FC<Props> = ({ onChange }) => {
   return (
     <DNDProvider>
       {dragItem && <DraggableContainer id={dragItem} />}
-
       <div data-ctfl-root className={styles.container} ref={containerRef} style={containerStyles}>
-        {/* 
-          This hitbox is required so that users can
-          add sections to the top of the document.
-        */}
-        {userIsDragging && draggingNewComponent && (
-          <div className={styles.hitbox} data-ctfl-zone-id={ROOT_ID} />
-        )}
+        {userIsDragging && <div data-ctfl-zone-id={ROOT_ID} className={styles.hitbox} />}
         <Dropzone zoneId={ROOT_ID} resolveDesignValue={resolveDesignValue} />
-        {/* 
-          This hitbox is required so that users can
-          add sections to the bottom of the document.
-        */}
-        {userIsDragging && draggingNewComponent && (
-          <div data-ctfl-zone-id={ROOT_ID} className={styles.hitboxLower} />
-        )}
+        {userIsDragging && <div data-ctfl-zone-id={ROOT_ID} className={styles.hitboxLower} />}
       </div>
       <div data-ctfl-hitboxes />
     </DNDProvider>


### PR DESCRIPTION
## Purpose

* [fix: don't track errors thrown from imported components](https://github.com/contentful/experience-builder/commit/070360f1910c73ba0c81e2d24b9c64fb812cdf32)
* [fix(visual-editor): allow first and last root dropzones to activate when moving components](https://github.com/contentful/experience-builder/commit/090181e7f923a7146b1dc4af181c2f3c4fb3e02e)