### PR TITLE
fix: type error when breakpoint is undefined

### DIFF
--- a/packages/core/src/utils/breakpoints.spec.ts
+++ b/packages/core/src/utils/breakpoints.spec.ts
@@ -82,6 +82,18 @@ describe('getValueForBreakpoint', () => {
       expect(value).toEqual(desktopValue);
     });
   });
+
+  describe('when rendering a view without a matching breakpoint', () => {
+    it('falls back to the desktop-specific value', () => {
+      const value = getValueForBreakpoint(
+        valuesByBreakpointWithoutTabletAndMobile,
+        breakpoints,
+        3,
+        variableName,
+      );
+      expect(value).toEqual(desktopValue);
+    });
+  });
 });
 
 describe('getActiveBreakpointIndex', () => {

--- a/packages/core/src/utils/breakpoints.ts
+++ b/packages/core/src/utils/breakpoints.ts
@@ -109,7 +109,7 @@ export const getValueForBreakpoint = (
   if (valuesByBreakpoint instanceof Object) {
     // Assume that the values are sorted by media query to apply the cascading CSS logic
     for (let index = activeBreakpointIndex; index >= 0; index--) {
-      const breakpointId = breakpoints[index].id;
+      const breakpointId = breakpoints[index]?.id;
       if (valuesByBreakpoint[breakpointId]) {
         // If the value is defined, we use it and stop the breakpoints cascade
         return eventuallyResolveDesignTokens(valuesByBreakpoint[breakpointId]);
@@ -117,8 +117,10 @@ export const getValueForBreakpoint = (
     }
     // If no breakpoint matched, we search and apply the fallback breakpoint
     const fallbackBreakpointIndex = getFallbackBreakpointIndex(breakpoints);
-    const fallbackBreakpointId = breakpoints[fallbackBreakpointIndex].id;
-    return eventuallyResolveDesignTokens(valuesByBreakpoint[fallbackBreakpointId]);
+    const fallbackBreakpointId = breakpoints[fallbackBreakpointIndex]?.id;
+    if (valuesByBreakpoint[fallbackBreakpointId]) {
+      return eventuallyResolveDesignTokens(valuesByBreakpoint[fallbackBreakpointId]);
+    }
   } else {
     // Old design properties did not support breakpoints, keep for backward compatibility
     return valuesByBreakpoint;


### PR DESCRIPTION
## Purpose

Make sure that `getValueByBreakpoint` doesn't crash if current index doesn't match any breakpoints.
Fixes https://contentful.sentry.io/issues/5794748829/

## Approach

`getValueByBreakpoint` should be more defensive against a `currentIndex` that doesn't match any breakpoints otherwise the above error will happen and will crash the app.

Normally `currentIndex` should correspond to a breakpoint but since we cannot ensure that the caller has verified this we should handle this case more gracefully. It seems that a customer has already ran into this issue but since I cannot reproduce it on my side it's hard to tell where in the workflow the current index gets a wrong value.

<!--

Three important notes on Pull Requests:
- In general, you should ask yourself whether this code change will improve or worsen the overall code quality. Any new tech debt will probably never be cleaned up.
- Please remember that newly introduced logic should be validated and protected through testing.
- Take a look at PR guides such as Google's [Google’s Code Review Guidelines](https://google.github.io/eng-practices/) and [Blockly - Writing a Good Pull Request](https://developers.google.com/blockly/guides/contribute/get-started/write_a_good_pr)

-->
