### PR TITLE
fix: add maxWidth to list with design tokens

### DIFF
--- a/packages/core/src/utils/breakpoints.ts
+++ b/packages/core/src/utils/breakpoints.ts
@@ -88,6 +88,7 @@ const builtInStylesWithDesignTokens = [
   'cfLineHeight',
   'cfLetterSpacing',
   'cfTextColor',
+  'cfMaxWidth',
 ];
 
 export const getValueForBreakpoint = (


### PR DESCRIPTION
## Purpose

maxWidth currently does not work if you use design tokens for the value

## Approach

Add maxWidth to the list of styles that use design tokens so that the code knows to resolve the design token value

https://www.loom.com/share/f86d1c370ab04e9d94befe3410fac2ca?sid=070c270d-72ee-4282-958c-10c7b729fd22 
