### PR TITLE
fix: incorrect placeholder styling [ALT-1011]

### DIFF
--- a/packages/visual-editor/src/components/DraggableHelpers/Placeholder.tsx
+++ b/packages/visual-editor/src/components/DraggableHelpers/Placeholder.tsx
@@ -96,12 +96,8 @@ const calcNewComponentStyles = (params: CalcStylesParams): CSSProperties => {
 
   const width = isHorizontal ? DRAGGABLE_WIDTH : dropzoneSizes.width - horizontalPadding;
   const height = isHorizontal ? dropzoneSizes.height - verticalPadding : DRAGGABLE_HEIGHT;
-  const top = isHorizontal
-    ? calcOffsetTop(element.parentElement, height, elementSizes.height)
-    : -height;
-  const left = isHorizontal
-    ? -width
-    : calcOffsetLeft(element.parentElement, width, elementSizes.width);
+  const top = isHorizontal ? calcOffsetTop(element, height, elementSizes.height) : -height;
+  const left = isHorizontal ? -width : calcOffsetLeft(element, width, elementSizes.width);
 
   return {
     width,
@@ -154,12 +150,8 @@ const calcMovementStyles = (params: CalcStylesParams): CSSProperties => {
 
   const width = isHorizontal ? draggableSizes.width : dropzoneSizes.width - horizontalPadding;
   const height = isHorizontal ? dropzoneSizes.height - verticalPadding : draggableSizes.height;
-  const top = isHorizontal
-    ? calcOffsetTop(element.parentElement, height, elementSizes.height)
-    : -height;
-  const left = isHorizontal
-    ? -width
-    : calcOffsetLeft(element.parentElement, width, elementSizes.width);
+  const top = isHorizontal ? calcOffsetTop(element, height, elementSizes.height) : -height;
+  const left = isHorizontal ? -width : calcOffsetLeft(element, width, elementSizes.width);
 
   return {
     width,
@@ -228,6 +220,7 @@ const Placeholder: React.FC<PlaceholderProps> = (props) => {
           }),
           backgroundColor: 'rgba(var(--exp-builder-blue300-rgb), 0.5)',
           position: 'absolute',
+          pointerEvents: 'none',
         }}
       />
     )


### PR DESCRIPTION
## Purpose
When we refactored the SDK to no longer include a wrapping div, placeholder styles needed to be updated to reference sizing from the correct element. Instead of referencing the `.parentElement` it needed to reference the element itself since the wrapping div no longer applies.

Ticket: https://contentful.atlassian.net/browse/ALT-1011