### PR TITLE
fix: divider not selectable in editor mode [ALT-1120]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2684,6 +2684,7 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {

--- a/packages/components/src/components/Divider/ContentfulDivider.tsx
+++ b/packages/components/src/components/Divider/ContentfulDivider.tsx
@@ -8,7 +8,7 @@ export type ContentfulDividerProps = {
 export const ContentfulDivider = (props: ContentfulDividerProps) => {
   const { className } = props;
   return (
-    <div className={'cf-divider'} {...props}>
+    <div className="cf-divider" {...props}>
       <hr className={className} />
     </div>
   );

--- a/packages/components/src/components/Divider/ContentfulDivider.tsx
+++ b/packages/components/src/components/Divider/ContentfulDivider.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import './ContentfulDivider.css';
+import { combineClasses } from '@/utils/combineClasses';
 
 export type ContentfulDividerProps = {
   className?: string;
@@ -8,7 +9,7 @@ export type ContentfulDividerProps = {
 export const ContentfulDivider = (props: ContentfulDividerProps) => {
   const { className } = props;
   return (
-    <div className="cf-divider">
+    <div className={combineClasses('cf-divider', className)} {...props}>
       <hr className={className} />
     </div>
   );

--- a/packages/components/src/components/Divider/ContentfulDivider.tsx
+++ b/packages/components/src/components/Divider/ContentfulDivider.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import './ContentfulDivider.css';
-import { combineClasses } from '@/utils/combineClasses';
 
 export type ContentfulDividerProps = {
   className?: string;
@@ -9,7 +8,7 @@ export type ContentfulDividerProps = {
 export const ContentfulDivider = (props: ContentfulDividerProps) => {
   const { className } = props;
   return (
-    <div className={combineClasses('cf-divider', className)} {...props}>
+    <div className={'cf-divider'} {...props}>
       <hr className={className} />
     </div>
   );

--- a/packages/test-apps/react-vite/src/studio-config.ts
+++ b/packages/test-apps/react-vite/src/studio-config.ts
@@ -1,4 +1,8 @@
-import { defineComponents, defineBreakpoints } from '@contentful/experiences-sdk-react';
+import {
+  defineComponents,
+  defineBreakpoints,
+  defineDesignTokens,
+} from '@contentful/experiences-sdk-react';
 import ComponentWithChildren from './components/ComponentWithChildren';
 import { LinkComponent } from './components/LinkComponent';
 import { CustomImageComponent } from './components/CustomImageComponent';
@@ -167,3 +171,22 @@ defineBreakpoints([
     previewSize: '390px',
   },
 ]);
+
+const color = { Slate: '#94a3b8', Azure: 'azure', Orange: '#fdba74', Blue: '#0000ff' };
+// register design tokens
+defineDesignTokens({
+  spacing: { XS: '4px', S: '16px', M: '32px', L: '64px', XL: '128px' },
+  sizing: { XS: '16px', S: '100px', M: '300px', L: '600px', XL: '1024px' },
+  color: color,
+  border: {
+    Azure: { width: '1px', style: 'solid', color: color.Azure },
+    Hero: { width: '2px', style: 'dashed', color: color.Orange },
+    Card: { width: '1px', style: 'solid', color: color.Blue },
+    Carousel: { width: '2px', style: 'dotted', color: color.Slate },
+  },
+  borderRadius: { XS: '2px', S: '4px', MMM: '16px', LLLLLLLLLLLLLL: '85px', XL: '1280px' },
+  fontSize: { XS: '12px', SM: '14px', MD: '16px', LG: '24px', XL: '32px' },
+  lineHeight: { XS: '1', SM: '1.25', MD: '1.5', LG: '200%' },
+  letterSpacing: { None: '0', XS: '0.05em', SM: '0.1em', MD: '0.15em', LG: '0.2em' },
+  textColor: { Dark: '#1a1a1a', Light: '#efefef', Slate: '#94a3b8' },
+});

--- a/packages/test-apps/react-vite/src/studio-config.ts
+++ b/packages/test-apps/react-vite/src/studio-config.ts
@@ -1,8 +1,4 @@
-import {
-  defineComponents,
-  defineBreakpoints,
-  defineDesignTokens,
-} from '@contentful/experiences-sdk-react';
+import { defineComponents, defineBreakpoints } from '@contentful/experiences-sdk-react';
 import ComponentWithChildren from './components/ComponentWithChildren';
 import { LinkComponent } from './components/LinkComponent';
 import { CustomImageComponent } from './components/CustomImageComponent';
@@ -171,22 +167,3 @@ defineBreakpoints([
     previewSize: '390px',
   },
 ]);
-
-const color = { Slate: '#94a3b8', Azure: 'azure', Orange: '#fdba74', Blue: '#0000ff' };
-// register design tokens
-defineDesignTokens({
-  spacing: { XS: '4px', S: '16px', M: '32px', L: '64px', XL: '128px' },
-  sizing: { XS: '16px', S: '100px', M: '300px', L: '600px', XL: '1024px' },
-  color: color,
-  border: {
-    Azure: { width: '1px', style: 'solid', color: color.Azure },
-    Hero: { width: '2px', style: 'dashed', color: color.Orange },
-    Card: { width: '1px', style: 'solid', color: color.Blue },
-    Carousel: { width: '2px', style: 'dotted', color: color.Slate },
-  },
-  borderRadius: { XS: '2px', S: '4px', MMM: '16px', LLLLLLLLLLLLLL: '85px', XL: '1280px' },
-  fontSize: { XS: '12px', SM: '14px', MD: '16px', LG: '24px', XL: '32px' },
-  lineHeight: { XS: '1', SM: '1.25', MD: '1.5', LG: '200%' },
-  letterSpacing: { None: '0', XS: '0.05em', SM: '0.1em', MD: '0.15em', LG: '0.2em' },
-  textColor: { Dark: '#1a1a1a', Light: '#efefef', Slate: '#94a3b8' },
-});


### PR DESCRIPTION
## Purpose
Props weren't spread on the root component of the divider making it not selectable in editor mode