### PR TITLE
chore: handle default string input gracefully

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,7 +38,7 @@ jobs:
       id-token: write
     uses: ./.github/workflows/publish.yaml
     with:
-      publish-prelease: ${{ inputs.publish-prerelease }}
+      publish-prelease: ${{ !!inputs.publish-prerelease }}
     secrets:
       VAULT_URL: ${{ secrets.VAULT_URL }}
   upload-artifact-cleanup:


### PR DESCRIPTION
## Purpose

When a PR is merged a "push" event occurs and the value of the recently added `publish-prerelease` input is not false or null but rather an empty string. This doesn't match the required type here https://github.com/contentful/experience-builder/blob/development/.github/workflows/publish.yaml#L6-L10 .

To get this working we'll need to cast the input to a boolean.

Example failed workflow: https://github.com/contentful/experience-builder/actions/runs/9323345098

## Approach

* Coerce the value to a boolean using a double bang (`!!`). According to the GIthub Action docs (https://docs.github.com/en/actions/learn-github-actions/expressions) "in conditionals, falsy values (false, 0, -0, "", '', null) are coerced to false and truthy (true and other non-falsy values) are coerced to true." 