### PR TITLE
feat: add style prop to toggle visibility in component registration [SPA-2371]

### DIFF
--- a/packages/core/src/definitions/styles.ts
+++ b/packages/core/src/definitions/styles.ts
@@ -56,7 +56,7 @@ export const builtInStyles: VariableDefinitions = {
     defaultValue: 'center',
     displayName: 'Horizontal alignment',
   },
-  cfCanToggleVisibility: {
+  cfVisibility: {
     displayName: 'Visibility toggle',
     type: 'Boolean',
     group: 'style',
@@ -341,7 +341,7 @@ export const containerBuiltInStyles: VariableDefinitions = {
 };
 
 export const dividerBuiltInStyles: VariableDefinitions = {
-  cfCanToggleVisibility: builtInStyles.cfCanToggleVisibility,
+  cfVisibility: builtInStyles.cfVisibility,
   cfBorderRadius: optionalBuiltInStyles.cfBorderRadius,
   cfMargin: {
     displayName: 'Margin',
@@ -381,7 +381,7 @@ export const dividerBuiltInStyles: VariableDefinitions = {
 };
 
 export const singleColumnBuiltInStyles: VariableDefinitions = {
-  cfCanToggleVisibility: builtInStyles.cfCanToggleVisibility,
+  cfVisibility: builtInStyles.cfVisibility,
   cfBorderRadius: optionalBuiltInStyles.cfBorderRadius,
   cfBackgroundColor: optionalBuiltInStyles.cfBackgroundColor,
   cfBackgroundImageUrl: optionalBuiltInStyles.cfBackgroundImageUrl,
@@ -480,7 +480,7 @@ export const singleColumnBuiltInStyles: VariableDefinitions = {
 };
 
 export const columnsBuiltInStyles: VariableDefinitions = {
-  cfCanToggleVisibility: builtInStyles.cfCanToggleVisibility,
+  cfVisibility: builtInStyles.cfVisibility,
   cfBorderRadius: optionalBuiltInStyles.cfBorderRadius,
   cfBackgroundColor: optionalBuiltInStyles.cfBackgroundColor,
   cfBackgroundImageUrl: optionalBuiltInStyles.cfBackgroundImageUrl,

--- a/packages/core/src/definitions/styles.ts
+++ b/packages/core/src/definitions/styles.ts
@@ -56,6 +56,13 @@ export const builtInStyles: VariableDefinitions = {
     defaultValue: 'center',
     displayName: 'Horizontal alignment',
   },
+  cfCanToggleVisibility: {
+    displayName: 'Visibility toggle',
+    type: 'Boolean',
+    group: 'style',
+    defaultValue: false,
+    description: 'To enable visibility toggle in patterns',
+  },
   cfMargin: {
     displayName: 'Margin',
     type: 'Text',

--- a/packages/core/src/definitions/styles.ts
+++ b/packages/core/src/definitions/styles.ts
@@ -61,7 +61,7 @@ export const builtInStyles: VariableDefinitions = {
     type: 'Boolean',
     group: 'style',
     defaultValue: false,
-    description: 'To enable visibility toggle in patterns',
+    description: 'To enable visibility toggle in components',
   },
   cfMargin: {
     displayName: 'Margin',

--- a/packages/core/src/definitions/styles.ts
+++ b/packages/core/src/definitions/styles.ts
@@ -341,6 +341,7 @@ export const containerBuiltInStyles: VariableDefinitions = {
 };
 
 export const dividerBuiltInStyles: VariableDefinitions = {
+  cfCanToggleVisibility: builtInStyles.cfCanToggleVisibility,
   cfBorderRadius: optionalBuiltInStyles.cfBorderRadius,
   cfMargin: {
     displayName: 'Margin',
@@ -380,6 +381,7 @@ export const dividerBuiltInStyles: VariableDefinitions = {
 };
 
 export const singleColumnBuiltInStyles: VariableDefinitions = {
+  cfCanToggleVisibility: builtInStyles.cfCanToggleVisibility,
   cfBorderRadius: optionalBuiltInStyles.cfBorderRadius,
   cfBackgroundColor: optionalBuiltInStyles.cfBackgroundColor,
   cfBackgroundImageUrl: optionalBuiltInStyles.cfBackgroundImageUrl,
@@ -478,6 +480,7 @@ export const singleColumnBuiltInStyles: VariableDefinitions = {
 };
 
 export const columnsBuiltInStyles: VariableDefinitions = {
+  cfCanToggleVisibility: builtInStyles.cfCanToggleVisibility,
   cfBorderRadius: optionalBuiltInStyles.cfBorderRadius,
   cfBackgroundColor: optionalBuiltInStyles.cfBackgroundColor,
   cfBackgroundImageUrl: optionalBuiltInStyles.cfBackgroundImageUrl,

--- a/packages/core/src/definitions/styles.ts
+++ b/packages/core/src/definitions/styles.ts
@@ -60,8 +60,8 @@ export const builtInStyles: VariableDefinitions = {
     displayName: 'Visibility toggle',
     type: 'Boolean',
     group: 'style',
-    defaultValue: false,
-    description: 'To enable visibility toggle in components',
+    defaultValue: true,
+    description: 'The visibility of the component',
   },
   cfMargin: {
     displayName: 'Margin',

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -176,7 +176,7 @@ export type InternalSDKMode = ExternalSDKMode | 'editor';
  * collisions with user defined variables.
  */
 export type StyleProps = {
-  cfCanToggleVisibility: boolean;
+  cfVisibility: boolean;
   cfHorizontalAlignment: 'start' | 'end' | 'center';
   cfVerticalAlignment: 'start' | 'end' | 'center';
   cfMargin: string;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -176,6 +176,7 @@ export type InternalSDKMode = ExternalSDKMode | 'editor';
  * collisions with user defined variables.
  */
 export type StyleProps = {
+  cfCanToggleVisibility: boolean;
   cfHorizontalAlignment: 'start' | 'end' | 'center';
   cfVerticalAlignment: 'start' | 'end' | 'center';
   cfMargin: string;

--- a/packages/experience-builder-sdk/src/core/componentRegistry.test.tsx
+++ b/packages/experience-builder-sdk/src/core/componentRegistry.test.tsx
@@ -147,7 +147,7 @@ describe('component registration', () => {
       expect(variableKeys).not.toContain('cfMargin');
     });
 
-    it('should apply fallback to group: content for variables that have it undefined', () => {
+    it('should contain cfVisibility property by default', () => {
       const definitionId = 'TestComponent';
 
       registry.defineComponents([
@@ -166,12 +166,11 @@ describe('component registration', () => {
         },
       ]);
 
-      const definition = registry.getComponentRegistration(definitionId);
-      expect(definition).toBeDefined();
+      const componentRegistration = registry.getComponentRegistration(definitionId);
+      expect(componentRegistration).toBeDefined();
 
-      for (const variable of Object.values(definition!.definition.variables)) {
-        expect(variable.group).toBe('content');
-      }
+      const variableKeys = Object.keys(componentRegistration!.definition.variables);
+      expect(variableKeys).toContain('cfVisibility');
     });
   });
 });

--- a/packages/experience-builder-sdk/src/core/componentRegistry.ts
+++ b/packages/experience-builder-sdk/src/core/componentRegistry.ts
@@ -56,6 +56,7 @@ const applyBuiltInStyleDefinitions = (componentDefinition: ComponentDefinition) 
   if (!clone.builtInStyles) {
     clone.builtInStyles = ['cfMargin'];
   }
+  clone.variables['cfCanToggleVisibility'] = builtInStyleDefinitions['cfCanToggleVisibility'];
 
   for (const style of Object.values(clone.builtInStyles || [])) {
     if (builtInStyleDefinitions[style]) {

--- a/packages/experience-builder-sdk/src/core/componentRegistry.ts
+++ b/packages/experience-builder-sdk/src/core/componentRegistry.ts
@@ -56,7 +56,7 @@ const applyBuiltInStyleDefinitions = (componentDefinition: ComponentDefinition) 
   if (!clone.builtInStyles) {
     clone.builtInStyles = ['cfMargin'];
   }
-  clone.variables['cfCanToggleVisibility'] = builtInStyleDefinitions['cfCanToggleVisibility'];
+  clone.variables['cfVisibility'] = builtInStyleDefinitions['cfVisibility'];
 
   for (const style of Object.values(clone.builtInStyles || [])) {
     if (builtInStyleDefinitions[style]) {

--- a/packages/experience-builder-sdk/src/core/componentRegistry.ts
+++ b/packages/experience-builder-sdk/src/core/componentRegistry.ts
@@ -56,6 +56,8 @@ const applyBuiltInStyleDefinitions = (componentDefinition: ComponentDefinition) 
   if (!clone.builtInStyles) {
     clone.builtInStyles = ['cfMargin'];
   }
+
+  // Enforce the presence of this property for toggling visibility on any node
   clone.variables['cfVisibility'] = builtInStyleDefinitions['cfVisibility'];
 
   for (const style of Object.values(clone.builtInStyles || [])) {

--- a/packages/experience-builder-sdk/src/core/sdkFeatures.ts
+++ b/packages/experience-builder-sdk/src/core/sdkFeatures.ts
@@ -1,4 +1,5 @@
 // Object to store the SDK features that are enabled/disabled
 export const sdkFeatures: Record<string, unknown> = {
   hasSDKVersionUI: true,
+  cfVisibility: true,
 };

--- a/packages/test-apps/react-vite/src/studio-config.ts
+++ b/packages/test-apps/react-vite/src/studio-config.ts
@@ -171,7 +171,7 @@ defineComponents([
 
 defineBreakpoints([
   {
-    id: 'test-desktop1',
+    id: 'test-desktop',
     query: '*',
     displayName: 'All Sizes',
     displayIcon: 'desktop',

--- a/packages/test-apps/react-vite/src/studio-config.ts
+++ b/packages/test-apps/react-vite/src/studio-config.ts
@@ -171,7 +171,7 @@ defineComponents([
 
 defineBreakpoints([
   {
-    id: 'test-desktop',
+    id: 'test-desktop1',
     query: '*',
     displayName: 'All Sizes',
     displayIcon: 'desktop',


### PR DESCRIPTION
## Purpose
Introduce a cfVisibility style prop variable to the default style definitions

## Approach

- Add ` cfVisibility` to cf component default style definitions
- For custom components, add ` cfVisibility` default variable on component registration 