### PR TITLE
fix(test-app): define display icon for test-app breakpoints []

### DIFF
--- a/packages/test-apps/nextjs/src/eb-config.ts
+++ b/packages/test-apps/nextjs/src/eb-config.ts
@@ -103,18 +103,21 @@ defineBreakpoints([
     id: 'test-desktop',
     query: '*',
     displayName: 'All Sizes',
+    displayIcon: 'desktop',
     previewSize: '100%',
   },
   {
     id: 'test-tablet',
     query: '<982px',
     displayName: 'Tablet',
+    displayIcon: 'tablet',
     previewSize: '820px',
   },
   {
     id: 'test-mobile',
     query: '<360px',
     displayName: 'Mobile',
+    displayIcon: 'mobile',
     previewSize: '390px',
   },
 ]);

--- a/packages/test-apps/react-vite/src/eb-config.ts
+++ b/packages/test-apps/react-vite/src/eb-config.ts
@@ -103,18 +103,21 @@ defineBreakpoints([
     id: 'test-desktop',
     query: '*',
     displayName: 'All Sizes',
+    displayIcon: 'desktop',
     previewSize: '100%',
   },
   {
     id: 'test-tablet',
     query: '<982px',
     displayName: 'Tablet',
+    displayIcon: 'tablet',
     previewSize: '820px',
   },
   {
     id: 'test-mobile',
     query: '<360px',
     displayName: 'Mobile',
+    displayIcon: 'mobile',
     previewSize: '390px',
   },
 ]);


### PR DESCRIPTION
Currently, the test app defines no breakpoint icons. This makes the editor currently render the fallback icon.
Note that this change requires updating the breakpoints via the editor.

Before:
![Screenshot 2024-07-02 at 16 39 27](https://github.com/contentful/experience-builder/assets/9327071/43622e36-430d-4eba-a629-149f8a5e2046)

After:
![Screenshot 2024-07-02 at 16 39 13](https://github.com/contentful/experience-builder/assets/9327071/b2aec53c-31f1-48dd-a3a1-60a5c4c7448e)
