### PR TITLE
feat: enable text colors for rich text component [ALT-1216]

### DIFF
--- a/packages/components/src/components/RichText/index.ts
+++ b/packages/components/src/components/RichText/index.ts
@@ -20,6 +20,7 @@ export const RichTextComponentDefinition: ComponentDefinition = {
     'cfBackgroundColor',
     'cfBorder',
     'cfBorderRadius',
+    'cfTextColor',
   ],
   tooltip: {
     description: 'Drop onto the canvas to add text with Rich text formatting options.',


### PR DESCRIPTION
## Purpose

Enable the `cfTextColor` built in style option for the Rich Text built-in component

![Screenshot 2024-09-09 at 1 46 56 PM](https://github.com/user-attachments/assets/1e9fd3bd-8540-47c6-a524-0b9946e597dc)
