### PR TITLE
[ALT-692] feat: update definitions of fill to use 100% for components

### DIFF
--- a/packages/core/src/definitions/styles.ts
+++ b/packages/core/src/definitions/styles.ts
@@ -82,7 +82,7 @@ export const builtInStyles: VariableDefinitions = {
     type: 'Text',
     group: 'style',
     description: 'The width of the section',
-    defaultValue: 'fill',
+    defaultValue: '100%',
   },
   cfHeight: {
     displayName: 'Height',
@@ -340,7 +340,7 @@ export const dividerBuiltInStyles: VariableDefinitions = {
     type: 'Text',
     group: 'style',
     description: 'The width of the divider',
-    defaultValue: 'fill',
+    defaultValue: '100%',
   },
   cfHeight: {
     displayName: 'Height',
@@ -485,7 +485,7 @@ export const columnsBuiltInStyles: VariableDefinitions = {
     type: 'Text',
     group: 'style',
     description: 'The width of the columns',
-    defaultValue: 'fill',
+    defaultValue: '100%',
   },
   cfMaxWidth: {
     displayName: 'Max width',

--- a/packages/core/src/utils/styleUtils/styleTransformers.ts
+++ b/packages/core/src/utils/styleUtils/styleTransformers.ts
@@ -7,6 +7,9 @@ import {
 } from '@/types';
 import { isContentfulStructureComponent } from '@/utils/components';
 
+// Keep this for backwards compatilibity - deleting this would be a breaking change
+// because existing components on a users experience will have the width value as fill
+// rather than 100%
 export const transformFill = (value?: string) => (value === 'fill' ? '100%' : value);
 
 export const transformGridColumn = (span?: string): CSSProperties => {


### PR DESCRIPTION
## Purpose
With the updates to the new input styles on Experiences canvas on the ui side, these fill values are no longer valid since the ui doesn't convert fill into a relative 100% option and is instead better to use the actual valid css value of 100%.

Note that in `styleTransformers.ts` this block of code was kept for backwards compatibility
```
// Keep this for backwards compatilibity - deleting this would be a breaking change
// because existing components on a users experience will have the width value as fill 
// rather than 100%
export const transformFill = (value?: string) => (value === 'fill' ? '100%' : value);
```