### PR TITLE
fix: dont swallow errors that are originated inside the SDK [SPA-2189]

### DIFF
--- a/packages/visual-editor/src/components/DraggableHelpers/ImportedComponentErrorBoundary.tsx
+++ b/packages/visual-editor/src/components/DraggableHelpers/ImportedComponentErrorBoundary.tsx
@@ -7,8 +7,23 @@ class ImportedComponentError extends Error {
   }
 }
 
+/** Use this error class (inside visual-editor) if you want to make sure that the error
+ * is tracked via Sentry. Currently, the `ImportedComponentErrorBoundary` is swallowing
+ * more errors than intended, so this way we make sure that the errors are being tracked. */
+export class SDKVisualEditorError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'SDKVisualEditorError';
+  }
+}
+
 export class ImportedComponentErrorBoundary extends React.Component<{ children: ReactElement }> {
   componentDidCatch(error: Error, _errorInfo: ErrorInfo) {
+    if (error instanceof SDKVisualEditorError) {
+      // Turning it into ImportedComponentError skips it during error tracking. By explicitly creating
+      // a SDKVisualEditorError, we can make sure that errors in visual-editor are still being tracked.
+      throw error;
+    }
     const err = new ImportedComponentError(error.message);
     err.stack = error.stack;
     throw err;


### PR DESCRIPTION
## Purpose

The "imported component" error boundary seems to swallow any error in our rendering logic. When I turn [this warning](https://github.com/contentful/experience-builder/blob/b0213c0e261cf6c1219af99a238282f92f67438a/packages/visual-editor/src/hooks/useComponent.tsx#L58) again into an error, it gets swallowed. I assume that is because the boundary will wrap not only the component (whether custom or built-in) but also any logic inside its children and thus again the logic for the children inside `useComponent`. The top-level section component will already add the first boundary and thereby swallow any error regarding component registration, child rendering, etc.

## Approach

Introduce a new error class that explicitly not gets swallows:
<img width="1551" alt="Screenshot 2024-09-04 at 12 45 05" src="https://github.com/user-attachments/assets/72eb7df9-7eb5-44e8-a065-ffacf4e903c5">
<img width="1202" alt="Screenshot 2024-09-04 at 12 45 31" src="https://github.com/user-attachments/assets/8a8c871b-59cc-46c0-b8d1-2b6d1a64be22">

