### PR TITLE
fix: render default content values for patterns [SPA-2048]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43191,6 +43191,7 @@
         "@rollup/plugin-node-resolve": "^15.2.1",
         "@rollup/plugin-terser": "^0.4.3",
         "@rollup/plugin-typescript": "^11.1.3",
+        "@testing-library/react": "^15.0.4",
         "@types/lodash-es": "^4.17.12",
         "@types/react": "^18.2.15",
         "@types/react-dom": "^18.2.7",
@@ -43214,6 +43215,52 @@
       "peerDependencies": {
         "react": ">=17.0.0",
         "react-dom": ">=17.0.0"
+      }
+    },
+    "packages/visual-editor/node_modules/@testing-library/dom": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.0.0.tgz",
+      "integrity": "sha512-PmJPnogldqoVFf+EwbHvbBJ98MmqASV8kLrBYgsDNxQcFMeIS7JFL48sfyXvuMtgmWO/wMhh25odr+8VhDmn4g==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "chalk": "^4.1.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/visual-editor/node_modules/@testing-library/react": {
+      "version": "15.0.4",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-15.0.4.tgz",
+      "integrity": "sha512-Fw/LM1emOHKfCxv5R0tz+25TOtiMt0o5Np1zJmb4LbSacOagXQX4ooAaHiJfGUMe+OjUk504BX11W+9Z8CvyZA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "@testing-library/dom": "^10.0.0",
+        "@types/react-dom": "^18.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      }
+    },
+    "packages/visual-editor/node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "dependencies": {
+        "dequal": "^2.0.3"
       }
     },
     "packages/visual-editor/node_modules/rimraf": {

--- a/packages/experience-builder-sdk/src/blocks/preview/CompositionBlock.tsx
+++ b/packages/experience-builder-sdk/src/blocks/preview/CompositionBlock.tsx
@@ -134,6 +134,11 @@ export const CompositionBlock = ({
             acc[variableName] = entityStore.unboundValues[uuid]?.value;
             break;
           }
+          case 'ComponentValue':
+            // We're rendering a pattern entry. Content cannot be set for ComponentValue type properties
+            // directly in the pattern so we can safely use the default value
+            acc[variableName] = variableDefinition.defaultValue;
+            break;
           default:
             break;
         }

--- a/packages/visual-editor/package.json
+++ b/packages/visual-editor/package.json
@@ -45,6 +45,7 @@
     "@rollup/plugin-node-resolve": "^15.2.1",
     "@rollup/plugin-terser": "^0.4.3",
     "@rollup/plugin-typescript": "^11.1.3",
+    "@testing-library/react": "^15.0.4",
     "@types/lodash-es": "^4.17.12",
     "@types/react": "^18.2.15",
     "@types/react-dom": "^18.2.7",

--- a/packages/visual-editor/src/components/Dropzone/useComponentProps.spec.ts
+++ b/packages/visual-editor/src/components/Dropzone/useComponentProps.spec.ts
@@ -1,0 +1,95 @@
+import { ASSEMBLY_NODE_TYPE } from '@contentful/experiences-core/constants';
+import { useComponentProps } from './useComponentProps';
+import { ComponentDefinition, ExperienceTreeNode } from '@contentful/experiences-core/types';
+import { vi } from 'vitest';
+import { renderHook } from '@testing-library/react';
+
+const definition: ComponentDefinition = {
+  id: 'button',
+  name: 'Button',
+  variables: {
+    label: {
+      type: 'Text',
+      defaultValue: 'Click here',
+    },
+  },
+};
+const node: ExperienceTreeNode = {
+  data: {
+    id: 'id',
+    props: {},
+    unboundValues: {},
+    dataSource: {},
+    breakpoints: [],
+  },
+  children: [],
+  type: 'block',
+};
+const resolveDesignValue = vi.fn();
+const renderDropzone = vi.fn();
+const areEntitiesFetched = true;
+const userIsDragging = false;
+
+describe('useComponentProps', () => {
+  it('should return empty object when node type is ASSEMBLY_NODE_TYPE', () => {
+    const areEntitiesFetched = true;
+    const userIsDragging = false;
+
+    const { result } = renderHook(() =>
+      useComponentProps({
+        node: { ...node, type: ASSEMBLY_NODE_TYPE },
+        areEntitiesFetched,
+        resolveDesignValue,
+        renderDropzone,
+        definition,
+        userIsDragging,
+      }),
+    );
+
+    expect(Object.keys(result.current.componentProps)).not.toContain('label');
+  });
+
+  it('should return props with default values when variableMapping is falsy', () => {
+    const { result } = renderHook(() =>
+      useComponentProps({
+        node,
+        areEntitiesFetched,
+        resolveDesignValue,
+        renderDropzone,
+        definition,
+        userIsDragging,
+      }),
+    );
+
+    expect(result.current.componentProps.label).toEqual('Click here');
+  });
+
+  it('should return definition default value when type is ComponentValue', () => {
+    const areEntitiesFetched = true;
+    const userIsDragging = false;
+
+    const { result } = renderHook(() =>
+      useComponentProps({
+        node: {
+          ...node,
+          data: {
+            ...node.data,
+            props: {
+              label: {
+                key: 'random-uuid',
+                type: 'ComponentValue',
+              },
+            },
+          },
+        },
+        areEntitiesFetched,
+        resolveDesignValue,
+        renderDropzone,
+        definition,
+        userIsDragging,
+      }),
+    );
+
+    expect(result.current.componentProps.label).toEqual('Click here');
+  });
+});

--- a/packages/visual-editor/src/components/Dropzone/useComponentProps.ts
+++ b/packages/visual-editor/src/components/Dropzone/useComponentProps.ts
@@ -34,6 +34,14 @@ import { HYPERLINK_DEFAULT_PATTERN } from '@contentful/experiences-core/constant
 
 type ComponentProps = StyleProps | Record<string, PrimitiveValue | Link<'Entry'> | Link<'Asset'>>;
 
+type ResolvedComponentProps = ComponentProps & {
+  children?: React.JSX.Element | undefined;
+  className: string;
+  editorMode: boolean;
+  node: ExperienceTreeNode;
+  renderDropzone: RenderDropzoneFunction;
+};
+
 type UseComponentProps = {
   node: ExperienceTreeNode;
   resolveDesignValue: ResolveDesignValueType;
@@ -151,6 +159,13 @@ export const useComponentProps = ({
             ...acc,
             [variableName]: value,
           };
+        } else if (variableMapping.type === 'ComponentValue') {
+          // We are rendering a pattern (assembly) entry. Content properties cannot be edited in this,
+          // so we always render the default value
+          return {
+            ...acc,
+            [variableName]: variableDefinition.defaultValue,
+          };
         } else {
           return { ...acc };
         }
@@ -225,7 +240,7 @@ export const useComponentProps = ({
   const stylesToKeep = ['cfImageAsset'];
   const stylesToRemove = CF_STYLE_ATTRIBUTES.filter((style) => !stylesToKeep.includes(style));
 
-  const componentProps = {
+  const componentProps: ResolvedComponentProps = {
     className: componentClass,
     editorMode: true,
     node,

--- a/packages/visual-editor/vitest.config.ts
+++ b/packages/visual-editor/vitest.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
   //@ts-expect-error ignore
   plugins: [tsconfigPaths()],
   test: {
+    globals: true,
     coverage: {
       reporter: ['text', 'json', 'html'],
       reportsDirectory: 'reports',


### PR DESCRIPTION
## Purpose

When rendering a pattern in the editor, as a standalone pattern, outside of an experience, we need to still render the default (placeholder) values into the canvas to assist designers when adjusting the pattern.

## Approach

This PR makes sure that when we encounter a property with type `ComponentValue` (only available for patterns) we render the default value of the component.

### Before
<img width="1446" alt="Screenshot 2024-04-24 at 11 02 58" src="https://github.com/contentful/experience-builder/assets/2773012/295df548-e453-4434-8ca7-09a893085544">

### After
<img width="1454" alt="Screenshot 2024-04-24 at 11 03 59" src="https://github.com/contentful/experience-builder/assets/2773012/c9fe76ac-8124-418a-bd54-2725133874e0">

