### PR TITLE
fix(visual-editor): extra dropzone padding when dragging [ALT-746]

### DIFF
--- a/packages/visual-editor/src/components/Dropzone/useComponentProps.ts
+++ b/packages/visual-editor/src/components/Dropzone/useComponentProps.ts
@@ -239,13 +239,7 @@ export const useComponentProps = ({
 const addExtraDropzonePadding = (padding: string) =>
   padding
     .split(' ')
-    .map((value) => {
-      const numericValue = parseFloat(value);
-      const unit = value.replace(numericValue.toString(), '');
-
-      if (numericValue === 0 || (unit === 'px' && numericValue < 4)) {
-        return `${DRAG_PADDING}px`;
-      }
-      return value;
-    })
+    .map((value) =>
+      parseFloat(value) === 0 ? `${DRAG_PADDING}px` : `calc(${value} + ${DRAG_PADDING}px)`,
+    )
     .join(' ');

--- a/packages/visual-editor/src/components/Dropzone/useComponentProps.ts
+++ b/packages/visual-editor/src/components/Dropzone/useComponentProps.ts
@@ -240,10 +240,12 @@ const addExtraDropzonePadding = (padding: string) =>
   padding
     .split(' ')
     .map((value) => {
-      if (value.endsWith('px')) {
-        const parsedValue = parseInt(value.replace(/px$/, ''), 10);
-        return (parsedValue < DRAG_PADDING ? DRAG_PADDING : parsedValue) + 'px';
+      const numericValue = parseFloat(value);
+      const unit = value.replace(numericValue.toString(), '');
+
+      if (numericValue === 0 || (unit === 'px' && numericValue < 4)) {
+        return `${DRAG_PADDING}px`;
       }
-      return `${DRAG_PADDING}px`;
+      return value;
     })
     .join(' ');


### PR DESCRIPTION
## Purpose

Fixes an issue in the `addExtraDropzonePadding` method that causes structure components with non-pixel padding values to be overwritten with `4px` padding (via `DRAG_PADDING` const) when dragging components.

For example, this section has `5%` left/right padding, and when starting to drag the padding is changed to `4px` (to show the bug that was happening before the change)

https://github.com/contentful/experience-builder/assets/8539634/902c873d-0a55-4123-897d-68afebcf1951

With this change, only the sides with 0 padding or a pixel value less than 4px will be adjusted to 4px padding:

https://github.com/contentful/experience-builder/assets/8539634/6d3784b2-cf2d-4175-ad4c-c4b407e696ac

The purpose of this `addExtraDropzonePadding` method is to add a little padding when dragging, so that dropzones will activate in structure components that have children elements taking up the full size of the component.
