### PR TITLE
test: remove tests for already removed function []

### DIFF
--- a/packages/core/src/utils/styleUtils/styleTransformers.spec.ts
+++ b/packages/core/src/utils/styleUtils/styleTransformers.spec.ts
@@ -1,11 +1,9 @@
-import { CONTENTFUL_COMPONENTS } from '@/constants';
 import {
   transformAlignment,
   transformBackgroundImage,
   transformBorderStyle,
   transformFill,
   transformGridColumn,
-  transformWidthSizing,
 } from './styleTransformers';
 
 describe('transformFill', () => {
@@ -78,25 +76,5 @@ describe('transformBackgroundImage', () => {
       backgroundRepeat: 'no-repeat',
       backgroundSize: 'contain',
     });
-  });
-});
-describe('transformWidthSizing', () => {
-  it('takes into account margins if component is a structural component', () => {
-    expect(
-      transformWidthSizing({
-        value: '100px',
-        cfMargin: '10px 20px 30px 40px',
-        componentId: CONTENTFUL_COMPONENTS.container.id,
-      }),
-    ).toEqual('calc(100px - 40px - 20px)');
-  });
-  it('returns original width if component is not structural component', () => {
-    expect(
-      transformWidthSizing({
-        value: '100px',
-        cfMargin: '10px 10px 10px 10px',
-        componentId: CONTENTFUL_COMPONENTS.button.id,
-      }),
-    ).toEqual('100px');
   });
 });


### PR DESCRIPTION
## Purpose

`transformWidthSizing` was removed in a [different PR](https://github.com/contentful/experience-builder/pull/643) so the tests for it are no longer needed.