### PR TITLE
feat: support rendering of component values for design properties [SPA-2145]

### DIFF
--- a/packages/core/src/test/__fixtures__/experience.ts
+++ b/packages/core/src/test/__fixtures__/experience.ts
@@ -1,5 +1,5 @@
 import { CONTENTFUL_COMPONENTS, LATEST_SCHEMA_VERSION } from '@/constants';
-import { ExperienceEntry, SchemaVersions } from '@/types';
+import { ExperienceComponentSettings, ExperienceEntry, SchemaVersions } from '@/types';
 import { entityIds } from './entities';
 
 const experienceFields: ExperienceEntry['fields'] = {
@@ -184,6 +184,7 @@ export const createExperienceEntry = ({
 };
 
 export const assemblyGeneratedVariableName = 'text_uuid1Assembly';
+export const assemblyGeneratedDesignVariableName = 'cfWidth_uuid2Assembly';
 export const createAssemblyEntry = ({
   schemaVersion = LATEST_SCHEMA_VERSION,
   id = 'assembly-id',
@@ -225,8 +226,24 @@ export const createAssemblyEntry = ({
         children: [
           {
             definitionId: CONTENTFUL_COMPONENTS.container.id,
-            variables: {},
-            children: [],
+            variables: {
+              cfWidth: {
+                type: 'ComponentValue',
+                key: assemblyGeneratedDesignVariableName,
+              },
+            },
+            children: [
+              {
+                definitionId: 'custom-component',
+                variables: {
+                  text: {
+                    type: 'ComponentValue',
+                    key: assemblyGeneratedVariableName,
+                  },
+                },
+                children: [],
+              },
+            ],
           },
         ],
 
@@ -242,14 +259,18 @@ export const createAssemblyEntry = ({
       componentSettings: {
         variableDefinitions: {
           [assemblyGeneratedVariableName]: {
-            id: 'text',
-            name: 'Text',
+            displayName: 'Text',
             type: 'Text',
             defaultValue: { type: 'UnboundValue', key: 'unbound_uuid1Assembly' },
-            required: false,
+          },
+          [assemblyGeneratedDesignVariableName]: {
+            displayName: 'Width',
+            type: 'Text',
+            group: 'style',
+            defaultValue: { type: 'DesignValue', valuesByBreakpoint: { desktop: '42px' } },
           },
         },
-      },
+      } satisfies ExperienceComponentSettings,
     },
   };
 };

--- a/packages/experience-builder-sdk/src/blocks/preview/CompositionBlock.tsx
+++ b/packages/experience-builder-sdk/src/blocks/preview/CompositionBlock.tsx
@@ -136,6 +136,7 @@ export const CompositionBlock = ({
           case 'ComponentValue':
             // We're rendering a pattern entry. Content cannot be set for ComponentValue type properties
             // directly in the pattern so we can safely use the default value
+            // This can either a design (style) or a content variable
             acc[variableName] = variableDefinition.defaultValue;
             break;
           default:

--- a/packages/experience-builder-sdk/src/core/preview/assemblyUtils.spec.ts
+++ b/packages/experience-builder-sdk/src/core/preview/assemblyUtils.spec.ts
@@ -1,6 +1,9 @@
 import type { Entry } from 'contentful';
 import { experienceEntry } from '../../../test/__fixtures__/composition';
-import { createAssemblyEntry } from '../../../test/__fixtures__/assembly';
+import {
+  assemblyGeneratedDesignVariableName,
+  createAssemblyEntry,
+} from '../../../test/__fixtures__/assembly';
 import { assets, entries } from '../../../test/__fixtures__/entities';
 import { CONTENTFUL_COMPONENTS } from '@contentful/experiences-core/constants';
 import type { ComponentTreeNode } from '@contentful/experiences-core/types';
@@ -56,13 +59,8 @@ describe('resolveAssembly', () => {
 
     expect(result).toBe(assemblyNode);
   });
-  it('should return a assembly node with children', () => {
-    const assemblyNode: ComponentTreeNode = {
-      definitionId: 'assembly-id',
-      variables: {},
-      children: [],
-    };
 
+  describe('when the assembly exists in the entity store', () => {
     const assemblyEntry = createAssemblyEntry({
       id: 'assembly-id',
       schemaVersion: '2023-09-28',
@@ -80,15 +78,60 @@ describe('resolveAssembly', () => {
       locale: 'en-US',
     });
 
-    const result = resolveAssembly({ node: assemblyNode, entityStore });
+    it('should return a assembly node with children', () => {
+      const assemblyNode: ComponentTreeNode = {
+        definitionId: 'assembly-id',
+        variables: {},
+        children: [],
+      };
 
-    expect(result).toEqual({
-      ...assemblyNode,
-      children: assemblyEntry.fields.componentTree.children,
+      const result = resolveAssembly({ node: assemblyNode, entityStore });
+
+      expect(result.children).toHaveLength(1);
+      expect(result.children[0].children).toHaveLength(1);
+      // This will be exactly like in the definition as the instance doesn't define a value for the ComponentValue
+      expect(result.children[0].children[0]).toEqual(
+        assemblyEntry.fields.componentTree.children[0].children[0],
+      );
+      expect(entityStore.unboundValues).toEqual({
+        ...experienceEntry.fields.unboundValues,
+        ...assemblyEntry.fields.unboundValues,
+      });
     });
-    expect(entityStore.unboundValues).toEqual({
-      ...experienceEntry.fields.unboundValues,
-      ...assemblyEntry.fields.unboundValues,
+
+    it('resolves a style component value with the value of the assembly instance', () => {
+      const assemblyNode: ComponentTreeNode = {
+        definitionId: 'assembly-id',
+        variables: {
+          [assemblyGeneratedDesignVariableName]: {
+            type: 'DesignValue',
+            valuesByBreakpoint: { desktop: '99px' },
+          },
+        },
+        children: [],
+      };
+
+      const result = resolveAssembly({ node: assemblyNode, entityStore });
+
+      expect(result.children[0].variables.cfWidth).toEqual({
+        type: 'DesignValue',
+        valuesByBreakpoint: { desktop: '99px' },
+      });
+    });
+
+    it('falls back to the defaultValue when a style component value is not defined on the instance', () => {
+      const assemblyNode: ComponentTreeNode = {
+        definitionId: 'assembly-id',
+        variables: {},
+        children: [],
+      };
+
+      const result = resolveAssembly({ node: assemblyNode, entityStore });
+
+      expect(result.children[0].variables.cfWidth).toEqual({
+        type: 'DesignValue',
+        valuesByBreakpoint: { desktop: '42px' },
+      });
     });
   });
 });

--- a/packages/experience-builder-sdk/src/core/preview/assemblyUtils.ts
+++ b/packages/experience-builder-sdk/src/core/preview/assemblyUtils.ts
@@ -1,6 +1,8 @@
 import { checkIsAssemblyNode, EntityStore } from '@contentful/experiences-core';
 import type { ComponentPropertyValue, ComponentTreeNode } from '@contentful/experiences-core/types';
 
+/** While unfolding the assembly definition on the instance, this function will replace all
+ * ComponentValue in the definitions tree with the actual value on the instance. */
 export const deserializeAssemblyNode = ({
   node,
   componentInstanceVariables,
@@ -17,7 +19,7 @@ export const deserializeAssemblyNode = ({
       const instanceProperty = componentInstanceVariables[componentValueKey];
 
       // For assembly, we look up the variable in the assembly instance and
-      // replace the componentValue with that one.
+      // replace the ComponentValue with that one.
       if (instanceProperty?.type === 'UnboundValue') {
         variables[variableName] = {
           type: 'UnboundValue',
@@ -32,6 +34,11 @@ export const deserializeAssemblyNode = ({
         variables[variableName] = {
           type: 'HyperlinkValue',
           linkTargetKey: instanceProperty.linkTargetKey,
+        };
+      } else if (instanceProperty?.type === 'DesignValue') {
+        variables[variableName] = {
+          type: 'DesignValue',
+          valuesByBreakpoint: instanceProperty.valuesByBreakpoint,
         };
       }
     }

--- a/packages/experience-builder-sdk/test/__fixtures__/assembly.ts
+++ b/packages/experience-builder-sdk/test/__fixtures__/assembly.ts
@@ -3,7 +3,11 @@ import {
   ASSEMBLY_NODE_TYPE,
   LATEST_SCHEMA_VERSION,
 } from '@contentful/experiences-core/constants';
-import type { ExperienceTreeNode, SchemaVersions } from '@contentful/experiences-core/types';
+import type {
+  ExperienceComponentSettings,
+  ExperienceTreeNode,
+  SchemaVersions,
+} from '@contentful/experiences-core/types';
 
 type createAssemblyEntryArgs = {
   schemaVersion: SchemaVersions;
@@ -13,6 +17,7 @@ type createAssemblyEntryArgs = {
 export const defaultAssemblyId = 'assembly-id';
 
 export const assemblyGeneratedVariableName = 'text_uuid1Assembly';
+export const assemblyGeneratedDesignVariableName = 'cfWidth_uuid2Assembly';
 export const createAssemblyEntry = ({
   schemaVersion = LATEST_SCHEMA_VERSION,
   id = defaultAssemblyId,
@@ -54,7 +59,12 @@ export const createAssemblyEntry = ({
         children: [
           {
             definitionId: CONTENTFUL_COMPONENTS.container.id,
-            variables: {},
+            variables: {
+              cfWidth: {
+                type: 'ComponentValue',
+                key: assemblyGeneratedDesignVariableName,
+              },
+            },
             children: [
               {
                 definitionId: 'custom-component',
@@ -82,13 +92,17 @@ export const createAssemblyEntry = ({
         variableDefinitions: {
           [assemblyGeneratedVariableName]: {
             displayName: 'Text',
-            name: 'Text',
             type: 'Text',
             defaultValue: { type: 'UnboundValue', key: 'unbound_uuid1Assembly' },
-            required: false,
+          },
+          [assemblyGeneratedDesignVariableName]: {
+            displayName: 'Width',
+            type: 'Text',
+            group: 'style',
+            defaultValue: { type: 'DesignValue', valuesByBreakpoint: { desktop: '42px' } },
           },
         },
-      },
+      } satisfies ExperienceComponentSettings,
     },
   };
 };

--- a/packages/visual-editor/src/hooks/useComponentProps.ts
+++ b/packages/visual-editor/src/hooks/useComponentProps.ts
@@ -180,6 +180,7 @@ export const useComponentProps = ({
           // so we always render the default value
           return {
             ...acc,
+            // This can either a design (style) or a content variable
             [variableName]: variableDefinition.defaultValue,
           };
         } else {

--- a/packages/visual-editor/src/utils/assemblyUtils.spec.ts
+++ b/packages/visual-editor/src/utils/assemblyUtils.spec.ts
@@ -21,6 +21,11 @@ const assemblyEntry = createAssemblyEntry({
   schemaVersion: '2023-09-28',
 });
 
+const entityStore = new EditorModeEntityStore({
+  entities: [assemblyEntry, ...assets] as Array<Entry | Asset>,
+  locale: 'en-US',
+});
+
 describe('deserializeAssemblyNode', () => {
   beforeEach(() => {
     assembliesRegistry.set(assemblyEntry.sys.id, {
@@ -154,9 +159,7 @@ describe('resolveAssembly', () => {
       children: [],
     };
 
-    const entityStore = null;
-
-    const result = resolveAssembly({ node, entityStore });
+    const result = resolveAssembly({ node, entityStore: null });
 
     expect(result).toEqual(node);
   });
@@ -175,10 +178,8 @@ describe('resolveAssembly', () => {
       children: [],
     };
 
-    const entityStore = null;
-
     // Throws warning "Entry for assembly with ID 'assembly-id' not found"
-    const result = resolveAssembly({ node, entityStore });
+    const result = resolveAssembly({ node, entityStore: null });
 
     expect(result).toEqual(node);
   });
@@ -201,11 +202,6 @@ describe('resolveAssembly', () => {
       },
       children: [],
     };
-
-    const entityStore = new EditorModeEntityStore({
-      entities: [{ ...assemblyEntry, fields: {} }, ...assets] as Array<Entry | Asset>,
-      locale: 'en-US',
-    });
 
     const result = resolveAssembly({ node, entityStore });
 
@@ -231,10 +227,8 @@ describe('resolveAssembly', () => {
       children: [],
     };
 
-    const entityStore = null;
-
     // Throws warning "Entry for assembly with ID 'assembly-id' not found"
-    const result = resolveAssembly({ node, entityStore });
+    const result = resolveAssembly({ node, entityStore: null });
 
     expect(result).toEqual(node);
   });
@@ -246,11 +240,6 @@ describe('resolveAssembly', () => {
       id: 'random-node-id',
       unboundValueKey: 'unbound_uuid1Experience',
       unboundValue: 'New year Eve',
-    });
-
-    const entityStore = new EditorModeEntityStore({
-      entities: [assemblyEntry, ...assets] as Array<Entry | Asset>,
-      locale: 'en-US',
     });
 
     const result = resolveAssembly({ node, entityStore });
@@ -329,11 +318,6 @@ describe('resolveAssembly', () => {
       boundValueKey: 'bound_uuid1Experience',
     });
 
-    const entityStore = new EditorModeEntityStore({
-      entities: [assemblyEntry, ...assets] as Array<Entry | Asset>,
-      locale: 'en-US',
-    });
-
     const result = resolveAssembly({ node, entityStore });
 
     expect(result).not.toEqual(node);
@@ -348,6 +332,20 @@ describe('resolveAssembly', () => {
         linkType: 'Entry',
         id: 'someEntryId',
       },
+    });
+  });
+
+  it('returns a deserialized assembly node with an exposed design value', () => {
+    const node = createAssemblyNode({
+      id: 'random-node-id',
+      boundValueKey: 'bound_uuid1Experience',
+    });
+    const result = resolveAssembly({ node, entityStore });
+
+    expect(result).not.toEqual(node);
+    expect(result.children[0].data.props.cfWidth).toEqual({
+      type: 'DesignValue',
+      valuesByBreakpoint: { desktop: '42px' },
     });
   });
 });

--- a/packages/visual-editor/src/utils/assemblyUtils.ts
+++ b/packages/visual-editor/src/utils/assemblyUtils.ts
@@ -18,6 +18,8 @@ export const checkIsAssemblyEntry = (entry: Entry): boolean => {
   return Boolean(entry.fields?.componentSettings);
 };
 
+/** While unfolding the assembly definition on the instance, this function will replace all
+ * ComponentValue in the definitions tree with the actual value on the instance. */
 export const deserializeAssemblyNode = ({
   node,
   nodeId,
@@ -58,21 +60,17 @@ export const deserializeAssemblyNode = ({
       if (instanceProperty?.type === 'UnboundValue') {
         const componentInstanceValue = componentInstanceUnboundValues[instanceProperty.key];
         unboundValues[instanceProperty.key] = componentInstanceValue;
-        childNodeVariable[variableName] = {
-          type: 'UnboundValue',
-          key: instanceProperty.key,
-        };
+        childNodeVariable[variableName] = instanceProperty;
       } else if (instanceProperty?.type === 'BoundValue') {
         const [, dataSourceKey] = instanceProperty.path.split('/');
         const componentInstanceValue = componentInstanceDataSource[dataSourceKey];
         dataSource[dataSourceKey] = componentInstanceValue;
-        childNodeVariable[variableName] = {
-          type: 'BoundValue',
-          path: instanceProperty.path,
-        };
+        childNodeVariable[variableName] = instanceProperty;
       } else if (instanceProperty?.type === 'HyperlinkValue') {
         const componentInstanceValue = componentInstanceDataSource[instanceProperty.linkTargetKey];
         dataSource[instanceProperty.linkTargetKey] == componentInstanceValue;
+        childNodeVariable[variableName] = instanceProperty;
+      } else if (instanceProperty?.type === 'DesignValue') {
         childNodeVariable[variableName] = instanceProperty;
       }
     }

--- a/packages/visual-editor/src/utils/assemblyUtils.ts
+++ b/packages/visual-editor/src/utils/assemblyUtils.ts
@@ -58,7 +58,8 @@ export const deserializeAssemblyNode = ({
     if (variable.type === 'ComponentValue') {
       const componentValueKey = variable.key;
       const instanceProperty = componentInstanceProps[componentValueKey];
-      const defaultValue = assemblyVariableDefinitions?.[componentValueKey].defaultValue;
+      const variableDefinition = assemblyVariableDefinitions?.[componentValueKey];
+      const defaultValue = variableDefinition?.defaultValue;
 
       // For assembly, we look up the value in the assembly instance and
       // replace the componentValue with that one.
@@ -79,7 +80,7 @@ export const deserializeAssemblyNode = ({
         childNodeVariable[variableName] = instanceProperty;
       } else if (!instanceProperty && defaultValue) {
         // So far, we only automatically fallback to the defaultValue for design properties
-        if (typeof defaultValue === 'object' && defaultValue.type === 'DesignValue') {
+        if (variableDefinition.group === 'style') {
           childNodeVariable[variableName] = defaultValue as DesignValue;
         }
       }
@@ -164,6 +165,14 @@ export const resolveAssembly = ({
     console.warn(`Component tree for assembly with ID '${componentId}' not found`, {
       componentFields,
     });
+    return node;
+  }
+
+  if (!componentFields.componentSettings?.variableDefinitions) {
+    console.warn(`Component settings for assembly with ID '${componentId}' not found`, {
+      componentFields,
+    });
+    return node;
   }
 
   const deserializedNode = deserializeAssemblyNode({

--- a/packages/visual-editor/test/__fixtures__/assembly.ts
+++ b/packages/visual-editor/test/__fixtures__/assembly.ts
@@ -3,7 +3,12 @@ import {
   ASSEMBLY_NODE_TYPE,
   LATEST_SCHEMA_VERSION,
 } from '@contentful/experiences-core/constants';
-import type { ExperienceTreeNode, SchemaVersions } from '@contentful/experiences-core/types';
+import type {
+  ExperienceComponentSettings,
+  ExperienceEntry,
+  ExperienceTreeNode,
+  SchemaVersions,
+} from '@contentful/experiences-core/types';
 
 type createAssemblyEntryArgs = {
   schemaVersion: SchemaVersions;
@@ -13,10 +18,11 @@ type createAssemblyEntryArgs = {
 export const defaultAssemblyId = 'assembly-id';
 
 export const assemblyGeneratedVariableName = 'text_uuid1Assembly';
+export const assemblyGeneratedDesignVariableName = 'cfWidth_uuid2Assembly';
 export const createAssemblyEntry = ({
   schemaVersion = LATEST_SCHEMA_VERSION,
   id = defaultAssemblyId,
-}: createAssemblyEntryArgs) => {
+}: createAssemblyEntryArgs): ExperienceEntry => {
   return {
     sys: {
       id,
@@ -54,14 +60,19 @@ export const createAssemblyEntry = ({
         children: [
           {
             definitionId: CONTENTFUL_COMPONENTS.container.id,
-            variables: {},
+            variables: {
+              cfWidth: {
+                type: 'ComponentValue',
+                key: assemblyGeneratedDesignVariableName,
+              },
+            },
             children: [
               {
                 definitionId: 'custom-component',
                 variables: {
                   text: {
-                    key: assemblyGeneratedVariableName,
                     type: 'ComponentValue',
+                    key: assemblyGeneratedVariableName,
                   },
                 },
                 children: [],
@@ -81,14 +92,18 @@ export const createAssemblyEntry = ({
       componentSettings: {
         variableDefinitions: {
           [assemblyGeneratedVariableName]: {
-            id: 'text',
-            name: 'Text',
+            displayName: 'Text',
             type: 'Text',
             defaultValue: { type: 'UnboundValue', key: 'unbound_uuid1Assembly' },
-            required: false,
+          },
+          [assemblyGeneratedDesignVariableName]: {
+            displayName: 'Width',
+            type: 'Text',
+            group: 'style',
+            defaultValue: { type: 'DesignValue', valuesByBreakpoint: { desktop: '42px' } },
           },
         },
-      },
+      } satisfies ExperienceComponentSettings,
     },
   };
 };

--- a/packages/visual-editor/test/__fixtures__/assembly.ts
+++ b/packages/visual-editor/test/__fixtures__/assembly.ts
@@ -8,6 +8,7 @@ import type {
   ExperienceEntry,
   ExperienceTreeNode,
   SchemaVersions,
+  ValuesByBreakpoint,
 } from '@contentful/experiences-core/types';
 
 type createAssemblyEntryArgs = {
@@ -114,6 +115,7 @@ type createAssemblyNodeArgs = {
   unboundValue?: string;
   unboundValueKey?: string;
   boundValueKey?: string;
+  designValue?: ValuesByBreakpoint;
 };
 
 export const createAssemblyNode = ({
@@ -122,6 +124,7 @@ export const createAssemblyNode = ({
   unboundValue = 'New year Eve',
   unboundValueKey = undefined,
   boundValueKey = undefined,
+  designValue = undefined,
 }: createAssemblyNodeArgs): ExperienceTreeNode => {
   const node: ExperienceTreeNode = {
     type: ASSEMBLY_NODE_TYPE,
@@ -157,6 +160,12 @@ export const createAssemblyNode = ({
           id: 'someEntryId',
         },
       },
+    };
+  }
+  if (designValue) {
+    node.data.props[assemblyGeneratedDesignVariableName] = {
+      type: 'DesignValue',
+      valuesByBreakpoint: designValue,
     };
   }
   return node;


### PR DESCRIPTION
## Purpose

With the new feature of exposing design properties for pattern instances, they can now be of type `ComponentValues` inside the tree of a pattern.

## Approach

Similar to the previously implemented content variables, we're replacing those with the value of the componentValue when rendering the respective assembly child node.