### PR TITLE
feat: expose function to define custom breakpoints [SPA-2076]

### DIFF
--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -7,6 +7,7 @@ export const SCROLL_STATES = {
 export const OUTGOING_EVENTS = {
   Connected: 'connected',
   DesignTokens: 'registerDesignTokens',
+  RegisteredBreakpoints: 'registeredBreakpoints',
   HoveredSection: 'hoveredSection',
   MouseMove: 'mouseMove',
   NewHoveredElement: 'newHoveredElement',

--- a/packages/core/src/registries/breakpointsRegistry.spec.ts
+++ b/packages/core/src/registries/breakpointsRegistry.spec.ts
@@ -1,0 +1,98 @@
+import * as registry from './breakpointsRegistry';
+import { describe, afterEach, it, expect } from 'vitest';
+describe('defineBreakpoints', () => {
+  afterEach(() => {
+    registry.resetBreakpointsRegistry();
+  });
+
+  it('should register breakpoints in breakpoint registry', () => {
+    registry.defineBreakpoints([
+      {
+        id: 'test-desktop',
+        query: '*',
+        displayName: 'All Sizes',
+        previewSize: '100%',
+      },
+      {
+        id: 'test-tablet',
+        query: '<982px',
+        displayName: 'Tablet',
+        previewSize: '820px',
+      },
+      {
+        id: 'test-mobile',
+        query: '<360px',
+        displayName: 'Mobile',
+        previewSize: '390px',
+      },
+    ]);
+
+    const breakpointRegistration = registry.getBreakpointRegistration('test-tablet');
+    expect(breakpointRegistration).toBeDefined();
+  });
+});
+
+describe('runBreakpointsValidation', () => {
+  afterEach(() => {
+    registry.resetBreakpointsRegistry();
+  });
+  it('throws an error if breakpoints definition is invalid', () => {
+    registry.defineBreakpoints([
+      {
+        id: 'test-desktop',
+        query: '*',
+        displayName: 'All Sizes',
+        previewSize: '100%',
+      },
+      {
+        id: 'test-tablet',
+        query: '<982px',
+        displayName: 'Tablet',
+        previewSize: '820px',
+      },
+      {
+        id: 'test-mobile',
+        query: '<1000px',
+        displayName: 'Mobile',
+        previewSize: '390px',
+      },
+    ]);
+
+    const errors = [
+      {
+        details: 'Breakpoints should be ordered from largest to smallest pixel value',
+        name: 'custom',
+        path: [],
+      },
+    ];
+    const error = new Error(
+      `Invalid breakpoints definition. Failed with errors: \n${JSON.stringify(errors, null, 2)}`,
+    );
+    expect(() => registry.runBreakpointsValidation()).toThrow(error);
+  });
+
+  it('does not throw an error if no breakpoint definition is invalid', () => {
+    registry.defineBreakpoints([
+      {
+        id: 'test-desktop',
+        query: '*',
+        displayName: 'All Sizes',
+        previewSize: '100%',
+      },
+      {
+        id: 'test-tablet',
+        query: '<982px',
+        displayName: 'Tablet',
+        previewSize: '820px',
+      },
+      {
+        id: 'test-mobile',
+        query: '<576px',
+        displayName: 'Mobile',
+        previewSize: '390px',
+      },
+    ]);
+
+    expect(() => registry.runBreakpointsValidation()).not.toThrow();
+  });
+});

--- a/packages/core/src/registries/breakpointsRegistry.ts
+++ b/packages/core/src/registries/breakpointsRegistry.ts
@@ -1,6 +1,5 @@
 import { Breakpoint, validateBreakpointsDefinition } from '@contentful/experiences-validators';
 
-// export const breakpointsRegistry = new Map<string, Breakpoint>();
 export let breakpointsRegistry: Breakpoint[] = [];
 
 /**
@@ -21,6 +20,11 @@ export const runBreakpointsValidation = () => {
   }
 };
 
-export const resetComponentRegistry = () => {
+// Used in the tests to get a breakpoint registration
+export const getBreakpointRegistration = (id: string) =>
+  breakpointsRegistry.find((breakpoint) => breakpoint.id === id);
+
+// Used in the tests to reset the registry
+export const resetBreakpointsRegistry = () => {
   breakpointsRegistry = [];
 };

--- a/packages/core/src/registries/breakpointsRegistry.ts
+++ b/packages/core/src/registries/breakpointsRegistry.ts
@@ -1,0 +1,26 @@
+import { Breakpoint, validateBreakpointsDefinition } from '@contentful/experiences-validators';
+
+// export const breakpointsRegistry = new Map<string, Breakpoint>();
+export let breakpointsRegistry: Breakpoint[] = [];
+
+/**
+ * Register custom breakpoints
+ * @param breakpoints - [{[key:string]: string}]
+ * @returns void
+ */
+export const defineBreakpoints = (breakpoints: Breakpoint[]) => {
+  Object.assign(breakpointsRegistry, breakpoints);
+};
+
+export const runBreakpointsValidation = () => {
+  const validation = validateBreakpointsDefinition(breakpointsRegistry);
+  if (!validation.success) {
+    throw new Error(
+      `Invalid breakpoints definition. Failed with errors: \n${JSON.stringify(validation.errors, null, 2)}`,
+    );
+  }
+};
+
+export const resetComponentRegistry = () => {
+  breakpointsRegistry = [];
+};

--- a/packages/core/src/registries/index.ts
+++ b/packages/core/src/registries/index.ts
@@ -1,1 +1,2 @@
 export * from './designTokenRegistry';
+export * from './breakpointsRegistry';

--- a/packages/experience-builder-sdk/src/core/componentRegistry.test.tsx
+++ b/packages/experience-builder-sdk/src/core/componentRegistry.test.tsx
@@ -12,6 +12,7 @@ import {
 } from '@contentful/experiences-core/constants';
 import * as registry from './componentRegistry';
 import type { ComponentRegistration } from '@contentful/experiences-core/types';
+import { SDK_VERSION } from '../sdkVersion';
 
 const TestComponent = () => {
   return <div data-test-id="test">Test</div>;
@@ -396,11 +397,13 @@ describe('sendConnectedEventWithRegisteredComponents', () => {
 
     registry.sendConnectedEventWithRegisteredComponents();
 
-    expect(window.postMessage).toHaveBeenCalledWith(
+    expect(window.postMessage).toHaveBeenNthCalledWith(
+      1,
       {
         source: 'customer-app',
-        eventType: OUTGOING_EVENTS.RegisteredComponents,
+        eventType: OUTGOING_EVENTS.Connected,
         payload: {
+          sdkVersion: SDK_VERSION,
           definitions: Array.from(registry.componentRegistry.values()).map(
             (registration) => registration.definition,
           ),
@@ -409,12 +412,26 @@ describe('sendConnectedEventWithRegisteredComponents', () => {
       '*',
     );
 
-    expect(window.postMessage).toHaveBeenCalledWith(
+    expect(window.postMessage).toHaveBeenNthCalledWith(
+      2,
       {
         source: 'customer-app',
         eventType: OUTGOING_EVENTS.RegisteredBreakpoints,
         payload: {
           breakpoints: customBreakpoints,
+        },
+      },
+      '*',
+    );
+
+    expect(window.postMessage).toHaveBeenNthCalledWith(
+      3,
+      {
+        source: 'customer-app',
+        eventType: OUTGOING_EVENTS.DesignTokens,
+        payload: {
+          designTokens: {},
+          resolvedCssVariables: {},
         },
       },
       '*',

--- a/packages/experience-builder-sdk/src/core/componentRegistry.test.tsx
+++ b/packages/experience-builder-sdk/src/core/componentRegistry.test.tsx
@@ -354,7 +354,7 @@ describe('sendConnectedEventWithRegisteredComponents', () => {
     registry.resetComponentRegistry();
   });
 
-  it('should only send component definitions', () => {
+  it('should send connected event with component definitions, breakpoints, and design tokens ', () => {
     const definitionId = 'TestComponent';
     registry.defineComponents([
       {

--- a/packages/experience-builder-sdk/src/core/componentRegistry.ts
+++ b/packages/experience-builder-sdk/src/core/componentRegistry.ts
@@ -14,6 +14,7 @@ import {
 import {
   builtInStyles as builtInStyleDefinitions,
   designTokensRegistry,
+  breakpointsRegistry,
   optionalBuiltInStyles,
   sendMessage,
   containerDefinition,
@@ -295,6 +296,10 @@ export const sendConnectedEventWithRegisteredComponents = () => {
   sendMessage(OUTGOING_EVENTS.Connected, {
     sdkVersion: SDK_VERSION,
     definitions: registeredDefinitions,
+  });
+
+  sendMessage(OUTGOING_EVENTS.RegisteredBreakpoints, {
+    breakpoints: breakpointsRegistry,
   });
 
   sendMessage(OUTGOING_EVENTS.DesignTokens, {

--- a/packages/experience-builder-sdk/src/hooks/useInitializeVisualEditor.ts
+++ b/packages/experience-builder-sdk/src/hooks/useInitializeVisualEditor.ts
@@ -7,7 +7,7 @@ import {
   runRegisteredComponentValidations,
 } from '../core/componentRegistry';
 import { INTERNAL_EVENTS, VISUAL_EDITOR_EVENTS } from '@contentful/experiences-core/constants';
-import { designTokensRegistry } from '@contentful/experiences-core';
+import { designTokensRegistry, runBreakpointsValidation } from '@contentful/experiences-core';
 
 type InitializeVisualEditorParams = {
   initialLocale: string;
@@ -24,6 +24,7 @@ export const useInitializeVisualEditor = (params: InitializeVisualEditorParams) 
   useEffect(() => {
     if (!hasConnectEventBeenSent.current) {
       runRegisteredComponentValidations();
+      runBreakpointsValidation();
       // sending CONNECT but with the registered components now
       sendConnectedEventWithRegisteredComponents();
       hasConnectEventBeenSent.current = true;

--- a/packages/experience-builder-sdk/src/hooks/useInitializeVisualEditor.ts
+++ b/packages/experience-builder-sdk/src/hooks/useInitializeVisualEditor.ts
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
-import { EntityStore } from '@contentful/experiences-core';
+import { EntityStore, breakpointsRegistry } from '@contentful/experiences-core';
 import {
   componentRegistry,
   sendConnectedEventWithRegisteredComponents,
@@ -57,6 +57,7 @@ export const useInitializeVisualEditor = (params: InitializeVisualEditorParams) 
           detail: {
             componentRegistry,
             designTokens: designTokensRegistry,
+            breakpoints: breakpointsRegistry,
             locale,
             entities: initialEntities ?? [],
           },

--- a/packages/experience-builder-sdk/src/index.ts
+++ b/packages/experience-builder-sdk/src/index.ts
@@ -5,6 +5,7 @@ export { useFetchById, useFetchBySlug } from './hooks';
 export { defineComponents, maintainBasicComponentIdsWithoutPrefix } from './core/componentRegistry';
 export {
   defineDesignTokens,
+  defineBreakpoints,
   VisualEditorMode,
   fetchById,
   fetchBySlug,

--- a/packages/test-app/src/eb-config.ts
+++ b/packages/test-app/src/eb-config.ts
@@ -1,4 +1,4 @@
-import { defineComponents } from '@contentful/experiences-sdk-react';
+import { defineComponents, defineBreakpoints } from '@contentful/experiences-sdk-react';
 import ComponentWithChildren from './components/ComponentWithChildren';
 import { LinkComponent } from './components/LinkComponent';
 import { CustomImageComponent } from './components/CustomImageComponent';
@@ -73,5 +73,26 @@ defineComponents([
         },
       },
     },
+  },
+]);
+
+defineBreakpoints([
+  {
+    id: 'test-desktop',
+    query: '*',
+    displayName: 'All Sizes',
+    previewSize: '100%',
+  },
+  {
+    id: 'test-tablet',
+    query: '<982px',
+    displayName: 'Tablet',
+    previewSize: '820px',
+  },
+  {
+    id: 'test-mobile',
+    query: '<360px',
+    displayName: 'Mobile',
+    previewSize: '390px',
   },
 ]);

--- a/packages/validators/src/validators.ts
+++ b/packages/validators/src/validators.ts
@@ -1,3 +1,4 @@
+import { z } from 'zod';
 import { Schema_2023_09_28, ComponentDefinitionSchema } from './schemas';
 import {
   ContentfulErrorDetails,
@@ -6,6 +7,7 @@ import {
 } from './utils/zodToContentfulError';
 
 import { type SchemaVersions } from './types';
+import { BreakpointSchema, breakpointsRefinement } from './schemas/latest';
 
 const VERSION_SCHEMAS = {
   '2023-09-28': Schema_2023_09_28,
@@ -70,6 +72,20 @@ export const validateExperienceFields = (
 
 export const validateComponentDefinition = (definition): ValidatorReturnValue => {
   const result = ComponentDefinitionSchema.safeParse(definition);
+  if (!result.success) {
+    return {
+      success: false,
+      errors: result.error.issues.map(zodToContentfulError),
+    };
+  }
+  return { success: true };
+};
+
+export const validateBreakpointsDefinition = (breakpoints): ValidatorReturnValue => {
+  const result = z
+    .array(BreakpointSchema)
+    .superRefine(breakpointsRefinement)
+    .safeParse(breakpoints);
   if (!result.success) {
     return {
       success: false,

--- a/packages/validators/test/v2023_09_28/componentTree.spec.ts
+++ b/packages/validators/test/v2023_09_28/componentTree.spec.ts
@@ -42,7 +42,7 @@ describe('componentTree', () => {
       expect(result.success).toBe(false);
       expect(error?.name).toBe('custom');
       expect(error?.details).toBe(
-        'The first breakpoint should include the following attributes: { "id": "desktop", "query": "*" }',
+        'The first breakpoint should include the following attributes: { "query": "*" }',
       );
     });
 
@@ -119,8 +119,7 @@ describe('componentTree', () => {
 
       const expectedErrors = [
         {
-          details:
-            'The first breakpoint should include the following attributes: { "id": "desktop", "query": "*" }',
+          details: 'The first breakpoint should include the following attributes: { "query": "*" }',
           name: 'custom',
           path: ['componentTree', 'en-US', 'breakpoints'],
         },
@@ -158,6 +157,31 @@ describe('componentTree', () => {
       expect(error?.details).toBe(
         'Breakpoints should be ordered from largest to smallest pixel value',
       );
+    });
+
+    it(`fails if there are duplicate breakpoint ids`, () => {
+      const breakpoints = [
+        { id: 'desktop', query: '*', previewSize: 'large', displayName: 'Desktop' },
+        { id: 'tablet', query: '<1024px', previewSize: 'medium', displayName: 'Tablet' },
+        { id: 'mobile', query: '<768px', previewSize: 'small', displayName: 'Mobile' },
+        { id: 'mobile', query: '<350px', previewSize: 'small', displayName: 'Mobile' },
+      ];
+      const componentTree = experience.fields.componentTree[locale];
+      const updatedExperience = {
+        ...experience,
+        fields: {
+          ...experience.fields,
+          componentTree: { [locale]: { ...componentTree, breakpoints } },
+        },
+      };
+      const result = validateExperienceFields(updatedExperience, schemaVersion);
+
+      expect(result.success).toBe(false);
+      const error = result.errors?.[0];
+
+      expect(result.success).toBe(false);
+      expect(error?.name).toBe('custom');
+      expect(error?.details).toBe('Breakpoint IDs must be unique');
     });
   });
 

--- a/packages/validators/test/v2023_09_28/experienceValidator.spec.ts
+++ b/packages/validators/test/v2023_09_28/experienceValidator.spec.ts
@@ -1,7 +1,6 @@
-import { validateExperienceFields } from '../../src/validators';
+import { validateBreakpointsDefinition, validateExperienceFields } from '../../src/validators';
 import { experience, experiencePattern } from '../__fixtures__/v2023_09_28';
 import { describe, it, expect } from 'vitest';
-import { SafeParseError, SafeParseSuccess } from 'zod';
 
 const schemaVersion = '2023-09-28' as const;
 
@@ -37,5 +36,143 @@ describe(`${schemaVersion} version`, () => {
     const result = validateExperienceFields(experiencePattern);
 
     expect(result.success).toBe(true);
+  });
+});
+
+describe(validateBreakpointsDefinition, () => {
+  it('should validate that query is "<" px value', () => {
+    const breakpoints = [
+      {
+        id: 'test-desktop',
+        query: '*',
+        displayName: 'All Sizes',
+        previewSize: '100%',
+      },
+      {
+        id: 'test-tablet',
+        query: '>982px',
+        displayName: 'Tablet',
+        previewSize: '820px',
+      },
+    ];
+    const result = validateBreakpointsDefinition(breakpoints);
+
+    expect(result.success).toBe(false);
+    expect(result.errors).toBeDefined();
+  });
+
+  it('should validate that first breakpoint has a wild card query', () => {
+    const breakpoints = [
+      {
+        id: 'test-desktop',
+        query: '<1000px',
+        displayName: 'All Sizes',
+        previewSize: '100%',
+      },
+      {
+        id: 'test-tablet',
+        query: '<982px',
+        displayName: 'Tablet',
+        previewSize: '820px',
+      },
+    ];
+    const result = validateBreakpointsDefinition(breakpoints);
+
+    expect(result.success).toBe(false);
+    expect(result.errors).toBeDefined();
+    const error = result.errors?.[0];
+
+    expect(error?.details).toBe(
+      'The first breakpoint should include the following attributes: { "query": "*" }',
+    );
+  });
+
+  it('should validate that breakpoints have unique ids', () => {
+    const breakpoints = [
+      {
+        id: 'test-desktop',
+        query: '*',
+        displayName: 'All Sizes',
+        previewSize: '100%',
+      },
+      {
+        id: 'test-tablet',
+        query: '<982px',
+        displayName: 'Tablet',
+        previewSize: '820px',
+      },
+      {
+        id: 'test-tablet',
+        query: '<800px',
+        displayName: 'Tablet',
+        previewSize: '820px',
+      },
+    ];
+    const result = validateBreakpointsDefinition(breakpoints);
+
+    expect(result.success).toBe(false);
+    expect(result.errors).toBeDefined();
+    const error = result.errors?.[0];
+
+    expect(error?.details).toBe('Breakpoint IDs must be unique');
+  });
+
+  it('should validate that breakpoint queries are ordered from largest to smallest', () => {
+    const breakpoints = [
+      {
+        id: 'test-desktop',
+        query: '*',
+        displayName: 'All Sizes',
+        previewSize: '100%',
+      },
+      {
+        id: 'test-tablet',
+        query: '<982px',
+        displayName: 'Tablet',
+        previewSize: '820px',
+      },
+      {
+        id: 'test-mobile',
+        query: '<1000px',
+        displayName: 'Tablet',
+        previewSize: '820px',
+      },
+    ];
+    const result = validateBreakpointsDefinition(breakpoints);
+
+    expect(result.success).toBe(false);
+    expect(result.errors).toBeDefined();
+    const error = result.errors?.[0];
+
+    expect(error?.details).toBe(
+      'Breakpoints should be ordered from largest to smallest pixel value',
+    );
+  });
+
+  it('should validate that fields in breakpoint object', () => {
+    const breakpoints = [
+      {
+        id: 'test-desktop',
+        query: '*',
+        displayName: 'All Sizes',
+        previewSize: '100%',
+        displayIconUrl: 'https://test.com',
+      },
+      {
+        id: 'test-tablet',
+        query: '<982px',
+        displayName: 'Tablet',
+        previewSize: '820px',
+        displayIconUrl: 'https://test.com',
+        wrongFieldAdded: 'test',
+      },
+    ];
+    const result = validateBreakpointsDefinition(breakpoints);
+
+    expect(result.success).toBe(false);
+    expect(result.errors).toBeDefined();
+    const error = result.errors?.[0];
+
+    expect(error?.details).toBe('The property "wrongFieldAdded" is not expected');
   });
 });


### PR DESCRIPTION
## Purpose

To enable users to define their custom breakpoints, this PR exposes the `defineBreakpoints` function.

Wrong ❌

`
defineBreakpoints([
  {
    id: 'test-desktop',
    query: '*bnsmqw',
    displayName: 'All Sizes',
    previewSize: '100%',
  },
  {
    id: 'test -tablet',
    query: '<982px',
    displayName: 'Test Tablet',
    previewSize: '820px',
  },
  {
    id: 'test-mobile',
    query: '<1000px',
    displayName: 'Second Test Tablet',
    previewSize: '820px',
  },
  {
    id: 'test-mobile',
    query: '>400px',
    displayName: 'test-Mobile',
    previewSize: '390px',
  },
  {
    id: 'test-mobile',
    query: '>360px and <1000px',
    displayName: 'test-Mobile',
    previewSize: '390px',
  },
])
`

https://github.com/contentful/experience-builder/assets/30434146/750d17d8-d640-47d2-ab92-d293c95fd830

Correct ✅
`defineBreakpoints([
  {
    id: 'test-desktop',
    query: '*',
    displayName: 'All Sizes',
    previewSize: '100%',
  },
  {
    id: 'test-tablet',
    query: '<982px',
    displayName: 'Tablet',
    previewSize: '820px',
  },
  {
    id: 'test-mobile',
    query: '<360px',
    displayName: 'Mobile',
    previewSize: '390px',
  },
])`


https://github.com/contentful/experience-builder/assets/30434146/5c3d5891-0c7d-4be3-ba97-c65218b3e0f5

