### PR TITLE
feat(validators): add optional displayName to ComponentTreeNode [ALT-780]

### DIFF
--- a/packages/validators/src/schemas/v2023_09_28/experience.ts
+++ b/packages/validators/src/schemas/v2023_09_28/experience.ts
@@ -97,6 +97,7 @@ const UnboundValuesSchema = z.record(
 // Use helper schema to define a recursive schema with its type correctly below
 const BaseComponentTreeNodeSchema = z.object({
   definitionId: DefinitionPropertyKeySchema,
+  displayName: z.string().optional(),
   variables: z.record(propertyKeySchema, ComponentPropertyValueSchema),
 });
 export type ComponentTreeNode = z.infer<typeof BaseComponentTreeNodeSchema> & {

--- a/packages/validators/test/__fixtures__/v2023_09_28/experience.ts
+++ b/packages/validators/test/__fixtures__/v2023_09_28/experience.ts
@@ -246,7 +246,7 @@ export const experience = {
               },
               {
                 definitionId: 'button',
-                displayName: 'Button 1',
+                // Component node without optional `displayName`.
                 variables: {
                   label: {
                     path: '/5J8rtZN_nOJUx5YGdFuF0/fields/name/~locale',

--- a/packages/validators/test/__fixtures__/v2023_09_28/experience.ts
+++ b/packages/validators/test/__fixtures__/v2023_09_28/experience.ts
@@ -89,6 +89,7 @@ export const experience = {
         children: [
           {
             definitionId: 'contentful-container',
+            displayName: 'Container 1',
             variables: {
               cfVerticalAlignment: {
                 type: 'DesignValue',
@@ -196,6 +197,7 @@ export const experience = {
             children: [
               {
                 definitionId: 'heading',
+                displayName: 'Heading 1',
                 variables: {
                   text: {
                     type: 'UnboundValue',
@@ -244,6 +246,7 @@ export const experience = {
               },
               {
                 definitionId: 'button',
+                displayName: 'Button 1',
                 variables: {
                   label: {
                     path: '/5J8rtZN_nOJUx5YGdFuF0/fields/name/~locale',

--- a/packages/validators/test/v2023_09_28/componentTree.spec.ts
+++ b/packages/validators/test/v2023_09_28/componentTree.spec.ts
@@ -182,6 +182,7 @@ describe('componentTree', () => {
       expect(error?.details).toBe('The property "schemaVersion" is required here');
     });
   });
+
   it(`fails if unrecognised attribute is provided`, () => {
     const componentTree = experience.fields.componentTree[locale];
     const updatedExperience = {
@@ -276,7 +277,7 @@ describe('componentTree', () => {
       // Since displayName is optional, we expect the validation to succeed
       expect(result.success).toBe(true);
       // And we expect no errors
-      expect(result.errors).toEqual(undefined);
+      expect(result.errors).toBeUndefined();
     });
 
     describe('variables name', () => {


### PR DESCRIPTION
## Purpose

Adds an optional `displayName` field to the `ComponentTreeNode` type.
* We can use this field to allow custom names to be set for each component instance on the canvas or layer.

### Reviewer

For a cleaner diff, use the 'Hide whitespace' option in the diff settings on the File Changes tab.
