### PR TITLE
feat: implement column reorder [ALT-802]

### DIFF
--- a/packages/visual-editor/src/components/DraggableBlock/EditorBlock.tsx
+++ b/packages/visual-editor/src/components/DraggableBlock/EditorBlock.tsx
@@ -24,6 +24,7 @@ import { useDraggedItemStore } from '@/store/draggedItem';
 import classNames from 'classnames';
 import styles from './styles.module.css';
 import { parseZoneId } from '@/utils/zone';
+import useSingleColumn from '@/hooks/useSingleColumn';
 
 function getStyle(style, snapshot) {
   if (!snapshot.isDropAnimating) {
@@ -67,6 +68,7 @@ export const EditorBlock: React.FC<EditorBlockProps> = ({
     userIsDragging,
     slotId,
   });
+  const { isSingleColumn, isWrapped } = useSingleColumn(node, resolveDesignValue);
   const setDomRect = useDraggedItemStore((state) => state.setDomRect);
   const isHoveredComponent = useDraggedItemStore(
     (state) => state.hoveredComponentId === componentId,
@@ -76,12 +78,11 @@ export const EditorBlock: React.FC<EditorBlockProps> = ({
   const testId = `draggable-${node.data.blockId ?? 'node'}`;
   const isSelected = node.data.id === selectedNodeId;
   const isContainer = node.data.blockId === CONTENTFUL_COMPONENTS.container.id;
-  const isSingleColumn = node.data.blockId === CONTENTFUL_COMPONENTS.singleColumn.id;
   const isAssemblyBlock = node.type === ASSEMBLY_BLOCK_NODE_TYPE;
   const isAssembly = node.type === ASSEMBLY_NODE_TYPE;
   const isStructureComponent = isContentfulStructureComponent(node.data.blockId);
   const isSlotComponent = Boolean(node.data.slotId);
-  const isDragDisabled = isAssemblyBlock || isSingleColumn || isSlotComponent;
+  const isDragDisabled = isAssemblyBlock || (isSingleColumn && isWrapped) || isSlotComponent;
 
   const isEmptyZone = useMemo(() => {
     return !node.children.filter((node) => node.data.slotId === slotId).length;

--- a/packages/visual-editor/src/hooks/useSingleColumn.ts
+++ b/packages/visual-editor/src/hooks/useSingleColumn.ts
@@ -1,0 +1,50 @@
+import { useTreeStore } from '@/store/tree';
+import { getItem } from '@/utils/getItem';
+import { CONTENTFUL_COMPONENTS } from '@contentful/experiences-core/constants';
+import { ExperienceTreeNode, ResolveDesignValueType } from '@contentful/experiences-core/types';
+import { useMemo } from 'react';
+
+export default function useSingleColumn(
+  node: ExperienceTreeNode,
+  resolveDesignValue: ResolveDesignValueType,
+) {
+  const tree = useTreeStore((store) => store.tree);
+
+  const isSingleColumn = node.data.blockId === CONTENTFUL_COMPONENTS.singleColumn.id;
+
+  const { isWrapped, wrapColumnsCount } = useMemo(() => {
+    let isWrapped = false;
+    let wrapColumnsCount = 0;
+
+    if (!node.parentId || !isSingleColumn) {
+      return { isWrapped, wrapColumnsCount };
+    }
+
+    const parentNode = getItem({ id: node.parentId }, tree);
+
+    if (!parentNode) {
+      return { isWrapped, wrapColumnsCount };
+    }
+
+    const { cfWrapColumns, cfWrapColumnsCount } = parentNode.data.props;
+
+    if (cfWrapColumns.type === 'DesignValue') {
+      isWrapped = resolveDesignValue(cfWrapColumns.valuesByBreakpoint, 'cfWrapColumns') as boolean;
+    }
+
+    if (cfWrapColumnsCount.type === 'DesignValue') {
+      wrapColumnsCount = resolveDesignValue(
+        cfWrapColumnsCount.valuesByBreakpoint,
+        'cfWrapColumnsCount',
+      ) as number;
+    }
+
+    return { isWrapped, wrapColumnsCount };
+  }, [tree, node, isSingleColumn, resolveDesignValue]);
+
+  return {
+    isSingleColumn,
+    isWrapped,
+    wrapColumnsCount,
+  };
+}


### PR DESCRIPTION
## Purpose
Allow users to reorder single columns in a column component from the canvas. This is purposely only enabled when columnWrap is turned off as the complexity of reorder across rows and columns breaks dnd.

Ticket: https://contentful.atlassian.net/browse/ALT-802


https://github.com/user-attachments/assets/71a5c445-aca4-40d0-8473-198022974fd6

