### PR TITLE
fix: don't wrap rich text with an inline element

### DIFF
--- a/packages/components/src/components/RichText/RichText.cy.tsx
+++ b/packages/components/src/components/RichText/RichText.cy.tsx
@@ -17,21 +17,21 @@ describe('RichText', () => {
 
   it('mounts', () => {
     cy.mount(<RichText value={document} />);
-    cy.get('span').contains('abc');
+    cy.get('div').contains('abc');
   });
 
   it('additional props should be passed to the rich text', () => {
     cy.mount(<RichText value={document} data-foo="bar" />);
-    cy.get('span').should('have.attr', 'data-foo', 'bar');
+    cy.get('div').should('have.attr', 'data-foo', 'bar');
   });
 
   it('when className is provided, it should be added to the rich text', () => {
     cy.mount(<RichText value={document} className="custom-class" />);
-    cy.get('span').should('have.class', 'custom-class');
+    cy.get('div').should('have.class', 'custom-class');
   });
 
   it('has a default class of "cf-richtext"', () => {
     cy.mount(<RichText value={document} />);
-    cy.get('span').should('have.class', 'cf-richtext');
+    cy.get('div').should('have.class', 'cf-richtext');
   });
 });

--- a/packages/components/src/components/RichText/RichText.cy.tsx
+++ b/packages/components/src/components/RichText/RichText.cy.tsx
@@ -22,7 +22,7 @@ describe('RichText', () => {
 
   it('additional props should be passed to the rich text', () => {
     cy.mount(<RichText value={document} data-foo="bar" />);
-    cy.get('div').should('have.attr', 'data-foo', 'bar');
+    cy.get('div[class="cf-richtext"]').should('have.attr', 'data-foo', 'bar');
   });
 
   it('when className is provided, it should be added to the rich text', () => {
@@ -32,6 +32,6 @@ describe('RichText', () => {
 
   it('has a default class of "cf-richtext"', () => {
     cy.mount(<RichText value={document} />);
-    cy.get('div').should('have.class', 'cf-richtext');
+    cy.get('div[class="cf-richtext"]').should('have.class', 'cf-richtext');
   });
 });

--- a/packages/components/src/components/RichText/RichText.tsx
+++ b/packages/components/src/components/RichText/RichText.tsx
@@ -38,12 +38,12 @@ export const RichText: React.FC<RichTextProps> = ({ as = 'p', className, value, 
   const Tag = as;
 
   return (
-    <span className={combineClasses('cf-richtext', className)} {...props}>
+    <div className={combineClasses('cf-richtext', className)} {...props}>
       {documentToReactComponents(value, {
         renderNode: {
           [BLOCKS.PARAGRAPH]: (_node, children) => <Tag>{children}</Tag>,
         },
       })}
-    </span>
+    </div>
   );
 };


### PR DESCRIPTION
## Purpose

Adding design variables to a rich text component would not always display them properly.

## Approach

The rich text component was wrapping the outputs of the call to `documentToReactComponents` in a span tag, which is an inline level element. The markup that `documentToReactComponents` creates contains block level elements, and wrapping block level elements in an inline element can break layout flow (which we saw in this bug).

The issue was fixed by replacing the `span` tag with a `div` tag as the wrapper.

