### PR TITLE
feat: expose the HyperlinkValue type to consume it directly [SPA-227]

### DIFF
--- a/packages/validators/src/schemas/v2023_09_28/experience.ts
+++ b/packages/validators/src/schemas/v2023_09_28/experience.ts
@@ -69,6 +69,7 @@ const HyperlinkValueSchema = z
   .object({
     type: z.literal('HyperlinkValue'),
     linkTargetKey: z.string(),
+    /** Allows to override parts of the URL, e.g. the locale */
     overrides: z.object({}).optional(),
   })
   .strict();
@@ -260,4 +261,5 @@ export type PrimitiveValue = z.infer<typeof PrimitiveValueSchema>;
 export type DesignValue = z.infer<typeof DesignValueSchema>;
 export type BoundValue = z.infer<typeof BoundValueSchema>;
 export type UnboundValue = z.infer<typeof UnboundValueSchema>;
+export type HyperlinkValue = z.infer<typeof HyperlinkValueSchema>;
 export type ComponentValue = z.infer<typeof ComponentValueSchema>;


### PR DESCRIPTION
## Purpose

Using the union type `ComponentPropertyValue` is not strict enough and requires some additional typeguarding inside the customer application.

## Approach

Export the type explicitly same as for `UnboundValue` & co.