### PR TITLE
fix: remove error when breakpoints are not defined [SPA-2078]

### DIFF
--- a/packages/core/src/registries/breakpointsRegistry.ts
+++ b/packages/core/src/registries/breakpointsRegistry.ts
@@ -12,6 +12,8 @@ export const defineBreakpoints = (breakpoints: Breakpoint[]) => {
 };
 
 export const runBreakpointsValidation = () => {
+  if (!breakpointsRegistry.length) return;
+
   const validation = validateBreakpointsDefinition(breakpointsRegistry);
   if (!validation.success) {
     throw new Error(


### PR DESCRIPTION
## Purpose
Prevent the editor from throwing an error when breakpoints are not defined

We provide a default fallback breakpoint in the UI, so it doesn't make sense to disrupt the editor when the user doesn't define breakpoints.