### PR TITLE
docs: update/fix links to CF dev docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,17 +3,19 @@
 This repository represents a set of packages, related to the [Experiences](https://www.contentful.com/developers/docs/experiences/what-are-experiences/) product.
 
 ## Documentation Links
-- [Home](https://www.contentful.com/developers/docs/experiences/)
 - [What are Experiences?](https://www.contentful.com/developers/docs/experiences/what-are-experiences/)
 - [Set up Experiences SDK](https://www.contentful.com/developers/docs/experiences/set-up-experiences-sdk/)
 - [Register custom components](https://www.contentful.com/developers/docs/experiences/register-custom-components/)
 - [Component definition schema](https://www.contentful.com/developers/docs/experiences/component-definition-schema/)
 - [Built-in styles](https://www.contentful.com/developers/docs/experiences/built-in-styles/)
 - [Design tokens](https://www.contentful.com/developers/docs/experiences/design-tokens/)
+- [Register custom breakpoints](https://www.contentful.com/developers/docs/experiences/register-custom-breakpoints/)
+- [Layout structures](https://www.contentful.com/developers/docs/experiences/layout-structures/)
 - [Data structures](https://www.contentful.com/developers/docs/experiences/data-structures/)
 - [Error handling](https://www.contentful.com/developers/docs/experiences/error-handling/)
 - [Image optimzation](https://www.contentful.com/developers/docs/experiences/image-optimization/)
-- [Experiences with NextJS](https://www.contentful.com/developers/docs/experiences/using-with-nextjs/)
+- [Linking between experiences](https://www.contentful.com/developers/docs/experiences/experience-hyperlinks/)
+- [Using Experiences with NextJS](https://www.contentful.com/developers/docs/experiences/using-with-nextjs/)
 
 ## Links to packages in this repo
 - [Components](https://github.com/contentful/experience-builder/tree/main/packages/components)

--- a/examples/next-app-router/README.md
+++ b/examples/next-app-router/README.md
@@ -1,8 +1,8 @@
 # Studio Experiences with Next.js App Router example
 
-This example demonstrates how to use the Next.js App Router to create a server rendered page with Studio Experiences.
+This example demonstrates how to use the [Next.js App Router](https://nextjs.org/docs/app) to create a server rendered page with Studio Experiences.
 
-For more information, see [Using Experiences with Next.js](http://localhost:8001/developers/docs/experiences/using-with-nextjs/) in the Contentful docs.
+For more information, see [Using Experiences with Next.js](https://www.contentful.com/developers/docs/experiences/using-with-nextjs/) in the Contentful docs.
 
 ## Getting started
 

--- a/examples/next-pages-router/README.md
+++ b/examples/next-pages-router/README.md
@@ -1,8 +1,8 @@
 # Studio Experiences with Next.js Pages Router example
 
-This example demonstrates how to use the Next.js Pages Router to create a server rendered page with Studio Experiences.
+This example demonstrates how to use the [Next.js Pages Router](https://nextjs.org/docs/pages) to create a server rendered page with Studio Experiences.
 
-For more information, see [Using Experiences with Next.js](http://localhost:8001/developers/docs/experiences/using-with-nextjs/) in the Contentful docs.
+For more information, see [Using Experiences with Next.js](https://www.contentful.com/developers/docs/experiences/using-with-nextjs/) in the Contentful docs.
 
 ## Getting started
 


### PR DESCRIPTION
1. Adds new relevant links to contentful.com developer docs. Removes the "Home" link as it's just a redundant collection of links (also included on every individual doc's navigation sidebar)
2. Fix links to point to `contentful.com` instead of `localhost`. Also link to NextJS doc for app/pages routers.