### PR TITLE
feat(validators): add optional slotId to component tree node

### DIFF
--- a/packages/validators/src/schemas/v2023_09_28/experience.ts
+++ b/packages/validators/src/schemas/v2023_09_28/experience.ts
@@ -98,6 +98,7 @@ const UnboundValuesSchema = z.record(
 const BaseComponentTreeNodeSchema = z.object({
   definitionId: DefinitionPropertyKeySchema,
   displayName: z.string().optional(),
+  slotId: z.string().optional(),
   variables: z.record(propertyKeySchema, ComponentPropertyValueSchema),
 });
 export type ComponentTreeNode = z.infer<typeof BaseComponentTreeNodeSchema> & {

--- a/packages/validators/test/v2023_09_28/componentTree.spec.ts
+++ b/packages/validators/test/v2023_09_28/componentTree.spec.ts
@@ -252,12 +252,8 @@ describe('componentTree', () => {
       },
     );
 
-    it.each([
-      'Test', // displayName provided
-      undefined, // displayName not provided
-    ])('succeeds if displayName is %s', (displayName) => {
+    it.each(['Test', undefined])('succeeds if displayName is %s', (displayName) => {
       const componentTree = experience.fields.componentTree[locale];
-      // child includes all attributes, with displayName either provided or not
       const child = {
         definitionId: 'test',
         displayName,
@@ -273,10 +269,27 @@ describe('componentTree', () => {
         },
       };
       const result = validateExperienceFields(updatedExperience, schemaVersion);
-
-      // Since displayName is optional, we expect the validation to succeed
       expect(result.success).toBe(true);
-      // And we expect no errors
+      expect(result.errors).toBeUndefined();
+    });
+
+    it.each(['string-value', undefined])('succeeds if slotId is %s', (slotId) => {
+      const componentTree = experience.fields.componentTree[locale];
+      const child = {
+        definitionId: 'test',
+        slotId,
+        variables: {},
+        children: [],
+      };
+      const updatedExperience = {
+        ...experience,
+        fields: {
+          ...experience.fields,
+          componentTree: { [locale]: { ...componentTree, children: [child] } },
+        },
+      };
+      const result = validateExperienceFields(updatedExperience, schemaVersion);
+      expect(result.success).toBe(true);
       expect(result.errors).toBeUndefined();
     });
 


### PR DESCRIPTION
## Purpose

Added an optional `slotId` field to the `ComponentTreeNode` schema to support multiple dropzone slot locations per component.

This field allows nested child nodes to be identified and filtered by their slot locations. By having this data persist in the entries API, we can accurately reconstruct the component tree from an experience entry with data-level support for multiple dropzone slots per component.

Additional changes are needed to the User Interface and SDK to implement full support for multiple dropzone locations per component (this change is only for the API data layer).