### PR TITLE
fix: remove check if no margin

### DIFF
--- a/packages/core/src/utils/styleUtils/styleTransformers.ts
+++ b/packages/core/src/utils/styleUtils/styleTransformers.ts
@@ -157,12 +157,12 @@ export const transformWidthSizing = ({
   cfMargin?: string;
   componentId?: string;
 }) => {
-  if (!value || !cfMargin || !componentId) return;
+  if (!value || !componentId) return;
 
   const transformedValue = transformFill(value);
 
   if (isContentfulStructureComponent(componentId)) {
-    const marginValues = cfMargin.split(' ');
+    const marginValues = cfMargin ? cfMargin.split(' ') : [];
     const rightMargin = marginValues[1] || '0px';
     const leftMargin = marginValues[3] || '0px';
     const calcValue = `calc(${transformedValue} - ${leftMargin} - ${rightMargin})`;


### PR DESCRIPTION
## Purpose

fix bug where width in editor does not change if user does not have margin as a prop
[https://contentful.atlassian.net/jira/software/c/projects/ALT/boards/1552?selectedIssue=ALT-792]

- removed check in width transformation that returns undefined if no margin prop


