### PR TITLE
fix: assemblies incorrectly rendered on initial drop [ALT-1220]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2684,6 +2684,7 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -561,7 +561,7 @@ export type ComponentDraggingChangedPayload = {
 };
 
 export type IncomingComponentDragCanceledPayload = undefined;
-export type ComponentDragStartedPayload = { id: string };
+export type ComponentDragStartedPayload = { id: string; isAssembly: boolean };
 export type ComponentDragEndedPayload = undefined;
 export type IncomingComponentMoveEndedPayload = {
   mouseX: number;

--- a/packages/visual-editor/src/hooks/useCanvasInteractions.ts
+++ b/packages/visual-editor/src/hooks/useCanvasInteractions.ts
@@ -20,6 +20,10 @@ export default function useCanvasInteractions() {
       return;
     }
 
+    /**
+     * We only have the draggableId as information about the new component being dropped.
+     * So we need to split it to get the blockId and the isAssembly flag.
+     */
     const [blockId, isAssembly] = draggableId.split(':');
 
     const { nodeId: parentId, slotId } = parseZoneId(destination.droppableId);
@@ -43,6 +47,10 @@ export default function useCanvasInteractions() {
       node.children = [childNode];
     }
 
+    /**
+     * isAssembly comes from a string ID so we need to check if it's 'true' or 'false'
+     * in string format.
+     */
     if (isAssembly === 'false') {
       addChild(destination.index, parentId, node);
     }

--- a/packages/visual-editor/src/hooks/useCanvasInteractions.ts
+++ b/packages/visual-editor/src/hooks/useCanvasInteractions.ts
@@ -20,12 +20,14 @@ export default function useCanvasInteractions() {
       return;
     }
 
+    const [blockId, isAssembly] = draggableId.split(':');
+
     const { nodeId: parentId, slotId } = parseZoneId(destination.droppableId);
 
     const droppingOnRoot = parentId === ROOT_ID;
-    const isValidRootComponent = draggableId === CONTENTFUL_COMPONENTS.container.id;
+    const isValidRootComponent = blockId === CONTENTFUL_COMPONENTS.container.id;
 
-    let node = createTreeNode({ blockId: draggableId, parentId, slotId });
+    let node = createTreeNode({ blockId: blockId, parentId, slotId });
 
     if (droppingOnRoot && !isValidRootComponent) {
       const wrappingContainer = createTreeNode({
@@ -33,7 +35,7 @@ export default function useCanvasInteractions() {
         parentId,
       });
       const childNode = createTreeNode({
-        blockId: draggableId,
+        blockId: blockId,
         parentId: wrappingContainer.data.id,
       });
 
@@ -41,11 +43,13 @@ export default function useCanvasInteractions() {
       node.children = [childNode];
     }
 
-    addChild(destination.index, parentId, node);
+    if (!isAssembly) {
+      addChild(destination.index, parentId, node);
+    }
 
     onDrop({
       data: tree,
-      componentType: draggableId,
+      componentType: blockId,
       destinationIndex: destination.index,
       destinationZoneId: parentId,
       slotId,

--- a/packages/visual-editor/src/hooks/useCanvasInteractions.ts
+++ b/packages/visual-editor/src/hooks/useCanvasInteractions.ts
@@ -43,7 +43,7 @@ export default function useCanvasInteractions() {
       node.children = [childNode];
     }
 
-    if (!isAssembly) {
+    if (isAssembly === 'false') {
       addChild(destination.index, parentId, node);
     }
 

--- a/packages/visual-editor/src/hooks/useEditorSubscriber.ts
+++ b/packages/visual-editor/src/hooks/useEditorSubscriber.ts
@@ -321,9 +321,9 @@ export function useEditorSubscriber() {
           break;
         }
         case INCOMING_EVENTS.ComponentDragStarted: {
-          const { id } = eventData.payload;
+          const { id, isAssembly } = eventData.payload;
           SimulateDnD.setupDrag();
-          setComponentId(id || '');
+          setComponentId(`${id}:${isAssembly}` || '');
           setDraggingOnCanvas(true);
 
           sendMessage(OUTGOING_EVENTS.ComponentSelected, {


### PR DESCRIPTION
## Purpose
Our SDK logic to immediately add a component to the local tree was incorrectly adding an assembly as a regular block on the initial render. This resulted in broken behavior where editor mode props were not passed properly to an assembly and therefore breaking DND.

This fix adds functionality so that we know if we are dragging an assembly type node during a component add action and if we are, we prevent the auto-creation of a block node.

Ticket: https://contentful.atlassian.net/browse/ALT-1220

Related user_interface PR: https://github.com/contentful/user_interface/pull/23249