### PR TITLE
Allow package versions to be manually published as pre-releases for a selected branch

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,6 +5,12 @@ on:
     branches:
       - '**'
   workflow_dispatch:
+    inputs:
+      publish-prerelease:
+        description: 'Publish prerelease version of the selected branch'
+        required: false
+        default: false
+        type: boolean
 
 jobs:
   install-build:
@@ -21,7 +27,9 @@ jobs:
     if: >-
       (github.ref_name == 'main' ||
         github.ref_name == 'development' ||
-        github.ref_name == 'next') &&
+        github.ref_name == 'next' ||
+        inputs.publish-prerelease 
+      ) &&
       !contains(github.event.head_commit.message, 'skip-release') &&
       github.actor != 'dependabot[bot]' &&
       github.actor != 'contentful-automation[bot]'
@@ -29,6 +37,8 @@ jobs:
       contents: write
       id-token: write
     uses: ./.github/workflows/publish.yaml
+    with:
+      publish-prelease: ${{ inputs.publish-prerelease }}
     secrets:
       VAULT_URL: ${{ secrets.VAULT_URL }}
   upload-artifact-cleanup:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -80,8 +80,7 @@ jobs:
           git config user.email "${{ github.actor}}@users.noreply.github.com"
 
           if [ ${{ inputs.publish-prerelease }} ]; then
-            # temporarily echoing to verify that publish command is correct and correctly rendered
-            echo npx lerna publish --conventional-commits --conventional-prerelease --exact --force-publish --preid prerelease-$(date +%Y%m%dT%H%M)-$(git rev-parse HEAD | cut -c1-7) --no-changelog --no-push --yes --no-private --allow-branch ${{ github.ref_name }}
+            npx lerna publish --conventional-commits --conventional-prerelease --exact --force-publish --preid prerelease-$(date +%Y%m%dT%H%M)-$(git rev-parse HEAD | cut -c1-7) --no-changelog --no-push --yes --no-private --dist-tag prerelease --allow-branch ${{ github.ref_name }}
           elif [ ${{ github.ref_name }} = development ]; then
             npx lerna publish --conventional-commits --conventional-prerelease --exact --force-publish --preid dev-$(date +%Y%m%dT%H%M)-$(git rev-parse HEAD | cut -c1-7) --dist-tag dev --no-changelog --no-push --yes --no-private 
           elif [ ${{ github.ref_name }} = next ]; then

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -2,6 +2,12 @@ name: Publish packages
 
 on:
   workflow_call:
+    inputs:
+      publish-prelease:
+        description: 'Publish prerelease version of the current ref'
+        default: false
+        required: false
+        type: boolean
     secrets:
       VAULT_URL:
         required: true
@@ -73,14 +79,18 @@ jobs:
           git config user.name "${{ github.actor }}"
           git config user.email "${{ github.actor}}@users.noreply.github.com"
 
-          if [ ${{ github.ref_name }} = development ]; then
-            npx lerna publish --conventional-commits --conventional-prerelease --exact --force-publish --preid dev-$(date +%Y%m%dT%H%M)-$(git rev-parse HEAD  | cut -c1-7) --dist-tag dev --no-changelog --no-push --yes --no-private 
+          if [ ${{ inputs.publish-prerelease }} ]; then
+            # temporarily echoing to verify that publish command is correct and correctly rendered
+            echo npx lerna publish --conventional-commits --conventional-prerelease --exact --force-publish --preid prerelease-$(date +%Y%m%dT%H%M)-$(git rev-parse HEAD | cut -c1-7) --no-changelog --no-push --yes --no-private --allow-branch ${{ github.ref_name }}
+          elif [ ${{ github.ref_name }} = development ]; then
+            npx lerna publish --conventional-commits --conventional-prerelease --exact --force-publish --preid dev-$(date +%Y%m%dT%H%M)-$(git rev-parse HEAD | cut -c1-7) --dist-tag dev --no-changelog --no-push --yes --no-private 
           elif [ ${{ github.ref_name }} = next ]; then
             npx lerna publish --conventional-commits --conventional-prerelease --exact --force-publish --preid beta --dist-tag next --no-changelog --yes --no-private
           else
             npx lerna publish --conventional-commits --conventional-graduate --exact --force-publish --yes --no-private --dist-tag latest --create-release github
           fi
       - name: 'Merge changes downstream'
+        if: ${{ !inputs.publish-prerelease }}
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
         run: |

--- a/README.md
+++ b/README.md
@@ -63,6 +63,10 @@ When a PR is merged into `main`, the CI/CD pipeline will automatically publish a
 
 To fix a critical bug that is in `main`, branch of the `main` branch. When your work is complete open a PR against `main`, and when it is approved, merge it back into `main` using the "Squash and merge" option. The change will be automatically merged back into `next` and `development`. However, if there is a merge conflict doing so, you will have to resolve it manually.
 
+### "Prerelease" packages
+
+An option exists for developers to publish specific feature branches as an installable "prerelease" version for testing purposes. This option is presented when [manually triggering the main workflow](https://github.com/contentful/experience-builder/actions/workflows/main.yml). If the "Publish prerelease version of the selected branch" checkbox is selected, a package version for that work-in-progress feature branch will be published to the public NPM repository.
+
 ## Commit Message Guidelines
 
 We follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification for our commit messages. This allows us to automatically generate changelogs and version bumps based on the commit messages. Please take care in your commit messages that make it into the main branches (`development`, `next`, and `main`) to follow this specification, as it helps with the release process.


### PR DESCRIPTION
## Purpose

* Contributors from time to time want to publish specific builds to the public repo so they can be installed elsewhere (eg in user interface PRs where dependent changes are made)

## Approach

* Use existing workflow dispatch on main branch and add a toggle that allows a prerelease to be built for the selected branch
* Artifact uses same naming convention and lerna option as existing prerelease for `development` branch, except the preid is `prerelease` instead of `dev`. The dist-tag assigned is `prerelease`

<!--

Three important notes on Pull Requests:
- In general, you should ask yourself whether this code change will improve or worsen the overall code quality. Any new tech debt will probably never be cleaned up.
- Please remember that newly introduced logic should be validated and protected through testing.
- Take a look at PR guides such as Google's [Google’s Code Review Guidelines](https://google.github.io/eng-practices/) and [Blockly - Writing a Good Pull Request](https://developers.google.com/blockly/guides/contribute/get-started/write_a_good_pr)

-->