### PR TITLE
fix: default value for container margin to be auto left/right [ALT-1166]

### DIFF
--- a/packages/core/src/definitions/styles.ts
+++ b/packages/core/src/definitions/styles.ts
@@ -324,6 +324,13 @@ export const containerBuiltInStyles: VariableDefinitions = {
   cfBorderRadius: optionalBuiltInStyles.cfBorderRadius,
   cfBackgroundImageUrl: optionalBuiltInStyles.cfBackgroundImageUrl,
   cfBackgroundImageOptions: optionalBuiltInStyles.cfBackgroundImageOptions,
+  cfMargin: {
+    displayName: 'Margin',
+    type: 'Text',
+    group: 'style',
+    description: 'The margin of the section',
+    defaultValue: '0 auto 0 auto',
+  },
   cfMaxWidth: {
     displayName: 'Max Width',
     type: 'Text',


### PR DESCRIPTION
## Purpose
Second half of fixed margin for the Container component. We needed to fix the default value to be `margin: 0 auto 0 auto`.

Ticket: https://contentful.atlassian.net/browse/ALT-1166
Linked PR: https://github.com/contentful/user_interface/pull/23002
