### PR TITLE
fix(experience-builder-sdk): render defaultValue in preview when resolving doesnt work [SPA-2206]

### DIFF
--- a/packages/experience-builder-sdk/src/blocks/preview/CompositionBlock.tsx
+++ b/packages/experience-builder-sdk/src/blocks/preview/CompositionBlock.tsx
@@ -108,7 +108,7 @@ export const CompositionBlock = ({
               variableDefinition,
               variable.path,
             );
-            acc[variableName] = value;
+            acc[variableName] = value ?? variableDefinition.defaultValue;
             break;
           }
 
@@ -130,7 +130,8 @@ export const CompositionBlock = ({
           }
           case 'UnboundValue': {
             const uuid = variable.key;
-            acc[variableName] = entityStore.unboundValues[uuid]?.value;
+            acc[variableName] =
+              entityStore.unboundValues[uuid]?.value ?? variableDefinition.defaultValue;
             break;
           }
           case 'ComponentValue':

--- a/packages/visual-editor/src/hooks/useComponentProps.ts
+++ b/packages/visual-editor/src/hooks/useComponentProps.ts
@@ -96,7 +96,7 @@ export const useComponentProps = ({
         }
 
         if (variableMapping.type === 'DesignValue') {
-          const valueByBreakpoint = resolveDesignValue(
+          const valuesByBreakpoint = resolveDesignValue(
             variableMapping.valuesByBreakpoint,
             variableName,
           );
@@ -105,9 +105,9 @@ export const useComponentProps = ({
               ? calculateNodeDefaultHeight({
                   blockId: node.data.blockId,
                   children: node.children,
-                  value: valueByBreakpoint,
+                  value: valuesByBreakpoint,
                 })
-              : valueByBreakpoint;
+              : valuesByBreakpoint;
 
           return {
             ...acc,


### PR DESCRIPTION
## Purpose

When binding an entry and deleting the entry afterward, I saw the default content value "Heading" in the editor but in preview the whole component was not rendered at all.

![image](https://github.com/user-attachments/assets/ab5d5b4f-de8b-4ee4-a639-6c08408f6f1a)
![image](https://github.com/user-attachments/assets/b89eafbb-dad5-4f6b-a808-312bcff5bc53)


## Approach

So far, we did not fall back to the default values in preview mode. After aligning with design & product, this is now streamlined with the editor mode.