### PR TITLE
fix: ssr styles extraction for editable patterns [SPA-2157]

### DIFF
--- a/packages/core/src/utils/styleUtils/ssrStyles.ts
+++ b/packages/core/src/utils/styleUtils/ssrStyles.ts
@@ -169,7 +169,7 @@ export const detachExperienceStyles = (experience: Experience): string | undefin
           // and this is where the over-writes for the default values are stored
           // yes, I know, it's a bit confusing
           componentVariablesOverwrites: currentNode.variables,
-          // and this is where the pattern node
+          // pass top-level pattern node to store instance-specific child styles for rendering
           patternWrapper: currentNode,
         });
         continue;
@@ -323,13 +323,13 @@ export const detachExperienceStyles = (experience: Experience): string | undefin
       // making sure that we respect the order of breakpoints from
       // we can achieve "desktop first" or "mobile first" approach to style over-writes
       if (patternWrapper) {
-        // @ts-expect-error TODO: fix the types - add id to ComponentTreeNode
+        // @ts-expect-error -- temporarily add node ID to pick up the className during rendering in CompositionBlock
         currentNode.id = currentNode.id ?? generateRandomId(15);
-        // @ts-expect-error TODO: fix the types
+        // @ts-expect-error -- valueByBreakpoint is not explicitly defined, but it's already defined in the patternWrapper styles
         patternWrapper.variables.cfSsrClassName = {
           ...(patternWrapper.variables.cfSsrClassName ?? {}),
           type: 'DesignValue',
-          // @ts-expect-error TODO: fix the types - add id to ComponentTreeNode
+          // @ts-expect-error -- id is not defined in ComponentTreeNode type
           [currentNode.id]: {
             valuesByBreakpoint: {
               [breakpointIds[0]]: currentNodeClassNames.join(' '),

--- a/packages/core/src/utils/styleUtils/ssrStyles.ts
+++ b/packages/core/src/utils/styleUtils/ssrStyles.ts
@@ -575,8 +575,6 @@ export const indexByBreakpoint = ({
     let resolvedVariableData = variableData;
 
     if (variableData.type === 'ComponentValue') {
-      // console.log('componentVariablesOverwrites: ', componentVariablesOverwrites);
-      // console.log('componentSettings: ', componentSettings);
       const variableDefinition = componentSettings?.variableDefinitions[variableData.key];
       if (variableDefinition.group === 'style' && variableDefinition.defaultValue !== undefined) {
         const overrideVariableData = componentVariablesOverwrites?.[variableData.key];

--- a/packages/core/src/utils/styleUtils/ssrStyles.ts
+++ b/packages/core/src/utils/styleUtils/ssrStyles.ts
@@ -18,6 +18,7 @@ import {
   Breakpoint,
 } from '@/types';
 import { CF_STYLE_ATTRIBUTES } from '@/constants';
+import { nanoid } from 'nanoid';
 
 type MediaQueryTemplate = Record<
   string,
@@ -87,12 +88,14 @@ export const detachExperienceStyles = (experience: Experience): string | undefin
     unboundValues,
     componentSettings,
     componentVariablesOverwrites,
+    patternWrapper,
   }: {
     componentTree: ExperienceComponentTree;
     dataSource: ExperienceDataSource;
     unboundValues: ExperienceUnboundValues;
     componentSettings?: ExperienceComponentSettings;
     componentVariablesOverwrites?: Record<string, ComponentPropertyValue>;
+    patternWrapper?: ComponentTreeNode;
   }) => {
     // traversing the tree
     const queue: ComponentTreeNode[] = [];
@@ -166,6 +169,8 @@ export const detachExperienceStyles = (experience: Experience): string | undefin
           // and this is where the over-writes for the default values are stored
           // yes, I know, it's a bit confusing
           componentVariablesOverwrites: currentNode.variables,
+          // and this is where the pattern node
+          patternWrapper: currentNode,
         });
         continue;
       }
@@ -285,7 +290,6 @@ export const detachExperienceStyles = (experience: Experience): string | undefin
           'box-sizing': 'border-box'
         }
        */
-
         // I create a hash of the object above because that would ensure hash stability
         const styleHash = md5(JSON.stringify(stylesForBreakpointWithoutUndefined));
 
@@ -318,12 +322,28 @@ export const detachExperienceStyles = (experience: Experience): string | undefin
       // className3 will win over className2 and className1
       // making sure that we respect the order of breakpoints from
       // we can achieve "desktop first" or "mobile first" approach to style over-writes
-      currentNode.variables.cfSsrClassName = {
-        type: 'DesignValue',
-        valuesByBreakpoint: {
-          [breakpointIds[0]]: currentNodeClassNames.join(' '),
-        },
-      };
+      if (patternWrapper) {
+        // @ts-expect-error TODO: fix the types - add id to ComponentTreeNode
+        currentNode.id = currentNode.id ?? nanoid();
+        // @ts-expect-error TODO: fix the types
+        patternWrapper.variables.cfSsrClassName = {
+          ...(patternWrapper.variables.cfSsrClassName ?? {}),
+          type: 'DesignValue',
+          // @ts-expect-error TODO: fix the types - add id to ComponentTreeNode
+          [currentNode.id]: {
+            valuesByBreakpoint: {
+              [breakpointIds[0]]: currentNodeClassNames.join(' '),
+            },
+          },
+        };
+      } else {
+        currentNode.variables.cfSsrClassName = {
+          type: 'DesignValue',
+          valuesByBreakpoint: {
+            [breakpointIds[0]]: currentNodeClassNames.join(' '),
+          },
+        };
+      }
 
       queue.push(...currentNode.children);
     }

--- a/packages/core/src/utils/styleUtils/ssrStyles.ts
+++ b/packages/core/src/utils/styleUtils/ssrStyles.ts
@@ -552,11 +552,26 @@ export const indexByBreakpoint = ({
       continue;
     }
 
-    if (variableData.type !== 'DesignValue') {
+    let resolvedVariableData = variableData;
+
+    if (variableData.type === 'ComponentValue') {
+      // console.log('componentVariablesOverwrites: ', componentVariablesOverwrites);
+      // console.log('componentSettings: ', componentSettings);
+      const variableDefinition = componentSettings?.variableDefinitions[variableData.key];
+      if (variableDefinition.group === 'style' && variableDefinition.defaultValue !== undefined) {
+        const overrideVariableData = componentVariablesOverwrites?.[variableData.key];
+        resolvedVariableData =
+          overrideVariableData || (variableDefinition.defaultValue as ComponentPropertyValue);
+      }
+    }
+
+    if (resolvedVariableData.type !== 'DesignValue') {
       continue;
     }
 
-    for (const [breakpointId, variableValue] of Object.entries(variableData.valuesByBreakpoint)) {
+    for (const [breakpointId, variableValue] of Object.entries(
+      resolvedVariableData.valuesByBreakpoint,
+    )) {
       if (!variableValue) {
         continue;
       }

--- a/packages/core/src/utils/styleUtils/ssrStyles.ts
+++ b/packages/core/src/utils/styleUtils/ssrStyles.ts
@@ -18,7 +18,7 @@ import {
   Breakpoint,
 } from '@/types';
 import { CF_STYLE_ATTRIBUTES } from '@/constants';
-import { nanoid } from 'nanoid';
+import { generateRandomId } from '@/utils';
 
 type MediaQueryTemplate = Record<
   string,
@@ -324,7 +324,7 @@ export const detachExperienceStyles = (experience: Experience): string | undefin
       // we can achieve "desktop first" or "mobile first" approach to style over-writes
       if (patternWrapper) {
         // @ts-expect-error TODO: fix the types - add id to ComponentTreeNode
-        currentNode.id = currentNode.id ?? nanoid();
+        currentNode.id = currentNode.id ?? generateRandomId(15);
         // @ts-expect-error TODO: fix the types
         patternWrapper.variables.cfSsrClassName = {
           ...(patternWrapper.variables.cfSsrClassName ?? {}),

--- a/packages/core/src/utils/styleUtils/ssrStylesPattern.spec.ts
+++ b/packages/core/src/utils/styleUtils/ssrStylesPattern.spec.ts
@@ -618,6 +618,624 @@ const patternEntry: ExperienceEntry = {
   },
 };
 
+const editablePatternEntry: ExperienceEntry = {
+  metadata: {
+    tags: [],
+  },
+  sys: {
+    id: '4JYGAfHMSVdWkuf6kbd1n8-EditablePattern',
+    type: 'Entry',
+    createdAt: '2024-02-21T16:20:49.414Z',
+    updatedAt: '2024-03-05T10:52:46.832Z',
+    revision: 1,
+    contentType: {
+      sys: {
+        id: 'contentful-component',
+        type: 'Link',
+        linkType: 'ContentType',
+      },
+    },
+    space: {
+      sys: {
+        id: 'space-id',
+        type: 'Link',
+        linkType: 'Space',
+      },
+    },
+    environment: {
+      sys: {
+        id: 'master',
+        type: 'Link',
+        linkType: 'Environment',
+      },
+    },
+  },
+  fields: {
+    title: 'Hero image',
+    slug: 'hero-image-XpKBMxZnNvaLPm5rZXp3c',
+    componentTree: {
+      schemaVersion: '2023-09-28',
+      breakpoints: [
+        {
+          id: 'desktop',
+          query: '*',
+          displayName: 'All Sizes',
+          previewSize: '100%',
+        },
+        {
+          id: 'tablet',
+          query: '<992px',
+          displayName: 'Tablet',
+          previewSize: '820px',
+        },
+        {
+          id: 'mobile',
+          query: '<576px',
+          displayName: 'Mobile',
+          previewSize: '390px',
+        },
+      ],
+      children: [
+        {
+          definitionId: 'contentful-columns',
+          variables: {
+            cfMargin: {
+              type: 'DesignValue',
+              valuesByBreakpoint: {
+                desktop: '0 Auto 0 Auto',
+              },
+            },
+            cfWidth: {
+              type: 'DesignValue',
+              valuesByBreakpoint: {
+                desktop: 'fill',
+              },
+            },
+            cfMaxWidth: {
+              type: 'DesignValue',
+              valuesByBreakpoint: {
+                desktop: '1192px',
+              },
+            },
+            cfPadding: {
+              type: 'DesignValue',
+              valuesByBreakpoint: {
+                desktop: '10px 10px 10px 10px',
+              },
+            },
+            cfBackgroundColor: {
+              key: 'cfBackgroundColor_yZeyLCpBGeQ5ZCQ6POKF',
+              type: 'ComponentValue',
+            },
+            cfBorder: {
+              type: 'DesignValue',
+              valuesByBreakpoint: {
+                desktop: '0px outside rgba(255, 255, 255, 0)',
+              },
+            },
+            cfBackgroundImageUrl: {
+              key: 'cfBackgroundImageUrl_Tdhixzp1Gt91aI9uc5p88',
+              type: 'ComponentValue',
+            },
+            cfGap: {
+              type: 'DesignValue',
+              valuesByBreakpoint: {
+                desktop: '10px 10px',
+              },
+            },
+            cfBackgroundImageScaling: {
+              type: 'DesignValue',
+              valuesByBreakpoint: {
+                desktop: 'fit',
+              },
+            },
+            cfBackgroundImageAlignment: {
+              type: 'DesignValue',
+              valuesByBreakpoint: {
+                desktop: 'left top',
+              },
+            },
+            cfColumns: {
+              type: 'DesignValue',
+              valuesByBreakpoint: {
+                desktop: '[6,6]',
+              },
+            },
+            cfWrapColumns: {
+              type: 'DesignValue',
+              valuesByBreakpoint: {
+                desktop: false,
+              },
+            },
+            cfWrapColumnsCount: {
+              type: 'DesignValue',
+              valuesByBreakpoint: {
+                desktop: '2',
+              },
+            },
+          },
+          children: [
+            {
+              definitionId: 'contentful-single-column',
+              variables: {
+                cfVerticalAlignment: {
+                  type: 'DesignValue',
+                  valuesByBreakpoint: {
+                    desktop: 'start',
+                  },
+                },
+                cfHorizontalAlignment: {
+                  type: 'DesignValue',
+                  valuesByBreakpoint: {
+                    desktop: 'center',
+                  },
+                },
+                cfPadding: {
+                  type: 'DesignValue',
+                  valuesByBreakpoint: {
+                    desktop: '0 0 0 0',
+                  },
+                },
+                cfBackgroundColor: {
+                  key: 'cfBackgroundColor_yZeyLCpBGeQ5ZCQ6POKF',
+                  type: 'ComponentValue',
+                },
+                cfFlexDirection: {
+                  type: 'DesignValue',
+                  valuesByBreakpoint: {
+                    desktop: 'column',
+                  },
+                },
+                cfFlexWrap: {
+                  type: 'DesignValue',
+                  valuesByBreakpoint: {
+                    desktop: 'nowrap',
+                  },
+                },
+                cfBorder: {
+                  type: 'DesignValue',
+                  valuesByBreakpoint: {
+                    desktop: '0px outside rgba(255, 255, 255, 0)',
+                  },
+                },
+                cfGap: {
+                  type: 'DesignValue',
+                  valuesByBreakpoint: {
+                    desktop: '0px 0px',
+                  },
+                },
+                cfBackgroundImageUrl: {
+                  key: 'y-jkcH7tyRZjjY-fukECH',
+                  type: 'UnboundValue',
+                },
+                cfBackgroundImageScaling: {
+                  type: 'DesignValue',
+                  valuesByBreakpoint: {
+                    desktop: 'fit',
+                  },
+                },
+                cfBackgroundImageAlignment: {
+                  type: 'DesignValue',
+                  valuesByBreakpoint: {
+                    desktop: 'left top',
+                  },
+                },
+                cfColumnSpan: {
+                  type: 'DesignValue',
+                  valuesByBreakpoint: {
+                    desktop: '6',
+                  },
+                },
+                cfColumnSpanLock: {
+                  type: 'DesignValue',
+                  valuesByBreakpoint: {
+                    desktop: false,
+                  },
+                },
+              },
+              children: [
+                {
+                  definitionId: 'heading',
+                  variables: {
+                    text: {
+                      key: 'text_4aWMAKDfoDI5kWX7L3N-t',
+                      type: 'ComponentValue',
+                    },
+                    type: {
+                      type: 'DesignValue',
+                      valuesByBreakpoint: {
+                        desktop: 'h1',
+                      },
+                    },
+                    textAlign: {
+                      type: 'DesignValue',
+                      valuesByBreakpoint: {},
+                    },
+                    color: {
+                      type: 'DesignValue',
+                      valuesByBreakpoint: {},
+                    },
+                    cfMargin: {
+                      type: 'DesignValue',
+                      valuesByBreakpoint: {
+                        desktop: '0 0 0 0',
+                      },
+                    },
+                    cfPadding: {
+                      type: 'DesignValue',
+                      valuesByBreakpoint: {
+                        desktop: '0 0 0 0',
+                      },
+                    },
+                    cfWidth: {
+                      type: 'DesignValue',
+                      valuesByBreakpoint: {
+                        desktop: 'fill',
+                      },
+                    },
+                    cfMaxWidth: {
+                      type: 'DesignValue',
+                      valuesByBreakpoint: {
+                        desktop: 'none',
+                      },
+                    },
+                  },
+                  children: [],
+                },
+                {
+                  definitionId: 'text',
+                  variables: {
+                    text: {
+                      key: 'text_yZeyLCpBGe-Q5ZCQ6POKF',
+                      type: 'ComponentValue',
+                    },
+                    cfMargin: {
+                      type: 'DesignValue',
+                      valuesByBreakpoint: {
+                        desktop: '0 0 0 0',
+                      },
+                    },
+                    cfPadding: {
+                      type: 'DesignValue',
+                      valuesByBreakpoint: {
+                        desktop: '0 0 0 0',
+                      },
+                    },
+                    cfWidth: {
+                      type: 'DesignValue',
+                      valuesByBreakpoint: {
+                        desktop: 'fill',
+                      },
+                    },
+                    cfMaxWidth: {
+                      type: 'DesignValue',
+                      valuesByBreakpoint: {
+                        desktop: 'none',
+                      },
+                    },
+                    cfFontSize: {
+                      type: 'DesignValue',
+                      valuesByBreakpoint: {
+                        desktop: '16px',
+                      },
+                    },
+                    cfFontWeight: {
+                      type: 'DesignValue',
+                      valuesByBreakpoint: {
+                        desktop: '400',
+                      },
+                    },
+                    cfLineHeight: {
+                      type: 'DesignValue',
+                      valuesByBreakpoint: {
+                        desktop: '20px',
+                      },
+                    },
+                    cfLetterSpacing: {
+                      type: 'DesignValue',
+                      valuesByBreakpoint: {
+                        desktop: '0px',
+                      },
+                    },
+                    cfTextColor: {
+                      type: 'DesignValue',
+                      valuesByBreakpoint: {
+                        desktop: 'rgba(0, 0, 0, 1)',
+                      },
+                    },
+                    cfTextAlign: {
+                      type: 'DesignValue',
+                      valuesByBreakpoint: {
+                        desktop: 'left',
+                      },
+                    },
+                    cfTextTransform: {
+                      type: 'DesignValue',
+                      valuesByBreakpoint: {
+                        desktop: 'none',
+                      },
+                    },
+                    cfTextBold: {
+                      type: 'DesignValue',
+                      valuesByBreakpoint: {
+                        desktop: false,
+                      },
+                    },
+                    cfTextItalic: {
+                      type: 'DesignValue',
+                      valuesByBreakpoint: {
+                        desktop: false,
+                      },
+                    },
+                    cfTextUnderline: {
+                      type: 'DesignValue',
+                      valuesByBreakpoint: {
+                        desktop: false,
+                      },
+                    },
+                  },
+                  children: [],
+                },
+                {
+                  definitionId: 'button',
+                  variables: {
+                    label: {
+                      key: 'label_ReqsD8BhJLQ_-LEQQsFmf',
+                      type: 'ComponentValue',
+                    },
+                    targetUrl: {
+                      key: 'targetUrl_ReqsD8BhJLQ_-LEQQsFmf',
+                      type: 'ComponentValue',
+                    },
+                    variant: {
+                      type: 'DesignValue',
+                      valuesByBreakpoint: {},
+                    },
+                    cfMargin: {
+                      type: 'DesignValue',
+                      valuesByBreakpoint: {
+                        desktop: '0 0 0 0',
+                      },
+                    },
+                    cfPadding: {
+                      type: 'DesignValue',
+                      valuesByBreakpoint: {
+                        desktop: '0 0 0 0',
+                      },
+                    },
+                  },
+                  children: [],
+                },
+              ],
+            },
+            {
+              definitionId: 'contentful-single-column',
+              variables: {
+                cfVerticalAlignment: {
+                  type: 'DesignValue',
+                  valuesByBreakpoint: {
+                    desktop: 'center',
+                  },
+                },
+                cfHorizontalAlignment: {
+                  type: 'DesignValue',
+                  valuesByBreakpoint: {
+                    desktop: 'center',
+                  },
+                },
+                cfPadding: {
+                  type: 'DesignValue',
+                  valuesByBreakpoint: {
+                    desktop: '0 0 0 0',
+                  },
+                },
+                cfBackgroundColor: {
+                  type: 'DesignValue',
+                  valuesByBreakpoint: {
+                    desktop: 'rgba(255, 255, 255, 0)',
+                  },
+                },
+                cfFlexDirection: {
+                  type: 'DesignValue',
+                  valuesByBreakpoint: {
+                    desktop: 'column',
+                  },
+                },
+                cfFlexWrap: {
+                  type: 'DesignValue',
+                  valuesByBreakpoint: {
+                    desktop: 'nowrap',
+                  },
+                },
+                cfBorder: {
+                  type: 'DesignValue',
+                  valuesByBreakpoint: {
+                    desktop: '0px outside rgba(255, 255, 255, 0)',
+                  },
+                },
+                cfGap: {
+                  type: 'DesignValue',
+                  valuesByBreakpoint: {
+                    desktop: '0px 0px',
+                  },
+                },
+                cfBackgroundImageUrl: {
+                  key: 'KAWCUcizVSEoTtSPste7S',
+                  type: 'UnboundValue',
+                },
+                cfBackgroundImageScaling: {
+                  type: 'DesignValue',
+                  valuesByBreakpoint: {
+                    desktop: 'fit',
+                  },
+                },
+                cfBackgroundImageAlignment: {
+                  type: 'DesignValue',
+                  valuesByBreakpoint: {
+                    desktop: 'left top',
+                  },
+                },
+                cfColumnSpan: {
+                  type: 'DesignValue',
+                  valuesByBreakpoint: {
+                    desktop: '6',
+                  },
+                },
+                cfColumnSpanLock: {
+                  type: 'DesignValue',
+                  valuesByBreakpoint: {
+                    desktop: false,
+                  },
+                },
+              },
+              children: [
+                {
+                  definitionId: 'Image',
+                  variables: {
+                    alt: {
+                      key: 'alt_GQZDBcONTKHYmPU-nOPlw',
+                      type: 'ComponentValue',
+                    },
+                    url: {
+                      key: 'url_GQZDBcONTKHYmPU-nOPlw',
+                      type: 'ComponentValue',
+                    },
+                    width: {
+                      type: 'DesignValue',
+                      valuesByBreakpoint: {},
+                    },
+                    cfMargin: {
+                      type: 'DesignValue',
+                      valuesByBreakpoint: {
+                        desktop: '0 0 0 0',
+                      },
+                    },
+                    cfPadding: {
+                      type: 'DesignValue',
+                      valuesByBreakpoint: {
+                        desktop: '0 0 0 0',
+                      },
+                    },
+                  },
+                  children: [],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+    dataSource: {},
+    unboundValues: {
+      '9Ew1GTxkZvOXiBZxKPCSC': {
+        value: '',
+      },
+      'y-jkcH7tyRZjjY-fukECH': {
+        value: '',
+      },
+      OK5AKAasFE9EoMRngKZTC: {
+        value: 'Lorem ipsum',
+      },
+      qaov8cyn5yUVk0tA6Nrdr: {
+        value: 'Lorem ipsum',
+      },
+      QyZuk2tCmN0UwsRZuq9Wm: {
+        value: 'Lorem ipsum',
+      },
+      'dgl5-6XS2CxI24GQ2b2rl': {
+        value: '/',
+      },
+      KAWCUcizVSEoTtSPste7S: {
+        value: '',
+      },
+      QbZdm2qAJt8U14BL2ptcq: {},
+      md0XbAEkEck8ZACOrXppn: {
+        value:
+          'https://images.ctfassets.net/tofsejyzyo24/5owPX1vp6cXDZr7QOabwzT/d5580f5b4dbad3f74c87ce2f03efa581/Image_container.png',
+      },
+    },
+    componentSettings: {
+      variableDefinitions: {
+        cfBackgroundColor_yZeyLCpBGeQ5ZCQ6POKF: {
+          displayName: 'Background Color',
+          type: 'Text',
+          group: 'style',
+          defaultValue: {
+            type: 'DesignValue',
+            valuesByBreakpoint: {
+              desktop: 'rgba(255, 255, 255, 0)',
+            },
+          },
+          description: 'Background image for section or container',
+        },
+        cfBackgroundImageUrl_Tdhixzp1Gt91aI9uc5p88: {
+          displayName: 'Background Image',
+          type: 'Text',
+          defaultValue: {
+            key: '9Ew1GTxkZvOXiBZxKPCSC',
+            type: 'UnboundValue',
+          },
+          description: 'Background image for section or container',
+        },
+        'text_4aWMAKDfoDI5kWX7L3N-t': {
+          displayName: 'Text',
+          defaultValue: {
+            key: 'OK5AKAasFE9EoMRngKZTC',
+            type: 'UnboundValue',
+          },
+          type: 'Text',
+          group: 'content',
+        },
+        'text_yZeyLCpBGe-Q5ZCQ6POKF': {
+          displayName: 'Text',
+          type: 'Text',
+          defaultValue: {
+            key: 'qaov8cyn5yUVk0tA6Nrdr',
+            type: 'UnboundValue',
+          },
+          group: 'content',
+        },
+        'label_ReqsD8BhJLQ_-LEQQsFmf': {
+          displayName: 'Label',
+          type: 'Text',
+          defaultValue: {
+            key: 'QyZuk2tCmN0UwsRZuq9Wm',
+            type: 'UnboundValue',
+          },
+          group: 'content',
+        },
+        'targetUrl_ReqsD8BhJLQ_-LEQQsFmf': {
+          displayName: 'Target URL',
+          type: 'Text',
+          defaultValue: {
+            key: 'dgl5-6XS2CxI24GQ2b2rl',
+            type: 'UnboundValue',
+          },
+          group: 'content',
+        },
+        'alt_GQZDBcONTKHYmPU-nOPlw': {
+          displayName: 'Alt',
+          type: 'Text',
+          group: 'content',
+          defaultValue: {
+            key: 'QbZdm2qAJt8U14BL2ptcq',
+            type: 'UnboundValue',
+          },
+        },
+        'url_GQZDBcONTKHYmPU-nOPlw': {
+          displayName: 'Image Url',
+          type: 'Media',
+          defaultValue: {
+            key: 'md0XbAEkEck8ZACOrXppn',
+            type: 'UnboundValue',
+          },
+          group: 'content',
+        },
+      },
+    },
+  },
+};
+
 const getExperienceEntryWithNode = ({
   node,
   unboundValues = {},
@@ -777,9 +1395,11 @@ describe('pattern component', () => {
 
     const styles = detachExperienceStyles(experience);
 
-    const patternTreeNode = experienceEntry.fields.componentTree.children[0];
-    const queue = [...patternTreeNode.children];
+    const resolvedPatternEntry = experience.entityStore?.usedComponents[0] as ExperienceEntry;
+    const patternWrapper = experienceEntry.fields.componentTree.children[0];
+    const queue = [...resolvedPatternEntry.fields.componentTree.children];
 
+    expect(patternWrapper.variables.cfSsrClassName.type).toBe('DesignValue');
     while (queue.length) {
       const node = queue.shift();
 
@@ -787,19 +1407,13 @@ describe('pattern component', () => {
         continue;
       }
 
-      expect(node.variables.cfSsrClassName).toBeDefined();
-      expect(node.variables.cfSsrClassName.type).toBe('DesignValue');
+      //@ts-expect-error TODO: fix this
+      expect(patternWrapper.variables.cfSsrClassName[node.id]).toBeDefined();
       expect(
-        (node.variables.cfSsrClassName as DesignValue).valuesByBreakpoint.desktop,
+        //@ts-expect-error TODO: fix this
+        (patternWrapper.variables.cfSsrClassName[node.id] as DesignValue).valuesByBreakpoint
+          .desktop,
       ).toBeDefined();
-
-      expect(
-        (node.variables.cfSsrClassName as DesignValue).valuesByBreakpoint.tablet,
-      ).not.toBeDefined();
-      expect(
-        (node.variables.cfSsrClassName as DesignValue).valuesByBreakpoint.mobile,
-      ).not.toBeDefined();
-
       if (node?.children.length) {
         queue.push(...node.children);
       }
@@ -1085,5 +1699,96 @@ describe('pattern component', () => {
       '.cf-d2d0bfefe7032e1bd983bdc3c4c8b762{font-style:normal;text-decoration:none;box-sizing:border-box;}.cf-b1412ac844535c7e3cbc97cc32a5b8a8{margin:0 Auto 0 Auto;padding:10px 10px 10px 10px;background-color:rgba(255, 255, 255, 0);width:100%;max-width:1192px;border:0px outside rgba(255, 255, 255, 0);gap:10px 10px;background-image:url(https://www.contentful.com/image-asset.jpg);background-repeat:no-repeat;font-style:normal;text-decoration:none;box-sizing:border-box;}.cf-cd01b8f29d14c77082e72aba8f93df9d{padding:0 0 0 0;background-color:rgba(255, 255, 255, 0);grid-column:span 6;border:0px outside rgba(255, 255, 255, 0);gap:0px 0px;align-items:start;justify-content:safe center;flex-direction:column;flex-wrap:nowrap;font-style:normal;text-decoration:none;box-sizing:border-box;}.cf-0667ccfe39782f7b095158c091fe11b1{padding:0 0 0 0;background-color:rgba(255, 255, 255, 0);grid-column:span 6;border:0px outside rgba(255, 255, 255, 0);gap:0px 0px;align-items:center;justify-content:safe center;flex-direction:column;flex-wrap:nowrap;font-style:normal;text-decoration:none;box-sizing:border-box;}.cf-4a8f6203e699188eca59057cbc1c393d{margin:0 0 0 0;padding:0 0 0 0;width:100%;max-width:none;font-style:normal;text-decoration:none;box-sizing:border-box;}.cf-ce2b0ef076bc2a18ca68c23d8d0be35b{margin:0 0 0 0;padding:0 0 0 0;width:100%;max-width:none;font-size:16px;font-weight:400;font-style:normal;line-height:20px;letter-spacing:0px;color:rgba(0, 0, 0, 1);text-align:left;text-transform:none;text-decoration:none;box-sizing:border-box;}.cf-5b037779d15ede4fba2aaea00a0ac340{margin:0 0 0 0;padding:0 0 0 0;font-style:normal;text-decoration:none;box-sizing:border-box;}@media(max-width:992px){.cf-d2d0bfefe7032e1bd983bdc3c4c8b762{font-style:normal;text-decoration:none;box-sizing:border-box;}}@media(max-width:576px){.cf-d2d0bfefe7032e1bd983bdc3c4c8b762{font-style:normal;text-decoration:none;box-sizing:border-box;}}',
     );
     expect(styles).toContain(`background-image:url(${referencedAsset.fields.file?.url})`);
+  });
+
+  it('should resolve styles for a pattern with exposed design properties', () => {
+    const patternNode: ComponentTreeNode = {
+      definitionId: '4JYGAfHMSVdWkuf6kbd1n8-EditablePattern',
+      variables: {
+        cfBackgroundColor_yZeyLCpBGeQ5ZCQ6POKF: {
+          type: 'DesignValue',
+          valuesByBreakpoint: {
+            desktop: 'rgba(270, 154, 255, 0)',
+          },
+        },
+        cfBackgroundImageUrl_Tdhixzp1Gt91aI9uc5p88: {
+          type: 'UnboundValue',
+          key: '9TLvjMnVsdRjmY1ubLNoy',
+        },
+        'text_4aWMAKDfoDI5kWX7L3N-t': {
+          path: '/44VNjJs2idfY07POQ__X8/fields/title/~locale',
+          type: 'BoundValue',
+        },
+        'text_yZeyLCpBGe-Q5ZCQ6POKF': {
+          type: 'UnboundValue',
+          key: 'nd1ip1F1Qb8M8CHzfIJ9M',
+        },
+        'label_ReqsD8BhJLQ_-LEQQsFmf': {
+          type: 'UnboundValue',
+          key: '2U2Pjx_SAg4fY9uFBmtPZ',
+        },
+        'targetUrl_ReqsD8BhJLQ_-LEQQsFmf': {
+          type: 'UnboundValue',
+          key: 'khZLhNHYnmfN834xJhmmb',
+        },
+        'alt_GQZDBcONTKHYmPU-nOPlw': {
+          type: 'UnboundValue',
+          key: 'Q2Nxbd109_raK29mhzNHJ',
+        },
+        'url_GQZDBcONTKHYmPU-nOPlw': {
+          path: '/Bw0eYqeQVjz4vfkJPlZUe/fields/file/~locale',
+          type: 'BoundValue',
+        },
+      },
+      children: [],
+    };
+
+    const experienceEntry = getExperienceEntryWithNode({
+      node: patternNode,
+      unboundValues: {
+        '2U2Pjx_SAg4fY9uFBmtPZ': {
+          value: 'Lorem ipsum',
+        },
+        '9TLvjMnVsdRjmY1ubLNoy': {
+          value: '',
+        },
+        Q2Nxbd109_raK29mhzNHJ: {},
+        khZLhNHYnmfN834xJhmmb: {
+          value: '/',
+        },
+        nd1ip1F1Qb8M8CHzfIJ9M: {
+          value: 'Lorem ipsum',
+        },
+      },
+      dataSource: {
+        '44VNjJs2idfY07POQ__X8': {
+          sys: {
+            id: 'bound-asset-id',
+            type: 'Link',
+            linkType: 'Asset',
+          },
+        },
+        Bw0eYqeQVjz4vfkJPlZUe: {
+          sys: {
+            id: 'bound-asset-id',
+            type: 'Link',
+            linkType: 'Asset',
+          },
+        },
+      },
+      usedComponents: [editablePatternEntry],
+    });
+
+    const experience = createExperience({
+      experienceEntry: experienceEntry as Entry,
+      locale: 'en-US',
+      referencedEntries: [editablePatternEntry as Entry],
+      referencedAssets: [],
+    });
+
+    const styles = detachExperienceStyles(experience);
+
+    // Expecting if it style contains updated background color of pattern instance
+    expect(styles).toMatch('background-color:rgba(270, 154, 255, 0)');
   });
 });

--- a/packages/experience-builder-sdk/src/blocks/preview/CompositionBlock.tsx
+++ b/packages/experience-builder-sdk/src/blocks/preview/CompositionBlock.tsx
@@ -88,9 +88,9 @@ export const CompositionBlock = ({
     }
 
     const propMap: Record<string, PrimitiveValue> = {
-      // @ts-expect-error -- bla
+      // @ts-expect-error -- node id is being generated in ssrStyles.ts, currently missing ComponentTreeNode type
       cfSsrClassName: node.id
-        ? // @ts-expect-error -- bla
+        ? // @ts-expect-error -- node id is being generated in ssrStyles.ts, currently missing ComponentTreeNode type
           getPatternChildNodeClassName?.(node.id)
         : node.variables.cfSsrClassName
           ? resolveDesignValue(
@@ -200,7 +200,7 @@ export const CompositionBlock = ({
 
   const _getPatternChildNodeClassName = (childNodeId: string) => {
     if (isAssembly) {
-      // @ts-expect-error -- bla
+      // @ts-expect-error -- property cfSsrClassName is a map (id to classNames) that is added during rendering in ssrStyles
       const classesForNode = node.variables.cfSsrClassName[childNodeId];
       if (classesForNode) {
         return resolveDesignValue(

--- a/packages/experience-builder-sdk/src/blocks/preview/CompositionBlock.tsx
+++ b/packages/experience-builder-sdk/src/blocks/preview/CompositionBlock.tsx
@@ -33,6 +33,7 @@ type CompositionBlockProps = {
   entityStore: EntityStore;
   hyperlinkPattern?: string | undefined;
   resolveDesignValue: ResolveDesignValueType;
+  getPatternChildNodeClassName?: (childNodeId: string) => string | undefined;
 };
 
 export const CompositionBlock = ({
@@ -41,6 +42,7 @@ export const CompositionBlock = ({
   entityStore,
   hyperlinkPattern,
   resolveDesignValue,
+  getPatternChildNodeClassName,
 }: CompositionBlockProps) => {
   const isAssembly = useMemo(
     () =>
@@ -73,18 +75,30 @@ export const CompositionBlock = ({
   }, [isAssembly, node.definitionId]);
 
   const nodeProps = useMemo(() => {
-    const propMap: Record<string, PrimitiveValue> = {
-      cfSsrClassName: node.variables.cfSsrClassName
-        ? resolveDesignValue(
-            (node.variables.cfSsrClassName as DesignValue).valuesByBreakpoint,
-            'cfSsrClassName',
-          )
-        : undefined,
-    };
     // Don't enrich the assembly wrapper node with props
     if (!componentRegistration || isAssembly) {
-      return propMap;
+      return {
+        cfSsrClassName: node.variables.cfSsrClassName
+          ? resolveDesignValue(
+              (node.variables.cfSsrClassName as DesignValue).valuesByBreakpoint,
+              'cfSsrClassName',
+            )
+          : undefined,
+      };
     }
+
+    const propMap: Record<string, PrimitiveValue> = {
+      // @ts-expect-error -- bla
+      cfSsrClassName: node.id
+        ? // @ts-expect-error -- bla
+          getPatternChildNodeClassName?.(node.id)
+        : node.variables.cfSsrClassName
+          ? resolveDesignValue(
+              (node.variables.cfSsrClassName as DesignValue).valuesByBreakpoint,
+              'cfSsrClassName',
+            )
+          : undefined,
+    };
 
     const props = Object.entries(componentRegistration.definition.variables).reduce(
       (acc, [variableName, variableDefinition]) => {
@@ -184,11 +198,27 @@ export const CompositionBlock = ({
 
   const { component } = componentRegistration;
 
+  const _getPatternChildNodeClassName = (childNodeId: string) => {
+    if (isAssembly) {
+      // @ts-expect-error -- bla
+      const classesForNode = node.variables.cfSsrClassName[childNodeId];
+      if (classesForNode) {
+        return resolveDesignValue(
+          (classesForNode as DesignValue).valuesByBreakpoint,
+          'cfSsrClassName',
+        ) as string;
+      }
+      return;
+    }
+    return getPatternChildNodeClassName?.(childNodeId);
+  };
+
   const children =
     componentRegistration.definition.children === true
       ? node.children.map((childNode: ComponentTreeNode, index) => {
           return (
             <CompositionBlock
+              getPatternChildNodeClassName={_getPatternChildNodeClassName}
               node={childNode}
               key={index}
               locale={locale}

--- a/packages/experience-builder-sdk/src/core/preview/assemblyUtils.ts
+++ b/packages/experience-builder-sdk/src/core/preview/assemblyUtils.ts
@@ -71,6 +71,8 @@ export const deserializeAssemblyNode = ({
 
   return {
     definitionId: node.definitionId,
+    // @ts-expect-error TODO: fix this
+    id: node.id,
     variables,
     children,
     slotId: node.slotId,
@@ -108,6 +110,8 @@ export const resolveAssembly = ({
   const deserializedNode = deserializeAssemblyNode({
     node: {
       definitionId: node.definitionId,
+      // @ts-expect-error TODO: fix this
+      id: node.id,
       variables: node.variables,
       children: componentFields.componentTree.children,
     },

--- a/packages/experience-builder-sdk/src/core/preview/assemblyUtils.ts
+++ b/packages/experience-builder-sdk/src/core/preview/assemblyUtils.ts
@@ -71,7 +71,7 @@ export const deserializeAssemblyNode = ({
 
   return {
     definitionId: node.definitionId,
-    // @ts-expect-error TODO: fix this
+    // @ts-expect-error -- required to extract Ssr styles classNames for pattern instances, ComponentTreeNode type is missing id
     id: node.id,
     variables,
     children,
@@ -110,7 +110,7 @@ export const resolveAssembly = ({
   const deserializedNode = deserializeAssemblyNode({
     node: {
       definitionId: node.definitionId,
-      // @ts-expect-error TODO: fix this
+      // @ts-expect-error -- required to extract Ssr styles classNames for pattern instances, ComponentTreeNode type is missing id
       id: node.id,
       variables: node.variables,
       children: componentFields.componentTree.children,


### PR DESCRIPTION
## Purpose

With Editable patterns we now have different styles for each pattern instance, which needs to be considered when detaching styles for SSR.

## Approach

Pattern instances can have different styles due to Editable patterns, we have to store styles depending on the pattern instance in an experience rather than the pattern node itself.
We generate a unique identifier for each child component of a pattern and associate this identifier with the corresponding node. The style classes are then stored in the pattern wrapper node, keyed by these unique identifiers.
This approach ensures that the styles for each pattern’s instance are maintained separately, preventing conflicts.

### Things to consider
- Types needs to be adjusted as id doesn't exist currently in `ComponentTreeNode`
