### PR TITLE
fix(visual-editor): styling for custom component children dropzone [ALT-1085]

### DIFF
--- a/packages/visual-editor/src/components/DraggableBlock/Dropzone.tsx
+++ b/packages/visual-editor/src/components/DraggableBlock/Dropzone.tsx
@@ -165,6 +165,7 @@ export function Dropzone({
             }}
             id={zoneId}
             data-ctfl-zone-id={zoneId}
+            data-ctfl-slot-id={slotId}
             className={classNames(dragProps?.className, styles.Dropzone, className, {
               [styles.isEmptyCanvas]: isEmptyCanvas,
               [styles.isDragging]: userIsDragging,
@@ -172,8 +173,8 @@ export function Dropzone({
               [styles.isRoot]: isRootZone,
               [styles.isEmptyZone]: !content.length,
               [styles.isAssembly]: isRootAssembly,
-            })}
-            data-ctfl-slot-id={slotId}>
+              [styles.isSlot]: Boolean(slotId),
+            })}>
             {isEmptyCanvas ? (
               <EmptyContainer isDragging={isRootZone && userIsDragging} />
             ) : (

--- a/packages/visual-editor/src/components/DraggableBlock/EditorBlock.tsx
+++ b/packages/visual-editor/src/components/DraggableBlock/EditorBlock.tsx
@@ -168,9 +168,8 @@ export const EditorBlock: React.FC<EditorBlockProps> = ({
             },
             className: classNames(styles.DraggableComponent, {
               [styles.isAssemblyBlock]: isAssemblyBlock,
-              [styles.isDragging]: snapshot?.isDragging,
+              [styles.isDragging]: snapshot?.isDragging || userIsDragging,
               [styles.isSelected]: isSelected,
-              [styles.userIsDragging]: userIsDragging,
               [styles.isHoveringComponent]: isHoveredComponent,
             }),
             style: getStyle(provided.draggableProps.style, snapshot),

--- a/packages/visual-editor/src/components/DraggableBlock/styles.module.css
+++ b/packages/visual-editor/src/components/DraggableBlock/styles.module.css
@@ -1,4 +1,5 @@
-.DraggableComponent {
+.DraggableComponent,
+.Dropzone:not(.isSlot) {
   position: relative;
   transition: background-color 0.2s;
   pointer-events: all;
@@ -6,7 +7,8 @@
   cursor: grab;
 }
 
-.DraggableComponent:before {
+.DraggableComponent:before,
+.Dropzone:not(.isSlot):before {
   content: '';
   position: absolute;
   top: 0;
@@ -28,15 +30,6 @@
   width: 100%;
 }
 
-.Dropzone.isDestination:not(.isRoot):before {
-  transition:
-    outline 0.2s,
-    background-color 0.2s;
-  outline: 2px dashed var(--exp-builder-blue400);
-  background-color: rgba(var(--exp-builder-blue100-rgb), 0.5);
-  z-index: 2;
-}
-
 .DraggableComponent:is(.Dropzone).isDragging {
   pointer-events: all;
 }
@@ -52,6 +45,15 @@
 
 .isDragging:not(.isRoot):not(.DraggableClone):before {
   outline: 2px dashed var(--exp-builder-gray300);
+}
+
+.Dropzone.isDestination:not(.isRoot):before {
+  transition:
+    outline 0.2s,
+    background-color 0.2s;
+  outline: 2px dashed var(--exp-builder-blue400);
+  background-color: rgba(var(--exp-builder-blue100-rgb), 0.5);
+  z-index: 2;
 }
 
 .DraggableClone:before {


### PR DESCRIPTION
## Purpose

Fixes a bug with the custom components not accepting children to be dragged into the dropzone as expected.

The issue had two sides:
* First, the visual editor outlines were not rendering for `.Dropzone` elements
  * Fix: I added the `.Dropzone` selector to match the `.DraggableComponent` styles and included a `:not(.isSlot)` to prevent double-outlines rendering on Slot dropzones.

* Second, in `<EditorBlock>` the `userIsDragging` boolean was associated with a conditional `.userIsDragging` style, but those styles were replaced [in this PR](https://github.com/contentful/experience-builder/pull/635/files#diff-28d89a9f8f144ff448bc930e3241ff66dace31da1199a21b789b00ba852ae457) with the `.isDragging` class
  * Fix: I moved the `userIsDragging` boolean to be an OR condition on the conditional `.isDragging` style instead

https://github.com/user-attachments/assets/60f9fb6a-25bf-417f-8726-0c4f788bfdb2



