### PR TITLE
fix: fix issue where dragging a structure component could periodically make it go bye bye

### DIFF
--- a/packages/visual-editor/src/components/RootRenderer/DNDProvider.tsx
+++ b/packages/visual-editor/src/components/RootRenderer/DNDProvider.tsx
@@ -69,6 +69,13 @@ export const DNDProvider = ({ children }: Props) => {
     updateItem();
     SimulateDnD.reset();
 
+    // If the component is being dropped onto itself, do nothing
+    // This can happen from an apparent race condition where the hovering zone gets set
+    // to the component after its dropped.
+    if (dropResult.destination?.droppableId === dropResult.draggableId) {
+      return;
+    }
+
     if (!dropResult.destination) {
       if (!draggedItem?.destination) {
         // User cancel drag


### PR DESCRIPTION
## Purpose

Fixes [ALT-1038]

## Approach

Dragging a structural component and dropping it in its own position could have an issue where the SDK thinks it switching the parent of the component to itself, which would remove it from the tree. I put a check in that if the droppable id is the same as the draggable id, to nope out of the operation.

This uncovered what could be a potential race condition in the `isDropZoneEnabled` [check](https://github.com/contentful/experience-builder/blob/d48b81a4de4bbaf7deddf5928646db95335e1968/packages/visual-editor/src/components/DraggableBlock/Dropzone.tsx#L95), in which the hovered element could briefly be set back to the component being dragged, which would result in the drop zone of the dragging component not be appropriately disabled.

<!--

Three important notes on Pull Requests:
- In general, you should ask yourself whether this code change will improve or worsen the overall code quality. Any new tech debt will probably never be cleaned up.
- Please remember that newly introduced logic should be validated and protected through testing.
- Take a look at PR guides such as Google's [Google’s Code Review Guidelines](https://google.github.io/eng-practices/) and [Blockly - Writing a Good Pull Request](https://developers.google.com/blockly/guides/contribute/get-started/write_a_good_pr)

-->


[ALT-1038]: https://contentful.atlassian.net/browse/ALT-1038?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ