### PR TITLE
fix: allow experiences-sdk-react components/hooks to be imported in NextJS server components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2575,7 +2575,6 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -35993,6 +35992,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/rollup-plugin-preserve-directives": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-preserve-directives/-/rollup-plugin-preserve-directives-0.4.0.tgz",
+      "integrity": "sha512-gx4nBxYm5BysmEQS+e2tAMrtFxrGvk+Pe5ppafRibQi0zlW7VYAbEGk6IKDw9sJGPdFWgVTE0o4BU4cdG0Fylg==",
+      "dev": true,
+      "dependencies": {
+        "@rollup/pluginutils": "^5.1.0",
+        "magic-string": "^0.30.5"
+      },
+      "peerDependencies": {
+        "rollup": "2.x || 3.x || 4.x"
+      }
+    },
     "node_modules/rollup-plugin-serve": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/rollup-plugin-serve/-/rollup-plugin-serve-3.0.0.tgz",
@@ -42872,6 +42884,7 @@
       "dependencies": {
         "@contentful/experiences-components-react": "file:../components",
         "@contentful/experiences-core": "file:../core",
+        "@contentful/experiences-validators": "file:../validators",
         "@contentful/experiences-visual-editor-react": "file:../visual-editor",
         "@contentful/rich-text-types": "^16.2.1",
         "classnames": "^2.3.2",
@@ -42913,6 +42926,7 @@
         "rollup-plugin-node-externals": "^7.0.1",
         "rollup-plugin-peer-deps-external": "^2.2.4",
         "rollup-plugin-postcss": "^4.0.2",
+        "rollup-plugin-preserve-directives": "^0.4.0",
         "semantic-release": "23.0.2",
         "ts-jest": "^29.1.0",
         "typescript": "^5.2.2",

--- a/packages/experience-builder-sdk/package.json
+++ b/packages/experience-builder-sdk/package.json
@@ -35,6 +35,7 @@
   "dependencies": {
     "@contentful/experiences-components-react": "file:../components",
     "@contentful/experiences-core": "file:../core",
+    "@contentful/experiences-validators": "file:../validators",
     "@contentful/experiences-visual-editor-react": "file:../visual-editor",
     "@contentful/rich-text-types": "^16.2.1",
     "classnames": "^2.3.2",
@@ -76,6 +77,7 @@
     "rollup-plugin-node-externals": "^7.0.1",
     "rollup-plugin-peer-deps-external": "^2.2.4",
     "rollup-plugin-postcss": "^4.0.2",
+    "rollup-plugin-preserve-directives": "^0.4.0",
     "semantic-release": "23.0.2",
     "ts-jest": "^29.1.0",
     "typescript": "^5.2.2",

--- a/packages/experience-builder-sdk/rollup.config.mjs
+++ b/packages/experience-builder-sdk/rollup.config.mjs
@@ -5,6 +5,7 @@ import dts from 'rollup-plugin-dts';
 import postcss from 'rollup-plugin-postcss';
 import postcssImport from 'postcss-import';
 import nodeExternals from 'rollup-plugin-node-externals';
+import preserveDirectives from 'rollup-plugin-preserve-directives';
 
 export default [
   {
@@ -14,9 +15,11 @@ export default [
         dir: './dist',
         format: 'esm',
         sourcemap: true,
+        preserveModules: true,
       },
     ],
     plugins: [
+      preserveDirectives(),
       nodeExternals(),
       postcss({
         plugins: [postcssImport()],
@@ -28,6 +31,13 @@ export default [
       commonjs(),
       typescript({ tsconfig: './tsconfig.json', noEmitOnError: process.env.DEV ? false : true }),
     ],
+    onwarn(log, handler) {
+      //swallow warnings about using 'use client' directive
+      if (log.message.indexOf('Module level directives cause errors when bundled, "use client"') > -1) {
+        return;
+      }
+      handler(log)
+    },
   },
   {
     input: 'src/index.ts',

--- a/packages/experience-builder-sdk/src/ExperienceRoot.tsx
+++ b/packages/experience-builder-sdk/src/ExperienceRoot.tsx
@@ -35,7 +35,7 @@ export const ExperienceRoot = ({
   if (isEditorMode) {
     return (
       <VisualEditorRoot
-        experience={experienceObject}
+        experience={experienceObject as Experience<EntityStore> | undefined}
         visualEditorMode={visualEditorMode}
         initialLocale={locale}
       />

--- a/packages/experience-builder-sdk/src/ExperienceRoot.tsx
+++ b/packages/experience-builder-sdk/src/ExperienceRoot.tsx
@@ -1,6 +1,10 @@
 'use client';
 import React from 'react';
-import { VisualEditorMode, validateExperienceBuilderConfig } from '@contentful/experiences-core';
+import {
+  VisualEditorMode,
+  createExperience,
+  validateExperienceBuilderConfig,
+} from '@contentful/experiences-core';
 import { EntityStore } from '@contentful/experiences-core';
 import type { Experience } from '@contentful/experiences-core/types';
 import { PreviewDeliveryRoot } from './blocks/preview/PreviewDeliveryRoot';
@@ -8,7 +12,7 @@ import VisualEditorRoot from './blocks/editor/VisualEditorRoot';
 import { useDetectEditorMode } from './hooks/useDetectEditorMode';
 
 type ExperienceRootProps = {
-  experience?: Experience<EntityStore>;
+  experience?: Experience<EntityStore> | string;
   locale: string;
   visualEditorMode?: VisualEditorMode;
 };
@@ -19,6 +23,9 @@ export const ExperienceRoot = ({
   visualEditorMode = VisualEditorMode.LazyLoad,
 }: ExperienceRootProps) => {
   const isEditorMode = useDetectEditorMode();
+  //If experience is passed in as a JSON string, recreate it to an experience object
+  const experienceObject =
+    typeof experience === 'string' ? createExperience(experience) : experience;
 
   validateExperienceBuilderConfig({
     locale,
@@ -28,14 +35,14 @@ export const ExperienceRoot = ({
   if (isEditorMode) {
     return (
       <VisualEditorRoot
-        experience={experience}
+        experience={experienceObject}
         visualEditorMode={visualEditorMode}
         initialLocale={locale}
       />
     );
   }
 
-  if (!experience) return null;
+  if (!experienceObject) return null;
 
-  return <PreviewDeliveryRoot locale={locale} experience={experience} />;
+  return <PreviewDeliveryRoot locale={locale} experience={experienceObject} />;
 };

--- a/packages/experience-builder-sdk/src/ExperienceRoot.tsx
+++ b/packages/experience-builder-sdk/src/ExperienceRoot.tsx
@@ -1,3 +1,4 @@
+'use client';
 import React from 'react';
 import { VisualEditorMode, validateExperienceBuilderConfig } from '@contentful/experiences-core';
 import { EntityStore } from '@contentful/experiences-core';

--- a/packages/experience-builder-sdk/src/ExperienceRoot.tsx
+++ b/packages/experience-builder-sdk/src/ExperienceRoot.tsx
@@ -12,7 +12,7 @@ import VisualEditorRoot from './blocks/editor/VisualEditorRoot';
 import { useDetectEditorMode } from './hooks/useDetectEditorMode';
 
 type ExperienceRootProps = {
-  experience?: Experience<EntityStore> | string;
+  experience?: Experience<EntityStore> | string | null;
   locale: string;
   visualEditorMode?: VisualEditorMode;
 };

--- a/packages/experience-builder-sdk/src/hooks/useDetectEditorMode.tsx
+++ b/packages/experience-builder-sdk/src/hooks/useDetectEditorMode.tsx
@@ -1,3 +1,4 @@
+'use client';
 import { useEffect, useRef, useState } from 'react';
 import {
   doesMismatchMessageSchema,

--- a/packages/experience-builder-sdk/src/hooks/useFetchByBase.ts
+++ b/packages/experience-builder-sdk/src/hooks/useFetchByBase.ts
@@ -1,3 +1,4 @@
+'use client';
 import { useEffect, useState } from 'react';
 import { EntityStore } from '@contentful/experiences-core';
 import type { Experience } from '@contentful/experiences-core/types';


### PR DESCRIPTION
## Purpose

Allows importing code direclty from `@contentful/experiences-sdk-react` from NextJS server components.

Right now we have a workaround to import certain pieces from `@contentful/experiences-core` as importing them in a NextJS server component will throw an error. This fix allows those components to now be successfully imported from the main sdk.

Ticket: https://contentful.atlassian.net/browse/ALT-1010

## Approach

I added `use client` directives to components that use anything from React that requires client side (useState, useLayoutEffect, etc..). This instructs Next that these are client components, and it will import them as such. This change should have no effect on other frameworks as the 'use client' directive should simply be ignored by them.

To get this to work, I had to change the rollup build to preserve the modules (and not bundle them), and to not exclude the directive.

## Test Dev Build

You can test this out locally with a dev build by installing `@contentful/experiences-sdk-react@1.8.1-prerelease-20240624T1502-6dcdc44.0`