### PR TITLE
fix: full-width for pattern wrapper [ALT-1036]

### DIFF
--- a/packages/visual-editor/src/components/DraggableBlock/Dropzone.tsx
+++ b/packages/visual-editor/src/components/DraggableBlock/Dropzone.tsx
@@ -13,7 +13,11 @@ import { EmptyContainer } from '@components/EmptyContainer/EmptyContainer';
 import { getItem } from '@/utils/getItem';
 import { useZoneStore } from '@/store/zone';
 import { useDropzoneDirection } from '@/hooks/useDropzoneDirection';
-import { ASSEMBLY_NODE_TYPES, CONTENTFUL_COMPONENTS } from '@contentful/experiences-core/constants';
+import {
+  ASSEMBLY_NODE_TYPE,
+  ASSEMBLY_NODE_TYPES,
+  CONTENTFUL_COMPONENTS,
+} from '@contentful/experiences-core/constants';
 import { RenderDropzoneFunction } from './Dropzone.types';
 import { EditorBlockClone } from './EditorBlockClone';
 import { DropzoneClone } from './DropzoneClone';
@@ -59,7 +63,7 @@ export function Dropzone({
   const isDestination = draggedDestinationId === zoneId;
   const isEmptyCanvas = isRootZone && !content.length;
   const isAssembly = ASSEMBLY_NODE_TYPES.includes(node?.type || '');
-
+  const isRootAssembly = node?.type === ASSEMBLY_NODE_TYPE;
   const htmlDraggableProps = getHtmlDragProps(dragProps);
   const htmlProps = getHtmlComponentProps(rest);
   // To avoid a circular dependency, we create the recursive rendering function here and trickle it down
@@ -167,6 +171,7 @@ export function Dropzone({
               [styles.isDestination]: isDestination && !isAssembly,
               [styles.isRoot]: isRootZone,
               [styles.isEmptyZone]: !content.length,
+              [styles.isAssembly]: isRootAssembly,
             })}
             data-ctfl-slot-id={slotId}>
             {isEmptyCanvas ? (

--- a/packages/visual-editor/src/components/DraggableBlock/styles.module.css
+++ b/packages/visual-editor/src/components/DraggableBlock/styles.module.css
@@ -24,6 +24,10 @@
   outline-offset: -1px;
 }
 
+.Dropzone.isAssembly {
+  width: 100%;
+}
+
 .Dropzone.isDestination:not(.isRoot):before {
   transition:
     outline 0.2s,

--- a/packages/visual-editor/src/hooks/useComponent.tsx
+++ b/packages/visual-editor/src/hooks/useComponent.tsx
@@ -108,7 +108,7 @@ export const useComponent = ({
       }),
     );
 
-    if (!requiresDragWrapper) {
+    if (!requiresDragWrapper || isAssembly) {
       return element;
     }
 


### PR DESCRIPTION
## Purpose
Whether you are in delivery or edit mode, a pattern always adds a wrapping div to the content. This is because a pattern can have multiple root children so it's required to be wrapped in an element to be handled by the SDK.

The problem is that this div has `display: contents` in delivery mode so to the end user it seems to not exist but we can't use `display: contents` in editor mode because we need to be able to drag that root pattern element around on the canvas. 

To solve this for most use-cases we've added width: 100% to the root pattern node in editor mode

Ticket: https://contentful.atlassian.net/browse/ALT-1036

https://github.com/user-attachments/assets/5773e83b-ca24-4bd1-9f16-b6f501f9790a