### PR TITLE
fix: test apps mobile breakpoint config [ALT-1167]

### DIFF
--- a/packages/core/src/registries/breakpointsRegistry.spec.ts
+++ b/packages/core/src/registries/breakpointsRegistry.spec.ts
@@ -21,7 +21,7 @@ describe('defineBreakpoints', () => {
       },
       {
         id: 'test-mobile',
-        query: '<360px',
+        query: '<576px',
         displayName: 'Mobile',
         previewSize: '390px',
       },

--- a/packages/test-apps/nextjs/src/studio-config.ts
+++ b/packages/test-apps/nextjs/src/studio-config.ts
@@ -186,7 +186,7 @@ defineBreakpoints([
   },
   {
     id: 'test-mobile',
-    query: '<360px',
+    query: '<576px',
     displayName: 'Mobile',
     displayIcon: 'mobile',
     previewSize: '390px',

--- a/packages/test-apps/react-vite/src/studio-config.ts
+++ b/packages/test-apps/react-vite/src/studio-config.ts
@@ -186,7 +186,7 @@ defineBreakpoints([
   },
   {
     id: 'test-mobile',
-    query: '<360px',
+    query: '<576px',
     displayName: 'Mobile',
     displayIcon: 'mobile',
     previewSize: '390px',


### PR DESCRIPTION
## Purpose

Fixes rendering for mobile breakpoint styles in the test apps.

## Approach

The mobile breakpoint definition in the test apps was using the query `<360px` that was lower than the previewSize `390px`. Essentially telling the UI to render a 390px wide iframe preview and apply mobile styles when the viewport is below 360px.

I changed the mobile breakpoint query to `<576px` to match the [example custom breakpoints registration](https://www.contentful.com/developers/docs/experiences/register-custom-breakpoints/#example-custom-breakpoints-registration)

## Updating Breakpoints

For experiences created with the previous breakpoint config, each dev/user will need to update their experiences using the "Update breakpoints" button that displays in the design sidebar when no component is selected:

![Screenshot 2024-08-29 at 9 34 58 PM](https://github.com/user-attachments/assets/701cf9b3-c2ee-4732-8b28-af5fdc9c0d9e)

And then "Update breakpoints" in the confirmation modal:

![Screenshot 2024-08-29 at 9 35 06 PM](https://github.com/user-attachments/assets/c09855c2-9e4b-4358-b0ca-30f35d5962a0)

Once the breakpoints are updated in the experience, the mobile styles work as intended again:

https://github.com/user-attachments/assets/8a169513-354b-4bf3-bc2d-cd6f99684c24

