### PR TITLE
fix: slot components should fit their content once they have children

### DIFF
--- a/packages/visual-editor/src/components/DraggableBlock/EditorBlock.tsx
+++ b/packages/visual-editor/src/components/DraggableBlock/EditorBlock.tsx
@@ -66,7 +66,6 @@ export const EditorBlock: React.FC<EditorBlockProps> = ({
     resolveDesignValue,
     renderDropzone,
     userIsDragging,
-    slotId,
   });
   const { isSingleColumn, isWrapped } = useSingleColumn(node, resolveDesignValue);
   const setDomRect = useDraggedItemStore((state) => state.setDomRect);

--- a/packages/visual-editor/src/hooks/useComponent.tsx
+++ b/packages/visual-editor/src/hooks/useComponent.tsx
@@ -22,7 +22,6 @@ type UseComponentProps = {
   resolveDesignValue: ResolveDesignValueType;
   renderDropzone: RenderDropzoneFunction;
   userIsDragging: boolean;
-  slotId?: string;
 };
 
 export const useComponent = ({
@@ -30,7 +29,6 @@ export const useComponent = ({
   resolveDesignValue,
   renderDropzone,
   userIsDragging,
-  slotId,
 }: UseComponentProps) => {
   const areEntitiesFetched = useEntityStore((state) => state.areEntitiesFetched);
   const entityStore = useEntityStore((state) => state.entityStore);
@@ -74,7 +72,6 @@ export const useComponent = ({
     renderDropzone,
     definition: componentRegistration?.definition,
     userIsDragging,
-    slotId,
   });
 
   const elementToRender = (props?: { dragProps?: DragWrapperProps; rest?: unknown }) => {

--- a/packages/visual-editor/src/hooks/useComponentProps.ts
+++ b/packages/visual-editor/src/hooks/useComponentProps.ts
@@ -61,7 +61,6 @@ export const useComponentProps = ({
   renderDropzone,
   definition,
   userIsDragging,
-  slotId,
 }: UseComponentProps) => {
   const unboundValues = useEditorStore((state) => state.unboundValues);
   const hyperlinkPattern = useEditorStore((state) => state.hyperLinkPattern);
@@ -69,7 +68,7 @@ export const useComponentProps = ({
   const dataSource = useEditorStore((state) => state.dataSource);
   const entityStore = useEntityStore((state) => state.entityStore);
 
-  const isEmptyZone = !node.children.filter((child) => child.data.slotId === slotId).length;
+  const isEmptyZone = !node.children.length;
 
   const props: ComponentProps = useMemo(() => {
     const propsBase = {


### PR DESCRIPTION
## Purpose

[ALT-1012]

## Approach

Removed the filter based on `slotId` when determining if the node was empty or not. This had a ripple effect of removing passing around slotId up through `useComponentProps`, and `useComponent` as the `slotId` was only used in this calculation.

Also checking with @chasepoirier and @primeinteger to see if this filter had a specific purpose and if removing it would have any other effects.

<!--

Three important notes on Pull Requests:
- In general, you should ask yourself whether this code change will improve or worsen the overall code quality. Any new tech debt will probably never be cleaned up.
- Please remember that newly introduced logic should be validated and protected through testing.
- Take a look at PR guides such as Google's [Google’s Code Review Guidelines](https://google.github.io/eng-practices/) and [Blockly - Writing a Good Pull Request](https://developers.google.com/blockly/guides/contribute/get-started/write_a_good_pr)

-->
