### PR TITLE
fix: remove new errors as it's not used anywhere [SPA-2189]

### DIFF
--- a/packages/visual-editor/src/components/DraggableHelpers/ImportedComponentErrorBoundary.tsx
+++ b/packages/visual-editor/src/components/DraggableHelpers/ImportedComponentErrorBoundary.tsx
@@ -7,23 +7,8 @@ class ImportedComponentError extends Error {
   }
 }
 
-/** Use this error class (inside visual-editor) if you want to make sure that the error
- * is tracked via Sentry. Currently, the `ImportedComponentErrorBoundary` is swallowing
- * more errors than intended, so this way we make sure that the errors are being tracked. */
-export class SDKVisualEditorError extends Error {
-  constructor(message: string) {
-    super(message);
-    this.name = 'SDKVisualEditorError';
-  }
-}
-
 export class ImportedComponentErrorBoundary extends React.Component<{ children: ReactElement }> {
   componentDidCatch(error: Error, _errorInfo: ErrorInfo) {
-    if (error instanceof SDKVisualEditorError) {
-      // Turning it into ImportedComponentError skips it during error tracking. By explicitly creating
-      // a SDKVisualEditorError, we can make sure that errors in visual-editor are still being tracked.
-      throw error;
-    }
     const err = new ImportedComponentError(error.message);
     err.stack = error.stack;
     throw err;


### PR DESCRIPTION
Reverts contentful/experience-builder#728

Let's try to find a better way to make errors from our SDK visible.