### PR TITLE
fix: use a reasonable preview size for mobile []

### DIFF
--- a/packages/test-apps/react-vite/src/studio-config.ts
+++ b/packages/test-apps/react-vite/src/studio-config.ts
@@ -189,6 +189,6 @@ defineBreakpoints([
     query: '<360px',
     displayName: 'Mobile',
     displayIcon: 'mobile',
-    previewSize: '390px',
+    previewSize: '350px',
   },
 ]);


### PR DESCRIPTION
If you render the mobile preview in the test-app, you won't see the designs currently.