### PR TITLE
[ALT-1061] fix: hovering pattern in layers tab now renders the display name on canvas in studio experiences

### DIFF
--- a/packages/visual-editor/src/components/DraggableBlock/EditorBlock.tsx
+++ b/packages/visual-editor/src/components/DraggableBlock/EditorBlock.tsx
@@ -61,7 +61,7 @@ export const EditorBlock: React.FC<EditorBlockProps> = ({
   const ref = useRef<HTMLElement | null>(null);
   const setSelectedNodeId = useEditorStore((state) => state.setSelectedNodeId);
   const selectedNodeId = useEditorStore((state) => state.selectedNodeId);
-  const { node, componentId, elementToRender } = useComponent({
+  const { node, componentId, elementToRender, definition } = useComponent({
     node: rawNode,
     resolveDesignValue,
     renderDropzone,
@@ -73,7 +73,7 @@ export const EditorBlock: React.FC<EditorBlockProps> = ({
     (state) => state.hoveredComponentId === componentId,
   );
   const coordinates = useSelectedInstanceCoordinates({ node });
-  const displayName = node.data.displayName;
+  const displayName = node.data.displayName || rawNode.data.displayName || definition?.name;
   const testId = `draggable-${node.data.blockId ?? 'node'}`;
   const isSelected = node.data.id === selectedNodeId;
   const isContainer = node.data.blockId === CONTENTFUL_COMPONENTS.container.id;
@@ -82,7 +82,6 @@ export const EditorBlock: React.FC<EditorBlockProps> = ({
   const isStructureComponent = isContentfulStructureComponent(node.data.blockId);
   const isSlotComponent = Boolean(node.data.slotId);
   const isDragDisabled = isAssemblyBlock || (isSingleColumn && isWrapped) || isSlotComponent;
-
   const isEmptyZone = useMemo(() => {
     return !node.children.filter((node) => node.data.slotId === slotId).length;
   }, [node.children, slotId]);
@@ -115,9 +114,7 @@ export const EditorBlock: React.FC<EditorBlockProps> = ({
 
   const onMouseOver = (e: React.SyntheticEvent<Element, Event>) => {
     e.stopPropagation();
-
     if (userIsDragging) return;
-
     sendMessage(OUTGOING_EVENTS.NewHoveredElement, {
       nodeId: componentId,
     });
@@ -137,7 +134,7 @@ export const EditorBlock: React.FC<EditorBlockProps> = ({
       <Tooltip
         id={componentId}
         coordinates={coordinates}
-        isAssemblyBlock={isAssemblyBlock}
+        isAssemblyBlock={isAssemblyBlock || isAssembly}
         isContainer={isContainer}
         label={displayName || 'No label specified'}
       />
@@ -167,7 +164,7 @@ export const EditorBlock: React.FC<EditorBlockProps> = ({
               ref.current = refNode;
             },
             className: classNames(styles.DraggableComponent, {
-              [styles.isAssemblyBlock]: isAssemblyBlock,
+              [styles.isAssemblyBlock]: isAssemblyBlock || isAssembly,
               [styles.isDragging]: snapshot?.isDragging || userIsDragging,
               [styles.isSelected]: isSelected,
               [styles.isHoveringComponent]: isHoveredComponent,

--- a/packages/visual-editor/src/components/DraggableBlock/styles.module.css
+++ b/packages/visual-editor/src/components/DraggableBlock/styles.module.css
@@ -139,7 +139,7 @@
 .DraggableComponent:has(.isHoveringComponent):not(.isAssemblyBlock) .DraggableComponent:not(.isHoveringComponent):not(.isAssemblyBlock):before,
 .isHoveringComponent:not(.isAssemblyBlock) .DraggableComponent:not(.isAssemblyBlock):before,
 /* hovering related component in canvas */
-.DraggableComponent:not(.isDragging):hover:before,
+.DraggableComponent:not(.isAssemblyBlock):not(.isDragging):hover:before,
 .DraggableComponent:not(.isDragging):hover .DraggableComponent:before {
   outline: 2px dashed var(--exp-builder-gray500);
 }
@@ -147,7 +147,7 @@
 /* hovering component in layers tab */
 .isHoveringComponent:not(.isAssemblyBlock):before,
 /* hovering component in canvas */
-.DraggableComponent:not(.isDragging):hover:not(:has(.DraggableComponent:hover)):before {
+.DraggableComponent:not(.isAssemblyBlock):not(.isDragging):hover:not(:has(.DraggableComponent:hover)):before {
   outline: 2px solid var(--exp-builder-gray500);
 }
 


### PR DESCRIPTION
## Purpose
Hovering over a pattern in the layers tab now looks like this 
It uses the display name of the pattern
<img width="1035" alt="Screenshot 2024-08-27 at 11 48 47 AM" src="https://github.com/user-attachments/assets/8bc439e1-57e1-4baa-b702-ca5967969c97">


https://www.loom.com/share/1a504adca3cb4431a9d1e1d0d5bfc44d?sid=ae67f77c-bf40-43b6-82d1-1fb7580085bb