### PR TITLE
fix: allow design value to be falsy for certain breakpoint [SPA-2391]

### DIFF
--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -107,6 +107,7 @@ export const ASSEMBLY_BLOCK_NODE_TYPE = 'assemblyBlock';
 export const ASSEMBLY_NODE_TYPES = [ASSEMBLY_NODE_TYPE, ASSEMBLY_BLOCK_NODE_TYPE];
 export const LATEST_SCHEMA_VERSION = '2023-09-28';
 export const CF_STYLE_ATTRIBUTES = [
+  'cfVisibility',
   'cfHorizontalAlignment',
   'cfVerticalAlignment',
   'cfMargin',

--- a/packages/core/src/utils/breakpoints.ts
+++ b/packages/core/src/utils/breakpoints.ts
@@ -91,6 +91,10 @@ const builtInStylesWithDesignTokens = [
   'cfMaxWidth',
 ];
 
+const isValidBreakpointValue = (value: PrimitiveValue) => {
+  return value !== undefined && value !== null && value !== '';
+};
+
 export const getValueForBreakpoint = (
   valuesByBreakpoint: ValuesByBreakpoint,
   breakpoints: Breakpoint[],
@@ -110,7 +114,7 @@ export const getValueForBreakpoint = (
     // Assume that the values are sorted by media query to apply the cascading CSS logic
     for (let index = activeBreakpointIndex; index >= 0; index--) {
       const breakpointId = breakpoints[index]?.id;
-      if (valuesByBreakpoint[breakpointId]) {
+      if (isValidBreakpointValue(valuesByBreakpoint[breakpointId])) {
         // If the value is defined, we use it and stop the breakpoints cascade
         return eventuallyResolveDesignTokens(valuesByBreakpoint[breakpointId]);
       }
@@ -118,11 +122,12 @@ export const getValueForBreakpoint = (
     // If no breakpoint matched, we search and apply the fallback breakpoint
     const fallbackBreakpointIndex = getFallbackBreakpointIndex(breakpoints);
     const fallbackBreakpointId = breakpoints[fallbackBreakpointIndex]?.id;
-    if (valuesByBreakpoint[fallbackBreakpointId]) {
+    if (isValidBreakpointValue(valuesByBreakpoint[fallbackBreakpointId])) {
       return eventuallyResolveDesignTokens(valuesByBreakpoint[fallbackBreakpointId]);
     }
   } else {
     // Old design properties did not support breakpoints, keep for backward compatibility
     return valuesByBreakpoint;
   }
+  return undefined;
 };

--- a/packages/core/src/utils/styleUtils/ssrStyles.ts
+++ b/packages/core/src/utils/styleUtils/ssrStyles.ts
@@ -448,7 +448,7 @@ export const resolveBackgroundImageBinding = ({
     const variableDefinitionKey = variableData.key;
     const variableDefinition = componentSettings.variableDefinitions[variableDefinitionKey];
 
-    // @ts-expect-error TODO: fix the types as it thinks taht `defaultValue` is of type string
+    // @ts-expect-error TODO: Types coming from validations erroneously assume that `defaultValue` can be a primitive value (e.g. string or number)
     const defaultValueKey = variableDefinition.defaultValue?.key;
     const defaultValue = unboundValues[defaultValueKey].value;
 

--- a/packages/core/src/utils/styleUtils/styleTransformers.ts
+++ b/packages/core/src/utils/styleUtils/styleTransformers.ts
@@ -6,6 +6,16 @@ import {
   BackgroundImageAlignmentOption,
 } from '@/types';
 
+export const transformVisibility = (value?: boolean): CSSProperties => {
+  if (value === false) {
+    return {
+      display: 'none',
+    };
+  }
+  // Don't explicitly set anything when visible to not overwrite values like `grid` or `flex`.
+  return {};
+};
+
 // Keep this for backwards compatilibity - deleting this would be a breaking change
 // because existing components on a users experience will have the width value as fill
 // rather than 100%

--- a/packages/core/src/utils/styleUtils/styleTransformers.ts
+++ b/packages/core/src/utils/styleUtils/styleTransformers.ts
@@ -16,7 +16,7 @@ export const transformVisibility = (value?: boolean): CSSProperties => {
   return {};
 };
 
-// Keep this for backwards compatilibity - deleting this would be a breaking change
+// Keep this for backwards compatibility - deleting this would be a breaking change
 // because existing components on a users experience will have the width value as fill
 // rather than 100%
 export const transformFill = (value?: string) => (value === 'fill' ? '100%' : value);

--- a/packages/core/src/utils/styleUtils/stylesUtils.ts
+++ b/packages/core/src/utils/styleUtils/stylesUtils.ts
@@ -5,6 +5,7 @@ import {
   transformBorderStyle,
   transformFill,
   transformGridColumn,
+  transformVisibility,
 } from './styleTransformers';
 import { isContentfulStructureComponent } from '../components';
 import { EMPTY_CONTAINER_HEIGHT } from '../../constants';
@@ -64,8 +65,10 @@ export const buildCfStyles = ({
   cfTextItalic,
   cfTextUnderline,
   cfColumnSpan,
+  cfVisibility,
 }: Partial<StyleProps>): CSSProperties => {
   return {
+    ...transformVisibility(cfVisibility),
     margin: cfMargin,
     padding: cfPadding,
     backgroundColor: cfBackgroundColor,

--- a/packages/visual-editor/src/hooks/useComponentProps.ts
+++ b/packages/visual-editor/src/hooks/useComponentProps.ts
@@ -216,7 +216,7 @@ export const useComponentProps = ({
     renderDropzone,
   ]);
 
-  const cfStyles = buildCfStyles(props as StyleProps);
+  const cfStyles = useMemo(() => buildCfStyles(props as StyleProps), [props]);
 
   const sizeStyles: CSSProperties = {
     width: cfStyles.width,


### PR DESCRIPTION
## Purpose

Setting a design value like `cfTextItalic` to `false` for a certain breakpoint doesn't work as the conditional logic in the SDK would fall back to the next truthy value in the set of breakpoint values.

## Approach

Only cascade through the breakpoint values if the value at hand is `undefined | null | ''`