### PR TITLE
test: experiences SDK consumer pacts [SPA-2129]

### DIFF
--- a/packages/visual-editor/src/hooks/useEditorSubscriber.spec.ts
+++ b/packages/visual-editor/src/hooks/useEditorSubscriber.spec.ts
@@ -154,7 +154,6 @@ describe('Canvas Subscriber methods', () => {
   const createPostMessageReceiverForSelectedEntities = (_event: IncomingEvent, payload) =>
     asynchronousBodyHandler(async () => {
       const store = new EditorModeEntityStore({ entities: [], locale: 'en-US' });
-      console.log(store);
 
       const promise = store.fetchEntities({
         missingEntryIds: [entityIds.ENTRY1, entityIds.ENTRY2],
@@ -172,9 +171,6 @@ describe('Canvas Subscriber methods', () => {
     'should receive the expected payload for $event event',
     async ({ id, description, event, payload, payloadMatcher }) => {
       let messageReceiverConstructor = createPostMessageReceiver;
-      if (event !== INCOMING_EVENTS.RequestedEntities) {
-        return;
-      }
       if (event === INCOMING_EVENTS.RequestedEntities) {
         messageReceiverConstructor = createPostMessageReceiverForSelectedEntities;
       }

--- a/packages/visual-editor/src/hooks/useEditorSubscriber.spec.ts
+++ b/packages/visual-editor/src/hooks/useEditorSubscriber.spec.ts
@@ -1,58 +1,97 @@
 import { describe, it, vi } from 'vitest';
-import { renderHook } from '@testing-library/react';
+import { renderHook, act } from '@testing-library/react';
 import * as treeStoreModule from '@/store/tree';
 import * as entityStoreModule from '@/store/entityStore';
 import { useEditorSubscriber } from './useEditorSubscriber';
-import { IncomingEvent } from '@contentful/experiences-core/types';
-import { MessageConsumerPact, synchronousBodyHandler, Matchers as m } from '@pact-foundation/pact';
+import {
+  AssembliesAddedPayload,
+  AssembliesRegisteredPayload,
+  IncomingMouseMovePayload,
+  IncomingEvent,
+  UpdatedEntityPayload,
+  ComponentDraggingChangedPayload,
+  HoverComponentPayload,
+  SelectComponentPayload,
+  CanvasResizedPayload,
+  ExperienceUpdatedPayload,
+} from '@contentful/experiences-core/types';
+import { asynchronousBodyHandler } from '@pact-foundation/pact';
+import { entityIds, entries } from '../../test/__fixtures__/entities';
+import { interactions, InteractionIds, PactConsumer } from '../../test/pact';
+import { assembliesRegistry, componentRegistry } from '@/store/registries';
+import { useDraggedItemStore } from '@/store/draggedItem';
+import simulateDnD from '@/utils/simulateDnD';
+import * as communicationModule from '@/communication/sendSelectedComponentCoordinates';
+import { useEditorStore } from '@/store/editor';
+import * as coreModule from '@contentful/experiences-core';
+import { EditorModeEntityStore } from '@contentful/experiences-core';
 import { INCOMING_EVENTS } from '@contentful/experiences-core/constants';
-import { entries } from '../../test/__fixtures__/entities';
 
-const event = INCOMING_EVENTS.UpdatedEntity;
-const entity = entries[0];
-const updatedEntity = {
-  ...entity,
-  sys: { ...entity.sys, version: entity.sys.version + 1 },
-};
-const messagePayload = {
-  eventType: event,
-  payload: {
-    entity: updatedEntity,
-    shouldRerender: true,
-  },
-  source: 'composability-app',
-};
+const updateNodesByUpdatedEntity = vi.fn();
+const updateEntity = vi.fn();
+const updateTree = vi.fn();
 
-// This shape doesn't reflect reality completely, in reality we send a stringified JSON object
-const data = {
-  eventType: event,
-  payload: {
-    entity: {
-      sys: m.like({
-        id: m.string(),
-        type: m.string(),
-        version: m.integer(),
-      }),
-      fields: m.like({}),
-    },
-    shouldRerender: m.boolean(),
+const expectations = {
+  [InteractionIds.experienceTreeUpdatedInteractionId]: (payload: ExperienceUpdatedPayload) => {
+    expect(updateTree).toHaveBeenCalledWith(payload.tree);
+    expect(coreModule.getDataFromTree).toHaveBeenCalled();
   },
-  source: 'composability-app',
+  [InteractionIds.experienceNodeUpdatedInteractionId]: (payload: ExperienceUpdatedPayload) => {
+    expect(updateTree).toHaveBeenCalledWith(payload.tree);
+    expect(useEditorStore.getState().unboundValues).toStrictEqual(
+      payload.changedNode?.data?.unboundValues,
+    );
+    expect(coreModule.getDataFromTree).not.toHaveBeenCalled();
+  },
+  [InteractionIds.assembliesAddedInteractionId]: (payload: AssembliesAddedPayload) => {
+    const assemblyLink = { sys: { id: payload.assembly.sys.id, linkType: 'Entry', type: 'Link' } };
+    expect(updateEntity).toHaveBeenNthCalledWith(1, payload.assembly);
+    expect(assembliesRegistry.get(payload.assembly.sys.id)).toEqual(assemblyLink);
+    const registration = componentRegistry.get(payload.assembly.sys.id);
+    expect(registration?.definition).toEqual(payload.assemblyDefinition);
+  },
+  [InteractionIds.assembliesRegisteredInteractionId]: (payload: AssembliesRegisteredPayload) => {
+    const registration = componentRegistry.get(payload.assemblies[0].id);
+    expect(registration?.definition).toEqual(payload.assemblies[0]);
+  },
+  [InteractionIds.updatedEntityInteractionId]: (payload: UpdatedEntityPayload) => {
+    expect(updateNodesByUpdatedEntity).toHaveBeenNthCalledWith(1, payload.entity.sys.id);
+    expect(updateEntity).toHaveBeenNthCalledWith(1, payload.entity);
+  },
+  [InteractionIds.mouseMoveInteractionId]: (payload: IncomingMouseMovePayload) => {
+    expect(useDraggedItemStore.getState().mouseX).toBe(payload.mouseX);
+    expect(useDraggedItemStore.getState().mouseY).toBe(payload.mouseY);
+    expect(simulateDnD.updateDrag).toHaveBeenCalledWith(payload.mouseX, payload.mouseY);
+  },
+  [InteractionIds.componentDraggingChangedInteractionId]: (
+    payload: ComponentDraggingChangedPayload,
+  ) => {
+    expect(useDraggedItemStore.getState().componentId).toBe('');
+    expect(useDraggedItemStore.getState().isDraggingOnCanvas).toBe(payload.isDragging);
+  },
+  [InteractionIds.componentMoveEndedInteractionId]: (payload: IncomingMouseMovePayload) => {
+    expect(simulateDnD.endDrag).toHaveBeenCalledWith(payload.mouseX, payload.mouseY);
+  },
+  [InteractionIds.hoverComponentInteractionId]: (payload: HoverComponentPayload) => {
+    expect(useDraggedItemStore.getState().hoveredComponentId).toBe(payload.hoveredNodeId);
+  },
+  [InteractionIds.selectComponentInteractionId]: (payload: SelectComponentPayload) => {
+    expect(communicationModule.sendSelectedComponentCoordinates).toHaveBeenCalledWith(
+      payload.selectedNodeId,
+    );
+  },
+  [InteractionIds.canvasResizedInteractionId]: (payload: CanvasResizedPayload) => {
+    expect(communicationModule.sendSelectedComponentCoordinates).toHaveBeenCalledWith(
+      payload.selectedNodeId,
+    );
+  },
 };
 
 describe('Canvas Subscriber methods', () => {
-  const pact = new MessageConsumerPact({
-    consumer: 'ExperiencesSDKConsumer',
-    provider: 'UserInterfaceProvider',
-    logLevel: 'info',
-    // Silence warning about older spec version of existing pact files -> always overwrite existing pact files
-    pactfileWriteMode: 'overwrite',
-    dir: '../../pacts',
-  });
-
   beforeAll(() => {
     // Monkey patch console.debug to avoid debug logs for consequently fired messages
     const origConsoleDebug = console.debug;
+    const origConsoleWarn = console.warn;
     const debugMessages = ['sendMessage', 'onMessage'];
     console.debug = (message: unknown, ...args: unknown[]) => {
       if (debugMessages.some((msg) => `${message}`.includes(msg))) {
@@ -60,23 +99,45 @@ describe('Canvas Subscriber methods', () => {
       }
       origConsoleDebug.apply(console, [message, ...args]);
     };
+    console.warn = (message: unknown, ...args: unknown[]) => {
+      if (debugMessages.some((msg) => `${message}`.includes(msg))) {
+        return;
+      }
+      origConsoleWarn.apply(console, [message, ...args]);
+    };
   });
 
-  const createPostMessageReceiver = (_event: IncomingEvent, payload: typeof messagePayload) =>
-    synchronousBodyHandler(() => {
+  beforeEach(() => {
+    vi.spyOn(treeStoreModule, 'useTreeStore').mockReturnValue({
+      updateNodesByUpdatedEntity,
+      updateTree,
+    });
+    vi.spyOn(entityStoreModule, 'useEntityStore').mockImplementation((selector) =>
+      selector({
+        entityStore: {
+          entities: entries,
+          updateEntity,
+          locale: 'en-US',
+          getMissingEntityIds: vi.fn(() => ({ missingAssetIds: [], missingEntryIds: [] })),
+        },
+        setEntitiesFetched: vi.fn(),
+        setFetchingEntities: vi.fn(),
+      } as unknown as entityStoreModule.EntityState),
+    );
+    vi.spyOn(coreModule, 'getDataFromTree');
+    vi.spyOn(simulateDnD, 'updateDrag');
+    vi.spyOn(simulateDnD, 'endDrag');
+    vi.spyOn(communicationModule, 'sendSelectedComponentCoordinates');
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  const createPostMessageReceiver = (_event: IncomingEvent, payload, expectations) =>
+    asynchronousBodyHandler(async () => {
       let listener: EventListener | undefined;
-      const updateNodesByUpdatedEntity = vi.fn();
-      const updateEntity = vi.fn();
-      vi.spyOn(treeStoreModule, 'useTreeStore').mockReturnValueOnce({ updateNodesByUpdatedEntity });
-      vi.spyOn(entityStoreModule, 'useEntityStore').mockImplementation((selector) =>
-        selector({
-          entityStore: {
-            entities: entries,
-            updateEntity,
-            locale: 'en-US',
-          },
-        } as unknown as entityStoreModule.EntityState),
-      );
+
       vi.spyOn(window, 'addEventListener').mockImplementationOnce((_event, _listener) => {
         listener = _listener as EventListener;
       });
@@ -85,19 +146,42 @@ describe('Canvas Subscriber methods', () => {
 
       // assert that the listener is called with the expected payload and performs the right actions
       expect(listener).toBeDefined();
-      listener!(new MessageEvent('message', { data: JSON.stringify(payload) }));
-      expect(updateNodesByUpdatedEntity).toHaveBeenNthCalledWith(1, updatedEntity.sys.id);
-      expect(updateEntity).toHaveBeenNthCalledWith(1, updatedEntity);
+      await act(() => listener!(new MessageEvent('message', { data: JSON.stringify(payload) })));
+
+      expectations?.(payload.payload);
     });
 
-  it.each`
-    event    | payload           | data
-    ${event} | ${messagePayload} | ${data}
-  `('should receive the expected payload for "$event" event', async ({ event, payload, data }) => {
-    await pact
-      .given(`a ${event} message is sent`)
-      .expectsToReceive(`a ${event} message`)
-      .withContent(data)
-      .verify(createPostMessageReceiver(event, payload));
-  });
+  const createPostMessageReceiverForSelectedEntities = (_event: IncomingEvent, payload) =>
+    asynchronousBodyHandler(async () => {
+      const store = new EditorModeEntityStore({ entities: [], locale: 'en-US' });
+      console.log(store);
+
+      const promise = store.fetchEntities({
+        missingEntryIds: [entityIds.ENTRY1, entityIds.ENTRY2],
+        missingAssetIds: [],
+        skipCache: true,
+      });
+      window.dispatchEvent(new MessageEvent('message', { data: JSON.stringify(payload) }));
+
+      await promise;
+
+      expect(store.entities).toEqual(expect.arrayContaining(entries));
+    });
+
+  it.each(interactions)(
+    'should receive the expected payload for $event event',
+    async ({ id, description, event, payload, payloadMatcher }) => {
+      let messageReceiverConstructor = createPostMessageReceiver;
+      if (event !== INCOMING_EVENTS.RequestedEntities) {
+        return;
+      }
+      if (event === INCOMING_EVENTS.RequestedEntities) {
+        messageReceiverConstructor = createPostMessageReceiverForSelectedEntities;
+      }
+      await PactConsumer.given(description)
+        .expectsToReceive(id)
+        .withContent(payloadMatcher)
+        .verify(messageReceiverConstructor(event, payload, expectations[id]));
+    },
+  );
 });

--- a/packages/visual-editor/src/hooks/useEditorSubscriber.ts
+++ b/packages/visual-editor/src/hooks/useEditorSubscriber.ts
@@ -207,7 +207,6 @@ export function useEditorSubscriber() {
             newEntityStore = resetEntityStore(locale);
             setLocale(locale);
           }
-
           // Below are mutually exclusive cases
           if (changedNode) {
             /**

--- a/packages/visual-editor/test/__fixtures__/assembly.ts
+++ b/packages/visual-editor/test/__fixtures__/assembly.ts
@@ -6,8 +6,8 @@ import {
 import type { ExperienceTreeNode, SchemaVersions } from '@contentful/experiences-core/types';
 
 type createAssemblyEntryArgs = {
-  schemaVersion: SchemaVersions;
-  id: string;
+  schemaVersion?: SchemaVersions;
+  id?: string;
 };
 
 export const defaultAssemblyId = 'assembly-id';
@@ -45,6 +45,7 @@ export const createAssemblyEntry = ({
           id: 'cfexampleEnvironment',
         },
       },
+      version: 1,
     },
     metadata: { tags: [] },
     fields: {

--- a/packages/visual-editor/test/__fixtures__/assemblyDefinition.ts
+++ b/packages/visual-editor/test/__fixtures__/assemblyDefinition.ts
@@ -1,0 +1,8 @@
+import { ComponentDefinition } from '@contentful/experiences-core/types';
+import { defaultAssemblyId } from './assembly';
+
+export const assemblyDefinition: ComponentDefinition = {
+  id: defaultAssemblyId,
+  name: 'Assembly',
+  variables: {},
+};

--- a/packages/visual-editor/test/__fixtures__/tree.ts
+++ b/packages/visual-editor/test/__fixtures__/tree.ts
@@ -1,4 +1,8 @@
+<<<<<<< HEAD
 import { ExperienceTree } from '../../../core/src/types';
+=======
+import { ExperienceTree } from '@contentful/experiences-core/types';
+>>>>>>> d62612c8 (test: add pact contracts for ExperiencesSDKConsumer)
 
 export const tree: ExperienceTree = {
   root: {
@@ -10,8 +14,22 @@ export const tree: ExperienceTree = {
           breakpoints: [],
           dataSource: {},
           id: 'component-1',
+<<<<<<< HEAD
           props: {},
           unboundValues: {},
+=======
+          props: {
+            title: {
+              type: 'UnboundValue',
+              key: 'unbound_uuid1',
+            },
+          },
+          unboundValues: {
+            unbound_uuid1: {
+              value: 'custom component title',
+            },
+          },
+>>>>>>> d62612c8 (test: add pact contracts for ExperiencesSDKConsumer)
           blockId: 'component-1',
         },
       },

--- a/packages/visual-editor/test/__fixtures__/tree.ts
+++ b/packages/visual-editor/test/__fixtures__/tree.ts
@@ -1,8 +1,4 @@
-<<<<<<< HEAD
-import { ExperienceTree } from '../../../core/src/types';
-=======
 import { ExperienceTree } from '@contentful/experiences-core/types';
->>>>>>> d62612c8 (test: add pact contracts for ExperiencesSDKConsumer)
 
 export const tree: ExperienceTree = {
   root: {
@@ -14,10 +10,6 @@ export const tree: ExperienceTree = {
           breakpoints: [],
           dataSource: {},
           id: 'component-1',
-<<<<<<< HEAD
-          props: {},
-          unboundValues: {},
-=======
           props: {
             title: {
               type: 'UnboundValue',
@@ -29,7 +21,6 @@ export const tree: ExperienceTree = {
               value: 'custom component title',
             },
           },
->>>>>>> d62612c8 (test: add pact contracts for ExperiencesSDKConsumer)
           blockId: 'component-1',
         },
       },

--- a/packages/visual-editor/test/pact/PactConsumer.ts
+++ b/packages/visual-editor/test/pact/PactConsumer.ts
@@ -1,0 +1,12 @@
+const { MessageConsumerPact } = require('@pact-foundation/pact');
+
+const PACT_CONSUMER = 'ExperiencesSDKConsumer';
+const PACT_PROVIDER = 'UserInterfaceProvider';
+
+export const PactConsumer = new MessageConsumerPact({
+  consumer: PACT_CONSUMER,
+  provider: PACT_PROVIDER,
+  // Silence warning about older spec version of existing pact files -> always overwrite existing pact files
+  pactfileWriteMode: 'overwrite',
+  dir: '../../pacts',
+});

--- a/packages/visual-editor/test/pact/index.ts
+++ b/packages/visual-editor/test/pact/index.ts
@@ -1,0 +1,2 @@
+export { interactions, InteractionIds } from './interactions';
+export { PactConsumer } from './PactConsumer';

--- a/packages/visual-editor/test/pact/interactions.ts
+++ b/packages/visual-editor/test/pact/interactions.ts
@@ -1,0 +1,338 @@
+import {
+  AssembliesAddedPayload,
+  AssembliesRegisteredPayload,
+  CanvasResizedPayload,
+  ComponentDraggingChangedPayload,
+  ExperienceUpdatedPayload,
+  HoverComponentPayload,
+  MouseMovePayload,
+  RequestedEntitiesPayload,
+  SelectComponentPayload,
+  UpdatedEntityPayload,
+  IncomingComponentMoveEndedPayload,
+} from '@contentful/experiences-core/types';
+import { INCOMING_EVENTS } from '@contentful/experiences-core/constants';
+import { Matchers as m, MatchersV3 as mV3 } from '@pact-foundation/pact';
+import { entries } from '../__fixtures__/entities';
+import { assemblyDefinition } from '../__fixtures__/assemblyDefinition';
+import { createAssemblyEntry } from '../__fixtures__/assembly';
+import { tree } from '../__fixtures__/tree';
+
+const SOURCE = 'composability-app';
+
+export const InteractionIds = {
+  experienceTreeUpdatedInteractionId: 'component-tree-updated-event',
+  experienceNodeUpdatedInteractionId: 'component-tree-node-updated-event',
+  componentDraggingChangedInteractionId: 'component-dragging-changed-event',
+  componentMoveEndedInteractionId: 'component-move-ended-event',
+  canvasResizedInteractionId: 'canvas-resized-event',
+  selectComponentInteractionId: 'select-component-event',
+  hoverComponentInteractionId: 'hover-component-event',
+  updatedEntityInteractionId: 'updated-entity-event',
+  assembliesAddedInteractionId: 'assemblies-added-event',
+  assembliesRegisteredInteractionId: 'assemblies-registered-event',
+  mouseMoveInteractionId: 'mouse-move-event',
+  requestedEntitiesInteractionId: 'requested-entities-event',
+};
+
+const treeNodeMatcher = {
+  children: m.eachLike({}),
+  type: m.string(),
+  data: m.like({
+    breakpoints: m.eachLike({
+      id: m.string(),
+      displayName: m.string(),
+      query: m.string(),
+      previewSize: m.string(),
+      displayIcon: m.string(),
+    }),
+    dataSource: mV3.eachValueMatches(
+      { uuid1: { sys: { id: m.string(), linkType: m.like('Entry'), type: 'Link' } } },
+      mV3.like({ sys: { id: m.string(), linkType: m.like('Entry'), type: 'Link' } }),
+    ),
+    id: m.string(),
+    props: m.like({}),
+    unboundValues: mV3.eachValueMatches(
+      { uuid1: { value: m.string() } },
+      mV3.like({ value: m.string() }),
+    ),
+    blockId: m.string(),
+  }),
+};
+
+const treeMatcher = {
+  root: treeNodeMatcher,
+};
+const experienceTreeUpdatedInteraction = {
+  id: InteractionIds.experienceTreeUpdatedInteractionId,
+  description: `a ${INCOMING_EVENTS.ExperienceUpdated} event is sent by the Web App`,
+  event: INCOMING_EVENTS.ExperienceUpdated,
+  payload: {
+    eventType: INCOMING_EVENTS.ExperienceUpdated,
+    source: SOURCE,
+    payload: {
+      tree,
+      locale: 'en-US',
+    } as ExperienceUpdatedPayload,
+  },
+  payloadMatcher: {
+    eventType: INCOMING_EVENTS.ExperienceUpdated,
+    source: SOURCE,
+    payload: {
+      eventType: INCOMING_EVENTS.ExperienceUpdated,
+      source: SOURCE,
+      payload: {
+        tree: treeMatcher,
+        locale: m.string(),
+      },
+    },
+  },
+};
+
+const experienceNodeUpdatedInteraction = {
+  id: InteractionIds.experienceNodeUpdatedInteractionId,
+  description: `a ${INCOMING_EVENTS.ExperienceUpdated} event for a single node is sent by the Web App`,
+  event: INCOMING_EVENTS.ExperienceUpdated,
+  payload: {
+    eventType: INCOMING_EVENTS.ExperienceUpdated,
+    source: SOURCE,
+    payload: {
+      tree,
+      changedNode: tree.root.children[0],
+      changedValueType: 'UnboundValue',
+      locale: 'en-US',
+    } as ExperienceUpdatedPayload,
+  },
+  payloadMatcher: {
+    eventType: INCOMING_EVENTS.ExperienceUpdated,
+    source: SOURCE,
+    payload: {
+      tree: treeMatcher,
+      changedNode: treeNodeMatcher,
+      changedValueType: m.term({
+        generate: 'UnboundValue',
+        matcher: 'UnboundValue|BoundValue',
+      }),
+      locale: m.string(),
+    },
+  },
+};
+
+const componentDraggingChangedInteraction = {
+  id: InteractionIds.componentDraggingChangedInteractionId,
+  description: `a ${INCOMING_EVENTS.ComponentDraggingChanged} event is sent by the Web App`,
+  event: INCOMING_EVENTS.ComponentDraggingChanged,
+  payload: {
+    eventType: INCOMING_EVENTS.ComponentDraggingChanged,
+    source: SOURCE,
+    payload: { isDragging: false } as ComponentDraggingChangedPayload,
+  },
+  payloadMatcher: {
+    eventType: INCOMING_EVENTS.ComponentDraggingChanged,
+    source: SOURCE,
+    payload: {
+      isDragging: m.like(false),
+    },
+  },
+};
+
+const componentMoveEndedInteraction = {
+  id: InteractionIds.componentMoveEndedInteractionId,
+  description: `a ${INCOMING_EVENTS.ComponentMoveEnded} event is sent by the Web App`,
+  event: INCOMING_EVENTS.ComponentMoveEnded,
+  payload: {
+    eventType: INCOMING_EVENTS.ComponentMoveEnded,
+    source: SOURCE,
+    payload: {
+      mouseX: 100,
+      mouseY: 100,
+    } as IncomingComponentMoveEndedPayload,
+  },
+  payloadMatcher: {
+    eventType: INCOMING_EVENTS.ComponentMoveEnded,
+    source: SOURCE,
+    payload: {
+      mouseX: m.like(100),
+      mouseY: m.like(100),
+    },
+  },
+};
+
+const canvasResizedInteraction = {
+  id: InteractionIds.canvasResizedInteractionId,
+  description: `a ${INCOMING_EVENTS.CanvasResized} event is sent by the Web App`,
+  event: INCOMING_EVENTS.CanvasResized,
+  payload: {
+    eventType: INCOMING_EVENTS.CanvasResized,
+    source: SOURCE,
+    payload: { selectedNodeId: 'node-id' } as CanvasResizedPayload,
+  },
+  payloadMatcher: {
+    eventType: INCOMING_EVENTS.CanvasResized,
+    source: SOURCE,
+    payload: { selectedNodeId: m.like('node-id') },
+  },
+};
+
+const selectComponentInteraction = {
+  id: InteractionIds.selectComponentInteractionId,
+  description: `a ${INCOMING_EVENTS.SelectComponent} event is sent by the Web App`,
+  event: INCOMING_EVENTS.SelectComponent,
+  payload: {
+    eventType: INCOMING_EVENTS.SelectComponent,
+    source: SOURCE,
+    payload: { selectedNodeId: 'node-id' } as SelectComponentPayload,
+  },
+  payloadMatcher: {
+    eventType: INCOMING_EVENTS.SelectComponent,
+    source: SOURCE,
+    payload: { selectedNodeId: m.like('node-id') },
+  },
+};
+
+const hoverComponentInteraction = {
+  id: InteractionIds.hoverComponentInteractionId,
+  description: `a ${INCOMING_EVENTS.HoverComponent} event is sent by the Web App`,
+  event: INCOMING_EVENTS.HoverComponent,
+  payload: {
+    eventType: INCOMING_EVENTS.HoverComponent,
+    source: SOURCE,
+    payload: { hoveredNodeId: 'node-id' } as HoverComponentPayload,
+  },
+  payloadMatcher: {
+    eventType: INCOMING_EVENTS.HoverComponent,
+    source: SOURCE,
+    payload: { hoveredNodeId: m.like('node-id') },
+  },
+};
+
+const entity = entries[0];
+const updatedEntity = {
+  ...entity,
+  sys: { ...entity.sys, version: entity.sys.version + 1 },
+};
+const entityMatcher = {
+  sys: m.like({
+    id: m.string(),
+    type: m.string(),
+    version: m.integer(),
+  }),
+  fields: m.like({}),
+};
+const updatedEntityInteraction = {
+  id: InteractionIds.updatedEntityInteractionId,
+  description: `a ${INCOMING_EVENTS.UpdatedEntity} event is sent by the Web App`,
+  event: INCOMING_EVENTS.UpdatedEntity,
+  payload: {
+    eventType: INCOMING_EVENTS.UpdatedEntity,
+    source: SOURCE,
+    payload: {
+      entity: updatedEntity,
+      shouldRerender: true,
+    } as UpdatedEntityPayload,
+  },
+  payloadMatcher: {
+    eventType: INCOMING_EVENTS.UpdatedEntity,
+    source: SOURCE,
+    payload: {
+      entity: entityMatcher,
+      shouldRerender: m.boolean(),
+    },
+  },
+};
+
+const assembly = createAssemblyEntry({});
+const assembliesAddedInteraction = {
+  id: InteractionIds.assembliesAddedInteractionId,
+  description: `a ${INCOMING_EVENTS.AssembliesAdded} event is sent by the Web App`,
+  event: INCOMING_EVENTS.AssembliesAdded,
+  payload: {
+    eventType: INCOMING_EVENTS.AssembliesAdded,
+    source: SOURCE,
+    payload: {
+      assembly,
+      assemblyDefinition,
+    } as AssembliesAddedPayload,
+  },
+  payloadMatcher: {
+    eventType: INCOMING_EVENTS.AssembliesAdded,
+    source: SOURCE,
+    payload: {
+      assembly: {},
+      assemblyDefinition: {
+        id: m.like('assembly-id'),
+        name: m.like('Assembly'),
+        variables: m.like({}),
+      },
+    },
+  },
+};
+
+const assembliesRegisteredInteraction = {
+  id: InteractionIds.assembliesRegisteredInteractionId,
+  description: `a ${INCOMING_EVENTS.AssembliesRegistered} event is sent by the Web App`,
+  event: INCOMING_EVENTS.AssembliesRegistered,
+  payload: {
+    eventType: INCOMING_EVENTS.AssembliesRegistered,
+    source: SOURCE,
+    payload: { assemblies: [assemblyDefinition] } as AssembliesRegisteredPayload,
+  },
+  payloadMatcher: {
+    eventType: INCOMING_EVENTS.AssembliesRegistered,
+    source: SOURCE,
+    payload: {
+      assemblies: m.eachLike({
+        id: m.like('assembly-id'),
+        name: m.like('Assembly'),
+        variables: m.like({}),
+      }),
+    },
+  },
+};
+
+const mouseMoveInteraction = {
+  id: InteractionIds.mouseMoveInteractionId,
+  description: `a ${INCOMING_EVENTS.MouseMove} event is sent by the Web App`,
+  event: INCOMING_EVENTS.MouseMove,
+  payload: {
+    eventType: INCOMING_EVENTS.MouseMove,
+    source: SOURCE,
+    payload: { clientX: 100, clientY: 100 } as MouseMovePayload,
+  },
+  payloadMatcher: {
+    eventType: INCOMING_EVENTS.MouseMove,
+    source: SOURCE,
+    payload: { clientX: m.like(100), clientY: m.like(100) },
+  },
+};
+
+const requestedEntitiesInteraction = {
+  id: InteractionIds.requestedEntitiesInteractionId,
+  description: `a ${INCOMING_EVENTS.RequestedEntities} event is sent by the Web App`,
+  event: INCOMING_EVENTS.RequestedEntities,
+  payload: {
+    eventType: INCOMING_EVENTS.RequestedEntities,
+    source: SOURCE,
+    payload: { entities: entries } as RequestedEntitiesPayload,
+  },
+  payloadMatcher: {
+    eventType: INCOMING_EVENTS.RequestedEntities,
+    source: SOURCE,
+    payload: { entities: m.eachLike(entityMatcher) },
+  },
+};
+
+export const interactions = [
+  experienceTreeUpdatedInteraction,
+  experienceNodeUpdatedInteraction,
+  componentDraggingChangedInteraction,
+  componentMoveEndedInteraction,
+  canvasResizedInteraction,
+  selectComponentInteraction,
+  hoverComponentInteraction,
+  updatedEntityInteraction,
+  assembliesAddedInteraction,
+  assembliesRegisteredInteraction,
+  mouseMoveInteraction,
+  requestedEntitiesInteraction,
+];


### PR DESCRIPTION
## Purpose

Implement consumer contract tests for ExperiencesSDKConsumer.

## Approach

* Each interaction includes an example payload and a payload matcher as well as a unique id. 
* Each interaction is run through the `createPostMessageReceiver` function which renders the `useEditorSubscriber` hook and triggers a message with the specified payload.
* Each interaction created a pact in the `pacts/ExperiencesSDKConsumer-UserInterfaceProvider.json` file. (This file is ignored by git, but running the tests locally will generate it and can be inspected)
* For each interaction we run a set of assertions based on what is expected to happen when the specific message is received.
* Some trivial events with no payload have been ignored.


