### PR TITLE
feat: allow for optional composite design token values in experiences

### DIFF
--- a/packages/core/src/registries/designTokenRegistry.ts
+++ b/packages/core/src/registries/designTokenRegistry.ts
@@ -3,13 +3,33 @@ import { builtInStyles, optionalBuiltInStyles } from '../definitions/styles';
 
 export let designTokensRegistry: DesignTokensDefinition = {};
 
+// This function is used to ensure that the composite values are valid since composite values are optional.
+// Therefore only border and in the future text related design tokens are/will be checked in this funciton.
+// Ensuring values for simple key-value design tokens are not neccessary since they are required via typescript.
+const ensureValidCompositeValues = (designTokenDefinition: DesignTokensDefinition) => {
+  // TODO: add validation logic when text related design tokens are added
+
+  // Border validation
+  if (designTokenDefinition.border) {
+    for (const borderKey in designTokenDefinition.border) {
+      const borderValue = designTokenDefinition.border[borderKey];
+      designTokenDefinition.border[borderKey] = {
+        width: borderValue.width || '1px',
+        style: borderValue.style || 'solid',
+        color: borderValue.color || '#000000',
+      };
+    }
+  }
+  return designTokenDefinition;
+};
+
 /**
  * Register design tokens styling
  * @param designTokenDefinition - {[key:string]: Record<string, string>}
  * @returns void
  */
 export const defineDesignTokens = (designTokenDefinition: DesignTokensDefinition) => {
-  Object.assign(designTokensRegistry, designTokenDefinition);
+  Object.assign(designTokensRegistry, ensureValidCompositeValues(designTokenDefinition));
 };
 
 const templateStringRegex = /\${(.+?)}/g;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -234,7 +234,10 @@ export type DesignTokensDefinition = {
   spacing?: Record<string, string>;
   sizing?: Record<string, string>;
   color?: Record<string, string>;
-  border?: Record<string, { width: string; style: 'solid' | 'dashed' | 'dotted'; color: string }>;
+  border?: Record<
+    string,
+    { width?: string; style?: 'solid' | 'dashed' | 'dotted'; color?: string }
+  >;
   borderRadius?: Record<string, string>;
   fontSize?: Record<string, string>;
   lineHeight?: Record<string, string>;

--- a/packages/experience-builder-sdk/src/core/componentRegistry.ts
+++ b/packages/experience-builder-sdk/src/core/componentRegistry.ts
@@ -267,15 +267,15 @@ const resolveCssVariables = (designTokensDefinition: DesignTokensDefinition) => 
     Object.keys(border).forEach((borderKey) => {
       const { width, style, color } = border[borderKey];
 
-      if (CssVarRegex.test(width)) {
+      if (width && CssVarRegex.test(width)) {
         const resolvedValue = getSingleCssVariableValue(element, width, 'border-width');
         tempResolvedValue[width] = resolvedValue;
       }
-      if (CssVarRegex.test(style)) {
+      if (style && CssVarRegex.test(style)) {
         const resolvedValue = getSingleCssVariableValue(element, style, 'border-style');
         tempResolvedValue[style] = resolvedValue;
       }
-      if (CssVarRegex.test(color)) {
+      if (color && CssVarRegex.test(color)) {
         const resolvedValue = getSingleCssVariableValue(element, color, 'border-color');
         tempResolvedValue[color] = resolvedValue;
       }


### PR DESCRIPTION
## Purpose
To make composite values optional when defining design tokens like border where it consists of a width, color, and style property.

## Approach
When creating the in memory design token structure, make sure the values are all set during construction. Only composite design tokens like border and eventually text need to be checked because simple key-value DTs are enforced by typescript.
Use `1px` as a fallback default for width
Use `black` as a fallback default for color
Use `solid` as a fallback default for style

## Testing
```
Used this for my DTs where I had a width, color, and style missing
// register design tokens
defineDesignTokens({
  border: {
    Azure: { style: 'solid', color: 'azure' },
    Card: { width: '1px', style: 'solid' },
    Carousel: {},
    Hero: { width: '2px', color: '#ffaabb' },
  },
});
```
which then produced this in the console log on the ui side.
<img width="1026" alt="Screenshot 2024-06-03 at 2 59 42 PM" src="https://github.com/contentful/experience-builder/assets/124832189/acd82941-a133-48d6-8eb8-e840f1b82e18">

