### PR TITLE
[ALT-817-root] feat: update github readme at the root level for more direct links and more detailed explanations

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,19 +2,50 @@
 
 This repository represents a set of packages, related to the [Studio Experiences](https://www.contentful.com/developers/docs/experiences/what-are-experiences/) product.
 
-## Documentation
+## Documentation Links
+- [Home](https://www.contentful.com/developers/docs/experiences/)
+- [What are Experiences?](https://www.contentful.com/developers/docs/experiences/what-are-experiences/)
+- [Set up Experiences SDK](https://www.contentful.com/developers/docs/experiences/set-up-experiences-sdk/)
+- [Register custom components](https://www.contentful.com/developers/docs/experiences/register-custom-components/)
+- [Component definition schema](https://www.contentful.com/developers/docs/experiences/component-definition-schema/)
+- [Built-in styles](https://www.contentful.com/developers/docs/experiences/built-in-styles/)
+- [Design tokens](https://www.contentful.com/developers/docs/experiences/design-tokens/)
+- [Data structures](https://www.contentful.com/developers/docs/experiences/data-structures/)
+- [Error handling](https://www.contentful.com/developers/docs/experiences/error-handling/)
+- [Image optimzation](https://www.contentful.com/developers/docs/experiences/image-optimization/)
+- [Experiences with NextJS](https://www.contentful.com/developers/docs/experiences/using-with-nextjs/)
 
-Please refer to our [Documentation](https://www.contentful.com/developers/docs/experiences/) to learn more about it.
+## Links to packages in this repo
+- [Components](https://github.com/contentful/experience-builder/tree/main/packages/components)
+- [Core](https://github.com/contentful/experience-builder/tree/main/packages/core)
+- [Experiences CLI tool](https://github.com/contentful/experience-builder/tree/main/packages/create-experience-builder)
+- [Experiences SDK](https://github.com/contentful/experience-builder/tree/main/packages/experience-builder-sdk)
+- [Test-app](https://github.com/contentful/experience-builder/tree/main/packages/test-app)
+- [Validators](https://github.com/contentful/experience-builder/tree/main/packages/validators)
+- [Visual-editor](https://github.com/contentful/experience-builder/tree/main/packages/visual-editor)
 
 ## Local Development
+Each package has a 'dev' script that will build the application and watch for changes. Running `npm run dev` in the root directory of each package will have the benefit of hot-reloading when making changes at the cost of having more terminal windows depending on how many packages you are running. Therefore, if a more concise terminal windowed experience is preferred, you can always run `npm run build` at the project repo root level after every change instead at the cost of hot-reloading.
 
-Each package has a 'dev' script that will build the application and watch for changes.
+Additionally, there is a provided `test-app` package on your behalf to get you quickly started. This package handles fetching the experience and should be displayed in your Contentful Experience webapp once you setup your enablements, space, and Experience type in the Contentful webapp. 
 
-Run the following command in the directory of the package to start the dev script:
+**If you are looking to use the `test-app`, follow the steps below:**
 
-```bash
-npm run dev 
+1. Setup your enablements, space, and Experience type through the Contentful webapp. At this point, your Experience canvas in the UI should display some error state such as `localhost refused to connect`.
+2. Then in the `test-app` package open up the `local.env` file and make sure to fill out the following variables
 ```
+VITE_CTFL_ENVIRONMENT=
+VITE_CTFL_SPACE=
+VITE_CTFL_ACCESS_TOKEN=
+VITE_CTFL_PREVIEW_ACCESS_TOKEN=
+VITE_CTFL_DOMAIN=contentful.com
+VITE_CTFL_EXPERIENCE_TYPE=
+```
+3. Go to the root directory of the repo and run `npm i` and `npm run build`
+4. cd into the `test-app` directory and run `npm run dev`
+5. Go back into the Contentful Experiences UI and refresh. You should see your canvas in a happy state where you can now start adding components onto the canvas.
+
+If you are having issues getting the test-app to show up in the canvas checkout the Troubleshooting section below.
 
 ## Branching & Release Process
 
@@ -38,5 +69,6 @@ We follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0
 
 ## Troubleshooting
 
-> [!WARNING]
+> If your `test-app` is not being displayed in the Contentful Experience UI, double check your environment variables and make sure the values are correct. Additionally, double check your `Content preview settings` and ensure that you are pointing to the correct url which should be `http://localhost:5173`.
+
 > If your `build` command is stuck and not finishing, try resetting the cache via `npx nx reset`


### PR DESCRIPTION
## Purpose
Add github documentation at the root level repo

![Screenshot 2024-05-15 at 10 47 33 AM](https://github.com/contentful/experience-builder/assets/124832189/d2d960f4-ecb2-4f24-8c3e-2ad61ac386ad)
