### PR TITLE
fix: resilient resolve logic of deep bindings [SPA-2110]

### DIFF
--- a/packages/core/src/fetchers/gatherAutoFetchedReferentsFromIncludes.spec.ts
+++ b/packages/core/src/fetchers/gatherAutoFetchedReferentsFromIncludes.spec.ts
@@ -91,7 +91,7 @@ describe('gatherAutoFetchedReferentsFromIncludes', () => {
     });
   });
 
-  it('throws an error if head entity not in collection', () => {
+  it('resolves nothing if head entity is missing', () => {
     const deepReferences = [
       new DeepReference({
         path: '/uuid1/fields/logo/~locale/fields/file/~locale',
@@ -100,10 +100,29 @@ describe('gatherAutoFetchedReferentsFromIncludes', () => {
     ];
 
     const newCollection = { items: [], includes: { ...collection.includes } };
-    expect(() =>
-      gatherAutoFetchedReferentsFromIncludes(deepReferences, newCollection),
-    ).toThrowError(
-      `LogicError: When resolving deep-references could not find headEntry (id=entry1)`,
-    );
+    const result = gatherAutoFetchedReferentsFromIncludes(deepReferences, newCollection);
+    expect(result).toEqual({
+      autoFetchedReferentAssets: [],
+      autoFetchedReferentEntries: [],
+    });
+  });
+
+  it('resolves nothing if L2-referent is missing', () => {
+    const deepReferences = [
+      new DeepReference({
+        path: '/uuid1/fields/logo/~locale/fields/file/~locale',
+        dataSource,
+      }),
+    ];
+
+    const newCollection = {
+      items: [...collection.items],
+      includes: { Entry: [...collection.includes.Entry], Asset: [] },
+    };
+    const result = gatherAutoFetchedReferentsFromIncludes(deepReferences, newCollection);
+    expect(result).toEqual({
+      autoFetchedReferentAssets: [],
+      autoFetchedReferentEntries: [],
+    });
   });
 });

--- a/packages/core/src/fetchers/gatherAutoFetchedReferentsFromIncludes.ts
+++ b/packages/core/src/fetchers/gatherAutoFetchedReferentsFromIncludes.ts
@@ -37,23 +37,24 @@ export function gatherAutoFetchedReferentsFromIncludes(
       (entry) => entry.sys.id === reference.headEntityId,
     );
     if (!headEntry) {
-      throw new Error(
-        `LogicError: When resolving deep-references could not find headEntry (id=${reference.entityId})`,
+      console.debug(
+        `[experiences-sdk-core::fetchers] When resolving deep-references could not find headEntry with id '${reference.entityId}'`,
       );
+      continue;
     }
 
     const linkToReferent = headEntry.fields[reference.field] as UnresolvedLink<'Asset' | 'Entry'>;
 
     if (undefined === linkToReferent) {
       console.debug(
-        `[experiences-sdk-react::gatherAutoFetchedReferentsFromIncludes] Empty reference in headEntity. Probably reference is simply not set.`,
+        `[experiences-sdk-core::fetchers] Empty reference in headEntity. Probably reference is simply not set.`,
       );
       continue;
     }
 
     if (!isLink(linkToReferent)) {
       console.debug(
-        `[experiences-sdk-react::gatherAutoFetchedReferentsFromIncludes] Non-link value in headEntity. Probably broken path '${reference.originalPath}'`,
+        `[experiences-sdk-core::fetchers] Non-link value in headEntity. Probably broken path '${reference.originalPath}'`,
       );
       continue;
     }
@@ -62,9 +63,7 @@ export function gatherAutoFetchedReferentsFromIncludes(
 
     if (!['Entry', 'Asset'].includes(linkType)) {
       console.debug(
-        `[experiences-sdk-react::gatherAutoFetchedReferentsFromIncludes] Unhandled linkType :${JSON.stringify(
-          linkToReferent,
-        )}`,
+        `[experiences-sdk-core::fetchers] Unhandled linkType :${JSON.stringify(linkToReferent)}`,
       );
       continue;
     }
@@ -73,11 +72,14 @@ export function gatherAutoFetchedReferentsFromIncludes(
       (entity) => entity.sys.id === linkToReferent.sys.id,
     );
     if (!referentEntity) {
-      throw new Error(
-        `Logic Error: L2-referent ${linkType} was not found within .includes (${JSON.stringify({
-          linkToReferent,
-        })})`,
+      console.debug(
+        `[experiences-sdk-core::fetchers] L2-referent ${linkType} was not found within .includes (${JSON.stringify(
+          {
+            linkToReferent,
+          },
+        )})`,
       );
+      continue;
     }
 
     linkType === 'Entry'


### PR DESCRIPTION
## Purpose
When an entry or asset was deleted which is used in a deep-bound value, the app would just crash in preview mode. Similarly to other places in the code, we want here also a less disrupting experience but just ignore broken bindings.

## Approach
Similar to other cases covered in `gatherAutoFetchedReferentsFromIncludes`, we will create a debug message instead of throwing a crashing error.