### PR TITLE
fix: show custom display name on hover of component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2575,6 +2575,7 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {

--- a/packages/visual-editor/src/components/Draggable/DraggableChildComponent.tsx
+++ b/packages/visual-editor/src/components/Draggable/DraggableChildComponent.tsx
@@ -45,6 +45,7 @@ type DraggableChildComponentProps = {
   isDragDisabled?: boolean;
   className?: string;
   definition: ComponentDefinition<ComponentDefinitionVariableType>;
+  displayName?: string;
 };
 
 /**
@@ -73,6 +74,7 @@ export const DraggableChildComponent: React.FC<DraggableChildComponentProps> = (
     isDragDisabled = false,
     wrapperProps,
     definition,
+    displayName,
   } = props;
   const isHoveredComponent = useDraggedItemStore((state) => state.hoveredComponentId === id);
 
@@ -105,7 +107,7 @@ export const DraggableChildComponent: React.FC<DraggableChildComponentProps> = (
               coordinates={coordinates}
               isAssemblyBlock={isAssemblyBlock}
               isContainer={isContainer}
-              label={definition.name || 'No label specified'}
+              label={displayName || definition.name || 'No label specified'}
             />
           ),
         })

--- a/packages/visual-editor/src/components/Draggable/DraggableComponent.tsx
+++ b/packages/visual-editor/src/components/Draggable/DraggableComponent.tsx
@@ -45,6 +45,7 @@ interface DraggableComponentProps {
   style?: CSSProperties;
   isDragDisabled?: boolean;
   definition: ComponentDefinition<ComponentDefinitionVariableType>;
+  displayName?: string;
 }
 
 export const DraggableComponent: React.FC<DraggableComponentProps> = ({
@@ -64,6 +65,7 @@ export const DraggableComponent: React.FC<DraggableComponentProps> = ({
   isDragDisabled = false,
   placeholder,
   definition,
+  displayName,
   ...rest
 }) => {
   const ref = useRef<HTMLElement | null>(null);
@@ -116,7 +118,7 @@ export const DraggableComponent: React.FC<DraggableComponentProps> = ({
             coordinates={coordinates}
             isAssemblyBlock={isAssemblyBlock}
             isContainer={isContainer}
-            label={definition.name || 'No label specified'}
+            label={displayName || definition.name || 'No label specified'}
           />
           <Placeholder {...placeholder} id={id} />
           {children}

--- a/packages/visual-editor/src/components/Dropzone/EditorBlock.tsx
+++ b/packages/visual-editor/src/components/Dropzone/EditorBlock.tsx
@@ -49,6 +49,7 @@ export const EditorBlock: React.FC<EditorBlockProps> = ({
   });
 
   const coordinates = useSelectedInstanceCoordinates({ node });
+  const displayName = node.data.displayName;
 
   const isContainer = node.data.blockId === CONTENTFUL_COMPONENTS.container.id;
   const isSingleColumn = node.data.blockId === CONTENTFUL_COMPONENTS.singleColumn.id;
@@ -104,6 +105,7 @@ export const EditorBlock: React.FC<EditorBlockProps> = ({
         onClick={onClick}
         onMouseOver={onMouseOver}
         definition={definition}
+        displayName={displayName}
       />
     );
   }
@@ -123,7 +125,8 @@ export const EditorBlock: React.FC<EditorBlockProps> = ({
       coordinates={coordinates!}
       wrapperProps={wrapperProps}
       onClick={onClick}
-      onMouseOver={onMouseOver}>
+      onMouseOver={onMouseOver}
+      displayName={displayName}>
       {elementToRender()}
       {isStructureComponent && userIsDragging && (
         <Hitboxes parentZoneId={zoneId} zoneId={componentId} isEmptyZone={isEmptyZone} />


### PR DESCRIPTION
## Purpose

should show custom display name of component on hover overlay

https://contentful.atlassian.net/browse/ALT-688

<img width="568" alt="Screenshot 2024-05-23 at 1 24 45 PM" src="https://github.com/contentful/experience-builder/assets/166558611/1864df17-f8e1-45c1-981f-96dc4d217a81">
