### PR TITLE
fix: do not include margins in width calc

### DIFF
--- a/packages/core/src/utils/styleUtils/styleTransformers.ts
+++ b/packages/core/src/utils/styleUtils/styleTransformers.ts
@@ -5,7 +5,6 @@ import {
   BackgroundImageScalingOption,
   BackgroundImageAlignmentOption,
 } from '@/types';
-import { isContentfulStructureComponent } from '@/utils/components';
 
 // Keep this for backwards compatilibity - deleting this would be a breaking change
 // because existing components on a users experience will have the width value as fill
@@ -151,34 +150,8 @@ export const transformBackgroundImage = (
     backgroundSize: matchBackgroundSize(cfBackgroundImageOptions?.scaling),
   };
 };
-export const transformWidthSizing = ({
-  value,
-  cfMargin,
-  componentId,
-}: {
-  value?: string;
-  cfMargin?: string;
-  componentId?: string;
-}) => {
-  if (!value || !componentId) return;
+export const transformWidthSizing = ({ value }: { value?: string }) => {
+  if (!value) return;
 
-  const transformedValue = transformFill(value);
-
-  if (isContentfulStructureComponent(componentId)) {
-    const marginValues = cfMargin ? cfMargin.split(' ') : [];
-    const rightMargin = marginValues[1] || '0px';
-    const leftMargin = marginValues[3] || '0px';
-    const calcValue = `calc(${transformedValue} - ${leftMargin} - ${rightMargin})`;
-    /**
-     * We want to check if the calculated value is valid CSS. If this fails,
-     * this means the `transformedValue` is not a calculable value (not a px, rem, or %).
-     * The value may instead be a string such as `min-content` or `max-content`. In
-     * that case we don't want to use calc and instead return the raw value.
-     */
-    if (typeof window !== 'undefined' && CSS.supports('width', calcValue)) {
-      return calcValue;
-    }
-  }
-
-  return transformedValue;
+  return transformFill(value);
 };

--- a/packages/core/src/utils/styleUtils/stylesUtils.ts
+++ b/packages/core/src/utils/styleUtils/stylesUtils.ts
@@ -73,7 +73,7 @@ export const buildCfStyles = (
     margin: cfMargin,
     padding: cfPadding,
     backgroundColor: cfBackgroundColor,
-    width: transformWidthSizing({ value: cfWidth || cfImageOptions?.width, cfMargin, componentId }),
+    width: transformWidthSizing({ value: cfWidth || cfImageOptions?.width }),
     height: transformFill(cfHeight || cfImageOptions?.height),
     maxWidth: cfMaxWidth,
     ...transformGridColumn(cfColumnSpan),


### PR DESCRIPTION
## Purpose

our width calc currently includes the margin val which makes no sense

## Approach

do not include margin

https://www.loom.com/share/51076a59a9bd43e0bcdba2b01e26a999?sid=0c983b64-5552-4811-a277-7cc2f49e0637

NEED TO CHECK HOW THIS WILL AFFECT STAKEHOLDERS