### PR TITLE
chore: add/update repository/bugs field in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "homepage": "https://github.com/contentful/experience-builder#readme",
   "repository": {
     "type": "git",
-    "url": "https://github.com/contentful/experience-builder.git"
+    "url": "git+https://github.com/contentful/experience-builder.git"
   },
   "bugs": {
     "url": "https://github.com/contentful/experience-builder/issues"

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -5,7 +5,11 @@
   "homepage": "https://github.com/contentful/experience-builder/tree/next/packages/components#readme",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/contentful/experience-builder.git"
+    "url": "git+https://github.com/contentful/experience-builder.git",
+    "directory": "packages/components"
+  },
+  "bugs": {
+    "url": "https://github.com/contentful/experience-builder/issues"
   },
   "main": "./dist/index.js",
   "module": "./dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -8,7 +8,11 @@
   "type": "module",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/contentful/experience-builder.git"
+    "url": "git+https://github.com/contentful/experience-builder.git",
+    "directory": "packages/core"
+  },
+  "bugs": {
+    "url": "https://github.com/contentful/experience-builder/issues"
   },
   "files": [
     "readme.md",

--- a/packages/create-contentful-studio-experiences/package.json
+++ b/packages/create-contentful-studio-experiences/package.json
@@ -5,7 +5,11 @@
   "homepage": "https://github.com/contentful/experience-builder/tree/next/packages/create-contentful-studio-experiences#readme",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/contentful/experience-builder.git"
+    "url": "git+https://github.com/contentful/experience-builder.git",
+    "directory": "packages/create-contentful-studio-experiences"
+  },
+  "bugs": {
+    "url": "https://github.com/contentful/experience-builder/issues"
   },
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/experience-builder-sdk/package.json
+++ b/packages/experience-builder-sdk/package.json
@@ -10,6 +10,14 @@
   "publishConfig": {
     "registry": "https://npm.pkg.github.com/"
   },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/contentful/experience-builder.git",
+    "directory": "packages/experience-builder-sdk"
+  },
+  "bugs": {
+    "url": "https://github.com/contentful/experience-builder/issues"
+  },
   "scripts": {
     "clean": "rimraf dist",
     "predev": "npm run clean",

--- a/packages/storybook-addon/package.json
+++ b/packages/storybook-addon/package.json
@@ -9,7 +9,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/contentful/experience-builder-storybook"
+    "url": "git+https://github.com/contentful/experience-builder.git",
+    "directory": "packages/storybook-addon"
+  },
+  "bugs": {
+    "url": "https://github.com/contentful/experience-builder/issues"
   },
   "author": "Contentful <chase.poirier@contentful.com>",
   "license": "MIT",

--- a/packages/validators/package.json
+++ b/packages/validators/package.json
@@ -8,7 +8,11 @@
   "homepage": "https://github.com/contentful/experience-builder/tree/next/packages/validators#readme",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/contentful/experience-builder.git"
+    "url": "git+https://github.com/contentful/experience-builder.git",
+    "directory": "packages/validators"
+  },
+  "bugs": {
+    "url": "https://github.com/contentful/experience-builder/issues"
   },
   "scripts": {
     "predev": "npm run clean",

--- a/packages/visual-editor/package.json
+++ b/packages/visual-editor/package.json
@@ -13,6 +13,14 @@
   "publishConfig": {
     "registry": "https://npm.pkg.github.com/"
   },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/contentful/experience-builder.git",
+    "directory": "packages/visual-editor"
+  },
+  "bugs": {
+    "url": "https://github.com/contentful/experience-builder/issues"
+  },
   "scripts": {
     "bundle": "npx watchify dist/index.cjs -o dist/bundle.js",
     "clean": "rimraf dist",


### PR DESCRIPTION
## Purpose

Some packages are missing repository details in the package.json. Therefore, npm doesn't link to this repo.

![image](https://github.com/user-attachments/assets/cf21aacd-3360-4727-ad59-7042c29fb8e0)


## Approach

- Add `bugs` field to all package.json
- Update `repository.url` to consistent value
- Add `repository.directory` for packages.
- Fix repo URL for storybook