### PR TITLE
chore: update nextjs apps to use defineComponents

### DIFF
--- a/examples/next-app-router/src/app/[locale]/[slug]/page.tsx
+++ b/examples/next-app-router/src/app/[locale]/[slug]/page.tsx
@@ -1,5 +1,6 @@
+import Experience from '@/components/Experience';
 import { getExperience } from '@/getExperience';
-import { ExperienceRoot, detachExperienceStyles } from '@contentful/experiences-sdk-react';
+import { detachExperienceStyles } from '@contentful/experiences-sdk-react';
 
 type Page = {
   params: { locale?: string; slug?: string; preview?: string };
@@ -25,7 +26,7 @@ export default async function ExperiencePage({ params, searchParams }: Page) {
   return (
     <main style={{ width: '100%' }}>
       {stylesheet && <style>{stylesheet}</style>}
-      <ExperienceRoot experience={experienceJSON} locale={locale} />
+      <Experience experienceJSON={experienceJSON} locale={locale} />
     </main>
   );
 }

--- a/examples/next-app-router/src/components/Experience.tsx
+++ b/examples/next-app-router/src/components/Experience.tsx
@@ -1,0 +1,16 @@
+'use client';
+
+import '../eb-config';
+import { ExperienceRoot } from '@contentful/experiences-sdk-react';
+import React from 'react';
+
+interface ExperienceProps {
+  experienceJSON: string | null;
+  locale: string;
+}
+
+const Experience: React.FC<ExperienceProps> = ({ experienceJSON, locale }) => {
+  return <ExperienceRoot experience={experienceJSON} locale={locale} />;
+};
+
+export default Experience;

--- a/examples/next-app-router/src/eb-config.ts
+++ b/examples/next-app-router/src/eb-config.ts
@@ -1,0 +1,21 @@
+import { defineComponents } from '@contentful/experiences-sdk-react';
+
+defineComponents([
+  // Add your custom components here
+  // example:
+  // {
+  //   component: Button,
+  //   definition: {
+  //     id: 'custom-button',
+  //     name: 'Button',
+  //     category: 'Custom Components',
+  //     variables: {
+  //       text: {
+  //         displayName: 'Text',
+  //         type: 'Text',
+  //         defaultValue: 'Click me'
+  //       },
+  //     },
+  //   },
+  // },
+]);

--- a/examples/next-pages-router/src/eb-config.ts
+++ b/examples/next-pages-router/src/eb-config.ts
@@ -1,0 +1,21 @@
+import { defineComponents } from '@contentful/experiences-sdk-react';
+
+defineComponents([
+  // Add your custom components here
+  // example:
+  // {
+  //   component: Button,
+  //   definition: {
+  //     id: 'custom-button',
+  //     name: 'Button',
+  //     category: 'Custom Components',
+  //     variables: {
+  //       text: {
+  //         displayName: 'Text',
+  //         type: 'Text',
+  //         defaultValue: 'Click me'
+  //       },
+  //     },
+  //   },
+  // },
+]);

--- a/examples/next-pages-router/src/pages/[slug].tsx
+++ b/examples/next-pages-router/src/pages/[slug].tsx
@@ -3,6 +3,7 @@ import { GetServerSidePropsContext, InferGetServerSidePropsType } from 'next';
 import { ParsedUrlQuery } from 'querystring';
 import { getExperience } from '@/getExperience';
 import Head from 'next/head';
+import '../eb-config';
 
 interface Params extends ParsedUrlQuery {
   locale: string;

--- a/packages/test-apps/nextjs/src/app/[[...slug]]/page.tsx
+++ b/packages/test-apps/nextjs/src/app/[[...slug]]/page.tsx
@@ -1,5 +1,6 @@
+import Experience from '@/components/Experience';
 import { getExperience } from '@/utils/getExperience';
-import { ExperienceRoot, detachExperienceStyles } from '@contentful/experiences-sdk-react';
+import { detachExperienceStyles } from '@contentful/experiences-sdk-react';
 
 type Page = {
   params: { locale?: string; slug?: string; preview?: string };
@@ -25,7 +26,7 @@ export default async function ExperiencePage({ params, searchParams }: Page) {
   return (
     <main style={{ width: '100%' }}>
       {stylesheet && <style data-css-ssr>{stylesheet}</style>}
-      <ExperienceRoot experience={experienceJSON} locale={locale} />
+      <Experience experienceJSON={experienceJSON} locale={locale} />
     </main>
   );
 }

--- a/packages/test-apps/nextjs/src/components/Experience.tsx
+++ b/packages/test-apps/nextjs/src/components/Experience.tsx
@@ -1,0 +1,16 @@
+'use client';
+
+import '../eb-config';
+import { ExperienceRoot } from '@contentful/experiences-sdk-react';
+import React from 'react';
+
+interface ExperienceProps {
+  experienceJSON: string | null;
+  locale: string;
+}
+
+const Experience: React.FC<ExperienceProps> = ({ experienceJSON, locale }) => {
+  return <ExperienceRoot experience={experienceJSON} locale={locale} />;
+};
+
+export default Experience;


### PR DESCRIPTION
## Purpose

I noticed the new Next.js apps didn't have a call to defineComponents since they didn't have any custom components in the example. When I went to add it, I saw that in the case of app router, the current set up where the ExperienceRoot was directly in a RSC, the call to defineComponents didn't work as that was made server side. I updated the app router apps to put the `ExperienceRoot` in a client component and called the defineComponents method from there.
