### PR TITLE
feat(components): add loading attribute to image component

### DIFF
--- a/packages/components/src/components/Image/Image.tsx
+++ b/packages/components/src/components/Image/Image.tsx
@@ -35,6 +35,7 @@ export const Image: React.FC<ImageProps> = ({ className = '', src, cfImageAsset,
         src={cfImageAsset.url}
         srcSet={cfImageAsset.srcSet?.length ? cfImageAsset.srcSet?.join(', ') : undefined}
         sizes={cfImageAsset.sizes ? cfImageAsset.sizes : undefined}
+        loading={cfImageAsset.loading}
         className={'cf-image ' + className}
         {...props}
       />

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -309,6 +309,7 @@ export type OptimizedImageAsset = {
   quality?: number;
   format?: string;
   file: AssetFile;
+  loading?: ImageLoadingOption;
 };
 
 export type OptimizedBackgroundImageAsset = {
@@ -334,10 +335,13 @@ export type ImageObjectPositionOption =
   | 'center center'
   | 'center bottom';
 
+export type ImageLoadingOption = 'lazy' | 'eager';
+
 export type ImageOptions = {
   format?: string;
   width: string;
   height: string;
+  loading?: ImageLoadingOption;
   objectFit?: ImageObjectFitOption;
   objectPosition?: ImageObjectPositionOption;
   quality?: string;

--- a/packages/core/src/utils/transformers/media/getOptimizedImageAsset.spec.ts
+++ b/packages/core/src/utils/transformers/media/getOptimizedImageAsset.spec.ts
@@ -16,25 +16,25 @@ describe('transformImageAsset', () => {
 
   it('when width of image is 250, should return a srcSet with 2 parts', () => {
     file.details.image!.width = 250;
-    const result = getOptimizedImageAsset(file, '500px');
+    const result = getOptimizedImageAsset({ file, sizes: '500px' });
     expect(result.srcSet).toEqual([`https:${file.url}?w=125 125w`, `https:${file.url}?w=250 250w`]);
   });
 
   it('when width of image is 500, should return a srcSet with 2 parts', () => {
     file.details.image!.width = 500;
-    const result = getOptimizedImageAsset(file, '500px');
+    const result = getOptimizedImageAsset({ file, sizes: '500px' });
     expect(result.srcSet).toEqual([`https:${file.url}?w=250 250w`, `https:${file.url}?w=500 500w`]);
   });
 
   it('when width of image is 525, should return a srcSet with 2 parts', () => {
     file.details.image!.width = 525;
-    const result = getOptimizedImageAsset(file, '500px');
+    const result = getOptimizedImageAsset({ file, sizes: '500px' });
     expect(result.srcSet).toEqual([`https:${file.url}?w=263 263w`, `https:${file.url}?w=525 525w`]);
   });
 
   it('when width of image is 1000, should return a srcSet with 2 parts', () => {
     file.details.image!.width = 1000;
-    const result = getOptimizedImageAsset(file, '500px');
+    const result = getOptimizedImageAsset({ file, sizes: '500px' });
     expect(result.srcSet).toEqual([
       `https:${file.url}?w=500 500w`,
       `https:${file.url}?w=1000 1000w`,
@@ -43,7 +43,7 @@ describe('transformImageAsset', () => {
 
   it('when width of image is 1500, should return a srcSet with 3 parts', () => {
     file.details.image!.width = 1500;
-    const result = getOptimizedImageAsset(file, '500px');
+    const result = getOptimizedImageAsset({ file, sizes: '500px' });
     expect(result.srcSet).toEqual([
       `https:${file.url}?w=500 500w`,
       `https:${file.url}?w=1000 1000w`,
@@ -53,7 +53,7 @@ describe('transformImageAsset', () => {
 
   it('when width of image is 4000, should return a srcSet with 9 equalish parts', () => {
     file.details.image!.width = 4000;
-    const result = getOptimizedImageAsset(file, '500px');
+    const result = getOptimizedImageAsset({ file, sizes: '500px' });
     expect(result.srcSet).toEqual([
       `https:${file.url}?w=500 500w`,
       `https:${file.url}?w=1000 1000w`,
@@ -68,7 +68,7 @@ describe('transformImageAsset', () => {
 
   it('when width of image is over 4000 width, should cap API calls to 4000 width and set the full image as the last in the srcSet', () => {
     file.details.image!.width = 5000;
-    const result = getOptimizedImageAsset(file, '500px');
+    const result = getOptimizedImageAsset({ file, sizes: '500px' });
     expect(result.srcSet).toEqual([
       `https:${file.url}?w=500 500w`,
       `https:${file.url}?w=1000 1000w`,
@@ -83,33 +83,35 @@ describe('transformImageAsset', () => {
   });
 
   it('when no sizes is passed, srcSet should be empty', () => {
-    const result = getOptimizedImageAsset(file);
+    const result = getOptimizedImageAsset({ file });
     expect(result.srcSet).toEqual([]);
   });
 
   it('the url should have a width limit of 2000 and quality of 80% when the image width is larger than 2000', () => {
     file.details.image!.width = 2500;
-    const result = getOptimizedImageAsset(file, '500px', '80%');
+    const result = getOptimizedImageAsset({ file, sizes: '500px', quality: '80%' });
     expect(result.url).toEqual(`https:${file.url}?w=2000&q=80`);
   });
 
   it('the url should have no width limit and quality of 80% when the image width is 800', () => {
-    const result = getOptimizedImageAsset(file, '500px', '80%');
+    const result = getOptimizedImageAsset({ file, sizes: '500px', quality: '80%' });
     expect(result.url).toEqual(`https:${file.url}?q=80`);
   });
 
   it('when there is no file on the asset, should throw an error', () => {
     file.details.image = undefined;
-    expect(() => getOptimizedImageAsset(file)).toThrowError('No image in file asset to transform');
+    expect(() => getOptimizedImageAsset({ file })).toThrowError(
+      'No image in file asset to transform',
+    );
   });
 
   it('when sizes is passed, the sizes should be on the return object', () => {
-    const result = getOptimizedImageAsset(file, '500px');
+    const result = getOptimizedImageAsset({ file, sizes: '500px' });
     expect(result.sizes).toEqual('500px');
   });
 
   it('when quality is passed, the quality should be on the srcSet urls', () => {
-    const result = getOptimizedImageAsset(file, '500px', '50%');
+    const result = getOptimizedImageAsset({ file, sizes: '500px', quality: '50%' });
     expect(result.srcSet).toEqual([
       `https:${file.url}?w=400&q=50 400w`,
       `https:${file.url}?w=800&q=50 800w`,
@@ -117,29 +119,29 @@ describe('transformImageAsset', () => {
   });
 
   it('when quality is 0%, the quality should not be on the srcSet urls', () => {
-    const result = getOptimizedImageAsset(file, '500px', '0%');
+    const result = getOptimizedImageAsset({ file, sizes: '500px', quality: '0%' });
     expect(result.srcSet).toEqual([`https:${file.url}?w=400 400w`, `https:${file.url}?w=800 800w`]);
   });
 
   it('when quality is 100%, the quality should not be on the srcSet urls', () => {
-    const result = getOptimizedImageAsset(file, '500px', '100%');
+    const result = getOptimizedImageAsset({ file, sizes: '500px', quality: '100%' });
     expect(result.srcSet).toEqual([`https:${file.url}?w=400 400w`, `https:${file.url}?w=800 800w`]);
   });
 
   it('when quality is less than 0%, should throw an error', () => {
-    expect(() => getOptimizedImageAsset(file, '500px', '-1%')).toThrowError(
+    expect(() => getOptimizedImageAsset({ file, sizes: '500px', quality: '-1%' })).toThrowError(
       'Quality must be between 0 and 100',
     );
   });
 
   it('when quality is more than 100%, should throw an error', () => {
-    expect(() => getOptimizedImageAsset(file, '500px', '101%')).toThrowError(
+    expect(() => getOptimizedImageAsset({ file, sizes: '500px', quality: '101%' })).toThrowError(
       'Quality must be between 0 and 100',
     );
   });
 
   it('when format is passed, the format should be on the srcSet urls', () => {
-    const result = getOptimizedImageAsset(file, '500px', undefined, 'webp');
+    const result = getOptimizedImageAsset({ file, sizes: '500px', format: 'webp' });
     expect(result.srcSet).toEqual([
       `https:${file.url}?w=400&fm=webp 400w`,
       `https:${file.url}?w=800&fm=webp 800w`,
@@ -148,8 +150,18 @@ describe('transformImageAsset', () => {
 
   it('when an invalid format is passed, should throw an error', () => {
     // @ts-expect-error passing an invalid format on purpose yo
-    expect(() => getOptimizedImageAsset(file, '500px', undefined, 'jpeg')).toThrowError(
+    expect(() => getOptimizedImageAsset({ file, sizes: '500px', format: 'jpeg' })).toThrowError(
       'Format must be one of jpg, png, webp, gif, avif',
     );
+  });
+
+  it('loading should default to lazy', () => {
+    const result = getOptimizedImageAsset({ file, sizes: '500px', loading: undefined });
+    expect(result.loading).toEqual('lazy');
+  });
+
+  it('when loading is eager, should return eager', () => {
+    const result = getOptimizedImageAsset({ file, sizes: '500px', loading: 'eager' });
+    expect(result.loading).toEqual('eager');
   });
 });

--- a/packages/core/src/utils/transformers/media/getOptimizedImageAsset.spec.ts
+++ b/packages/core/src/utils/transformers/media/getOptimizedImageAsset.spec.ts
@@ -155,8 +155,13 @@ describe('transformImageAsset', () => {
     );
   });
 
-  it('loading should default to lazy', () => {
+  it('loading should default to undefined', () => {
     const result = getOptimizedImageAsset({ file, sizes: '500px', loading: undefined });
+    expect(result.loading).toEqual(undefined);
+  });
+
+  it('when loading is lazy, should return lazy', () => {
+    const result = getOptimizedImageAsset({ file, sizes: '500px', loading: 'lazy' });
     expect(result.loading).toEqual('lazy');
   });
 

--- a/packages/core/src/utils/transformers/media/getOptimizedImageAsset.ts
+++ b/packages/core/src/utils/transformers/media/getOptimizedImageAsset.ts
@@ -1,16 +1,25 @@
-import { OptimizedImageAsset } from '@/types';
+import { ImageLoadingOption, OptimizedImageAsset } from '@/types';
 import { AssetFile } from 'contentful';
 import { getOptimizedImageUrl } from './getOptimizedImageUrl';
 import { ValidFormats, validateParams } from './mediaUtils';
 
 const MAX_WIDTH_ALLOWED = 4000;
 
-export const getOptimizedImageAsset = (
-  file: AssetFile,
-  sizes?: string,
-  quality: string = '100%',
-  format?: ValidFormats,
-): OptimizedImageAsset => {
+type GetOptimizedImageAssetProps = {
+  file: AssetFile;
+  sizes?: string;
+  loading?: ImageLoadingOption;
+  quality?: string;
+  format?: ValidFormats;
+};
+
+export const getOptimizedImageAsset = ({
+  file,
+  sizes,
+  loading,
+  quality = '100%',
+  format,
+}: GetOptimizedImageAssetProps): OptimizedImageAsset => {
   const qualityNumber = Number(quality.replace('%', ''));
   if (!validateParams(file, qualityNumber, format)) {
     throw Error('Invalid parameters');
@@ -47,6 +56,7 @@ export const getOptimizedImageAsset = (
     srcSet,
     sizes,
     file,
+    loading,
   };
 
   return optimizedImageAsset;

--- a/packages/core/src/utils/transformers/media/transformMedia.ts
+++ b/packages/core/src/utils/transformers/media/transformMedia.ts
@@ -10,6 +10,7 @@ import { Asset, AssetFile } from 'contentful';
 import { getOptimizedBackgroundImageAsset } from './getOptimizedBackgroundImageAsset';
 import { getOptimizedImageAsset } from './getOptimizedImageAsset';
 import { getBoundValue } from '../getBoundValue';
+import { ValidFormats } from './mediaUtils';
 
 export const transformMedia = (
   asset: Asset,
@@ -36,12 +37,13 @@ export const transformMedia = (
       return;
     }
     try {
-      value = getOptimizedImageAsset(
-        asset.fields.file as AssetFile,
-        options.targetSize as string,
-        options.quality,
-        options.format as (typeof SUPPORTED_IMAGE_FORMATS)[number],
-      );
+      value = getOptimizedImageAsset({
+        file: asset.fields.file as AssetFile,
+        loading: options.loading,
+        sizes: options.targetSize as string,
+        quality: options.quality,
+        format: options.format as ValidFormats,
+      });
       return value;
     } catch (error) {
       console.error('Error transforming image asset', error);


### PR DESCRIPTION
## Purpose

Customers would like to add lazy loading to their images

## Approach

Extends the ImageOptimization options to include a loading flag that can be set to 'lazy', 'eager', or undefined, which is configured via the UI. This option will set its value to the `loading` attribute on the option.