### PR TITLE
fix: dont suppress errors in SDK code but only custom code []

### DIFF
--- a/packages/core/src/utils/components.ts
+++ b/packages/core/src/utils/components.ts
@@ -7,7 +7,7 @@ const structureComponentIds = new Set([
   CONTENTFUL_COMPONENTS.singleColumn.id,
 ]);
 
-const allComponentIds = new Set(
+const allContentfulComponentIds = new Set(
   Object.values(CONTENTFUL_COMPONENTS).map((component) => component.id),
 );
 
@@ -15,7 +15,7 @@ export const isContentfulStructureComponent = (componentId?: string) =>
   structureComponentIds.has(componentId ?? '');
 
 export const isContentfulComponent = (componentId?: string) =>
-  allComponentIds.has(componentId ?? '');
+  allContentfulComponentIds.has(componentId ?? '');
 
 export const isComponentAllowedOnRoot = (componentId?: string) =>
   isContentfulStructureComponent(componentId) || componentId === CONTENTFUL_COMPONENTS.divider.id;

--- a/packages/core/src/utils/components.ts
+++ b/packages/core/src/utils/components.ts
@@ -1,14 +1,21 @@
 import { CONTENTFUL_COMPONENTS } from '../constants';
 
-const structureComponents = new Set([
+const structureComponentIds = new Set([
   CONTENTFUL_COMPONENTS.section.id,
   CONTENTFUL_COMPONENTS.columns.id,
   CONTENTFUL_COMPONENTS.container.id,
   CONTENTFUL_COMPONENTS.singleColumn.id,
 ]);
 
+const allComponentIds = new Set(
+  Object.values(CONTENTFUL_COMPONENTS).map((component) => component.id),
+);
+
 export const isContentfulStructureComponent = (componentId?: string) =>
-  structureComponents.has(componentId ?? '');
+  structureComponentIds.has(componentId ?? '');
+
+export const isContentfulComponent = (componentId?: string) =>
+  allComponentIds.has(componentId ?? '');
 
 export const isComponentAllowedOnRoot = (componentId?: string) =>
   isContentfulStructureComponent(componentId) || componentId === CONTENTFUL_COMPONENTS.divider.id;

--- a/packages/visual-editor/src/hooks/useComponent.tsx
+++ b/packages/visual-editor/src/hooks/useComponent.tsx
@@ -98,7 +98,7 @@ export const useComponent = ({
 
     const element = React.createElement(
       ImportedComponentErrorBoundary,
-      null,
+      { componentID: node.data.blockId },
       React.createElement(componentRegistration.component, {
         ...modifiedProps,
         dragProps,

--- a/packages/visual-editor/src/hooks/useComponent.tsx
+++ b/packages/visual-editor/src/hooks/useComponent.tsx
@@ -98,7 +98,7 @@ export const useComponent = ({
 
     const element = React.createElement(
       ImportedComponentErrorBoundary,
-      { componentID: node.data.blockId },
+      { componentId: node.data.blockId },
       React.createElement(componentRegistration.component, {
         ...modifiedProps,
         dragProps,


### PR DESCRIPTION
## Purpose
If the customer's code caused an error, our "ImportedComponentErrorBoundary" would transform it to another error which is not forwarded to the web app and thus not tracked in Sentry.
As this error boundary is wrapping every node on every level, it suppressed also errors coming from our own SDK code as they are getting wrapped by this boundary as well.

## Approach
To ensure that we only forward errors that are caused by us, the deepest/ closest error boundary now differentiates between "Contentful component" and others. The error boundary of parent nodes will pass it on if it was already processed.

Imagine the following tree:
-> Section [SDK]
  ->> Custom Container with slots [Customer code]
    ->>> Button [SDK]

As we add the error boundary on every level, we can now catch any error directly after it was thrown and correctly determine its source. In my tests, errors in the package `visual-editor` or the package `components` were successfully forwarded to Sentry while any error in the customers code is labeled correctly and suppressed.

### Test 1: Throwing an error in "Nested Slots" (customer code):
https://github.com/user-attachments/assets/898ee622-4e38-4087-9aa0-56352329bb5b

### Test 2: Throwing an error in "Button" (SDK code):
https://github.com/user-attachments/assets/8149c38f-e035-4862-b1d5-6baefb7b7540
Notice at the end the iframe message being sent to the web app.


