### PR TITLE
[ALT-911] fix: only have default background color for components that need to have them

### DIFF
--- a/packages/core/src/definitions/styles.ts
+++ b/packages/core/src/definitions/styles.ts
@@ -75,7 +75,6 @@ export const builtInStyles: VariableDefinitions = {
     type: 'Text',
     group: 'style',
     description: 'The background color of the section',
-    defaultValue: 'rgba(255, 255, 255, 0)',
   },
   cfWidth: {
     displayName: 'Width',
@@ -427,7 +426,6 @@ export const singleColumnBuiltInStyles: VariableDefinitions = {
     type: 'Text',
     group: 'style',
     description: 'The background color of the column',
-    defaultValue: 'rgba(255, 255, 255, 0)',
   },
   cfFlexDirection: {
     displayName: 'Direction',
@@ -506,7 +504,6 @@ export const columnsBuiltInStyles: VariableDefinitions = {
     type: 'Text',
     group: 'style',
     description: 'The background color of the columns',
-    defaultValue: 'rgba(255, 255, 255, 0)',
   },
   cfBorder: {
     displayName: 'Border',

--- a/packages/experience-builder-sdk/src/utils/ssrStyles.spec.ts
+++ b/packages/experience-builder-sdk/src/utils/ssrStyles.spec.ts
@@ -58,7 +58,7 @@ describe('maybePopulateDesignTokenValue', () => {
       'color.black': '#000000',
     });
 
-    expect(res).toBe(builtInStyles.cfBackgroundColor?.defaultValue);
+    expect(res).toBe(`${builtInStyles.cfBackgroundColor?.defaultValue}`);
   });
 
   it('should repalce design token variables with their values', () => {


### PR DESCRIPTION
## Purpose
Only have default background color for components that need to have them which at this point is the `Button` and `Divider` component

https://www.loom.com/share/d44ced7d7abf4350898ec459c4448e86?sid=c7105e44-928c-4616-99f3-68f27579c313
