### PR TITLE
RETIRED: Fix/fallback missing components [SPA-2033]

### DIFF
--- a/packages/experience-builder-sdk/src/blocks/preview/CompositionBlock.tsx
+++ b/packages/experience-builder-sdk/src/blocks/preview/CompositionBlock.tsx
@@ -158,24 +158,7 @@ export const CompositionBlock = ({
   const className = useClassName({ props: nodeProps, node });
 
   if (!componentRegistration) {
-    console.info(
-      `;; cannot find componentRegistration for ${isAssembly ? `<embed ${node.definitionId}>` : `<${node.definitionId}>`}`,
-    );
-    return (
-      <div
-        style={{
-          border: '1px solid gold ',
-          width: '100%',
-          height: '100%',
-        }}>
-        <h1>
-          Cannot find componentRegistration <em>{node.definitionId}</em>
-        </h1>
-        <p>isAssembly: {isAssembly ? 'true' : 'false'}</p>
-        <p>definitionId: {node.definitionId}</p>
-        <pre>{JSON.stringify({ className }, null, 2)}</pre>
-      </div>
-    );
+    return null;
   }
 
   const { component } = componentRegistration;

--- a/packages/experience-builder-sdk/src/blocks/preview/CompositionBlock.tsx
+++ b/packages/experience-builder-sdk/src/blocks/preview/CompositionBlock.tsx
@@ -158,7 +158,24 @@ export const CompositionBlock = ({
   const className = useClassName({ props: nodeProps, node });
 
   if (!componentRegistration) {
-    return null;
+    console.info(
+      `;; cannot find componentRegistration for ${isAssembly ? `<embed ${node.definitionId}>` : `<${node.definitionId}>`}`,
+    );
+    return (
+      <div
+        style={{
+          border: '1px solid gold ',
+          width: '100%',
+          height: '100%',
+        }}>
+        <h1>
+          Cannot find componentRegistration <em>{node.definitionId}</em>
+        </h1>
+        <p>isAssembly: {isAssembly ? 'true' : 'false'}</p>
+        <p>definitionId: {node.definitionId}</p>
+        <pre>{JSON.stringify({ className }, null, 2)}</pre>
+      </div>
+    );
   }
 
   const { component } = componentRegistration;

--- a/packages/visual-editor/src/components/Draggable/SelectableComponent.tsx
+++ b/packages/visual-editor/src/components/Draggable/SelectableComponent.tsx
@@ -1,0 +1,78 @@
+import React, { useRef } from 'react';
+import { CSSProperties, ReactNode, SyntheticEvent } from 'react';
+import classNames from 'classnames';
+import styles from './styles.module.css';
+import { Rect } from '@components/Draggable/canvasToolsUtils';
+import Placeholder, { PlaceholderParams } from './Placeholder';
+import { useDraggedItemStore } from '@/store/draggedItem';
+import Tooltip from './Tooltip';
+
+interface SelectableComponentProps {
+  placeholder: PlaceholderParams;
+  wrapperProps: Record<string, string | undefined>;
+  tooltipLabel: string;
+  children: ReactNode;
+  id: string;
+  isAssemblyBlock?: boolean;
+  isSelected?: boolean;
+  onClick?: (e: SyntheticEvent) => void;
+  onMouseDown?: (e: SyntheticEvent) => void;
+  onMouseUp?: (e: SyntheticEvent) => void;
+  onMouseOver?: (e: SyntheticEvent) => void;
+  onMouseOut?: (e: SyntheticEvent) => void;
+  coordinates: Rect | null;
+  isContainer: boolean;
+  blockId?: string;
+  style?: CSSProperties;
+}
+
+export const SelectableComponent: React.FC<SelectableComponentProps> = ({
+  tooltipLabel,
+  children,
+  id,
+  isAssemblyBlock = false,
+  isSelected = false,
+  onClick = () => null,
+  onMouseOver = () => null,
+  coordinates,
+  style,
+  wrapperProps,
+  isContainer,
+  blockId,
+  placeholder,
+  ...rest
+}) => {
+  const ref = useRef<HTMLElement | null>(null);
+  const isHoveredComponent = useDraggedItemStore((state) => state.hoveredComponentId === id);
+
+  return (
+    <div
+      data-ctfl-draggable-id={id}
+      data-test-id={`draggable-${blockId ?? 'node'}`}
+      ref={(refNode) => {
+        ref.current = refNode;
+      }}
+      {...wrapperProps}
+      {...rest}
+      className={classNames(styles.DraggableComponent, wrapperProps.className, {
+        [styles.isAssemblyBlock]: isAssemblyBlock,
+        [styles.isSelected]: isSelected,
+        [styles.isHoveringComponent]: isHoveredComponent,
+      })}
+      style={{
+        ...style,
+      }}
+      onMouseOver={onMouseOver}
+      onClick={onClick}>
+      <Tooltip
+        id={id}
+        coordinates={coordinates}
+        isAssemblyBlock={isAssemblyBlock}
+        isContainer={isContainer}
+        label={tooltipLabel}
+      />
+      <Placeholder {...placeholder} id={id} />
+      {children}
+    </div>
+  );
+};

--- a/packages/visual-editor/src/components/Dropzone/EditorBlock.tsx
+++ b/packages/visual-editor/src/components/Dropzone/EditorBlock.tsx
@@ -89,7 +89,16 @@ export const EditorBlock: React.FC<EditorBlockProps> = ({
   };
 
   if (isComponentMissing || !definition || !elementToRender) {
-    return <div style={{ border: '1px solid gold' }}>Missing component</div>;
+    return (
+      <div
+        style={{
+          border: '1px solid red',
+          width: '100%',
+          height: '100%',
+        }}>
+        Missing component
+      </div>
+    );
   }
 
   if (isSingleColumn) {

--- a/packages/visual-editor/src/components/Dropzone/EditorBlock.tsx
+++ b/packages/visual-editor/src/components/Dropzone/EditorBlock.tsx
@@ -41,12 +41,13 @@ export const EditorBlock: React.FC<EditorBlockProps> = ({
 }) => {
   const setSelectedNodeId = useEditorStore((state) => state.setSelectedNodeId);
   const selectedNodeId = useEditorStore((state) => state.selectedNodeId);
-  const { node, componentId, wrapperProps, definition, elementToRender } = useComponent({
-    node: rawNode,
-    resolveDesignValue,
-    renderDropzone,
-    userIsDragging,
-  });
+  const { isComponentMissing, node, componentId, wrapperProps, definition, elementToRender } =
+    useComponent({
+      node: rawNode,
+      resolveDesignValue,
+      renderDropzone,
+      userIsDragging,
+    });
 
   const coordinates = useSelectedInstanceCoordinates({ node });
 
@@ -86,6 +87,10 @@ export const EditorBlock: React.FC<EditorBlockProps> = ({
       nodeId: componentId,
     });
   };
+
+  if (isComponentMissing || !definition || !elementToRender) {
+    return <div style={{ border: '1px solid gold' }}>Missing component</div>;
+  }
 
   if (isSingleColumn) {
     return (

--- a/packages/visual-editor/src/components/Dropzone/EditorBlock.tsx
+++ b/packages/visual-editor/src/components/Dropzone/EditorBlock.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { DraggableComponent } from '@components/Draggable/DraggableComponent';
+import { SelectableComponent } from '@components/Draggable/SelectableComponent';
 import { isContentfulStructureComponent, sendMessage } from '@contentful/experiences-core';
 import { useSelectedInstanceCoordinates } from '@/hooks/useSelectedInstanceCoordinates';
 import { useEditorStore } from '@/store/editor';
@@ -41,13 +42,19 @@ export const EditorBlock: React.FC<EditorBlockProps> = ({
 }) => {
   const setSelectedNodeId = useEditorStore((state) => state.setSelectedNodeId);
   const selectedNodeId = useEditorStore((state) => state.selectedNodeId);
-  const { isComponentMissing, node, componentId, wrapperProps, definition, elementToRender } =
-    useComponent({
-      node: rawNode,
-      resolveDesignValue,
-      renderDropzone,
-      userIsDragging,
-    });
+  const {
+    isComponentMissing,
+    node,
+    componentId /* node.data.id */,
+    wrapperProps,
+    definition,
+    elementToRender,
+  } = useComponent({
+    node: rawNode,
+    resolveDesignValue,
+    renderDropzone,
+    userIsDragging,
+  });
 
   const coordinates = useSelectedInstanceCoordinates({ node });
 
@@ -89,15 +96,32 @@ export const EditorBlock: React.FC<EditorBlockProps> = ({
   };
 
   if (isComponentMissing || !definition || !elementToRender) {
-    return (
+    const renderMissingComponentPlacehoder = () => (
       <div
         style={{
           border: '1px solid red',
           width: '100%',
           height: '100%',
         }}>
-        Missing component
+        Missing component &lt;{node.data.blockId}&gt;
       </div>
+    );
+
+    return (
+      <SelectableComponent
+        tooltipLabel="Missing component"
+        placeholder={placeholder}
+        id={node.data.id}
+        isAssemblyBlock={isAssembly || isAssemblyBlock}
+        isSelected={selectedNodeId === node.data.id}
+        isContainer={isContainer}
+        blockId={node.data.blockId}
+        coordinates={coordinates!}
+        wrapperProps={wrapperProps}
+        onClick={onClick}
+        onMouseOver={onMouseOver}>
+        {renderMissingComponentPlacehoder()}
+      </SelectableComponent>
     );
   }
 

--- a/packages/visual-editor/src/components/Dropzone/EditorBlockClone.tsx
+++ b/packages/visual-editor/src/components/Dropzone/EditorBlockClone.tsx
@@ -43,7 +43,7 @@ export const EditorBlockClone: React.FC<EditorBlockCloneProps> = ({
 }) => {
   const userIsDragging = useDraggedItemStore((state) => state.isDraggingOnCanvas);
 
-  const { node, wrapperProps, elementToRender } = useComponent({
+  const { isComponentMissing, node, wrapperProps, elementToRender } = useComponent({
     node: rawNode,
     resolveDesignValue,
     renderDropzone,
@@ -52,6 +52,10 @@ export const EditorBlockClone: React.FC<EditorBlockCloneProps> = ({
 
   const isAssemblyBlock = node.type === ASSEMBLY_BLOCK_NODE_TYPE;
   const isSingleColumn = node.data.blockId === CONTENTFUL_COMPONENTS.singleColumn.id;
+
+  if (isComponentMissing || !elementToRender) {
+    return <div>Missing component fallback</div>;
+  }
 
   if (isSingleColumn) {
     return elementToRender();

--- a/packages/visual-editor/src/components/Dropzone/useComponent.ts
+++ b/packages/visual-editor/src/components/Dropzone/useComponent.ts
@@ -1,5 +1,6 @@
 import React from 'react';
 import type {
+  ComponentRegistration,
   ExperienceTreeNode,
   ResolveDesignValueType,
 } from '@contentful/experiences-core/types';
@@ -42,7 +43,7 @@ export const useComponent = ({
     return rawNode;
   }, [areEntitiesFetched, rawNode, entityStore]);
 
-  const componentRegistration = useMemo(() => {
+  const componentRegistration: ComponentRegistration | undefined = useMemo(() => {
     let registration = componentRegistry.get(node.data.blockId!);
 
     if (node.type === ASSEMBLY_NODE_TYPE && !registration) {
@@ -53,9 +54,10 @@ export const useComponent = ({
     }
 
     if (!registration) {
-      throw Error(
-        `Component registration not found for component with id: "${node.data.blockId}". The component might of been removed. To proceed, remove the component manually from the layers tab.`,
+      console.warn(
+        `;;Component registration not found for component with id: "${node.data.blockId}". The component might of been removed. To proceed, remove the component manually from the layers tab.`,
       );
+      return undefined;
     }
     return registration;
   }, [node]);
@@ -67,30 +69,37 @@ export const useComponent = ({
     areEntitiesFetched,
     resolveDesignValue,
     renderDropzone,
-    definition: componentRegistration.definition,
+    definition: componentRegistration?.definition,
     userIsDragging,
   });
 
+  const createElementToRender = (componentRegistration: ComponentRegistration) => {
+    return builtInComponents.includes(node.data.blockId || '')
+      ? (dragProps?: NoWrapDraggableProps) =>
+          React.createElement(componentRegistration.component, { ...dragProps, ...componentProps })
+      : node.type === ASSEMBLY_NODE_TYPE
+        ? // Assembly.tsx requires renderDropzone and editorMode as well
+          () => React.createElement(componentRegistration.component, componentProps)
+        : () =>
+            React.createElement(
+              ImportedComponentErrorBoundary,
+              null,
+              React.createElement(componentRegistration.component, otherComponentProps),
+            );
+  };
+
   // Only pass editor props to built-in components
   const { editorMode, renderDropzone: _renderDropzone, ...otherComponentProps } = componentProps;
-  const elementToRender = builtInComponents.includes(node.data.blockId || '')
-    ? (dragProps?: NoWrapDraggableProps) =>
-        React.createElement(componentRegistration.component, { ...dragProps, ...componentProps })
-    : node.type === ASSEMBLY_NODE_TYPE
-      ? // Assembly.tsx requires renderDropzone and editorMode as well
-        () => React.createElement(componentRegistration.component, componentProps)
-      : () =>
-          React.createElement(
-            ImportedComponentErrorBoundary,
-            null,
-            React.createElement(componentRegistration.component, otherComponentProps),
-          );
+  const elementToRender = componentRegistration
+    ? createElementToRender(componentRegistration)
+    : null;
 
   return {
+    isComponentMissing: !componentRegistration,
     node,
     componentId,
     elementToRender,
     wrapperProps,
-    definition: componentRegistration.definition,
+    definition: componentRegistration ? componentRegistration.definition : null,
   };
 };

--- a/packages/visual-editor/src/components/Dropzone/useComponentProps.ts
+++ b/packages/visual-editor/src/components/Dropzone/useComponentProps.ts
@@ -47,7 +47,7 @@ type UseComponentProps = {
   node: ExperienceTreeNode;
   resolveDesignValue: ResolveDesignValueType;
   areEntitiesFetched: boolean;
-  definition: ComponentRegistration['definition'];
+  definition?: ComponentRegistration['definition'];
   renderDropzone: RenderDropzoneFunction;
   userIsDragging: boolean;
 };
@@ -260,7 +260,7 @@ export const useComponentProps = ({
     node,
     renderDropzone,
     ...omit(props, stylesToRemove, ['cfHyperlink', 'cfOpenInNewTab', 'cfSsrClassName']),
-    ...(definition.children ? { children: renderDropzone(node) } : {}),
+    ...(definition?.children ? { children: renderDropzone(node) } : {}),
   };
 
   return { componentProps, wrapperProps };


### PR DESCRIPTION
## ⚠️ RETIRED in favor of https://github.com/contentful/experience-builder/pull/658

## Purpose

> Relevant [user_interface PR](https://github.com/contentful/user_interface/pull/21393)


Instead of showing fatal error upon encountering missing component, just render placholder. Which would still allow the Editor to see the component in the canvas in EDITOR mode, as well as act upon canvas to solve the situation.


## Approach

The approach taken here is to introduce new component `<SelectableComponent>` which is supposed to be a younger and poorer brother of `<DraggableComponent>` with all of the DnD functionality stripped out. 

The assumption behind this choice was that - enhancing `<DraggableComponent>` with additional functionality will make it even more complicated. It already has so many variables/props which it depends on, that it's not that easy to follow what is happening there.
