### PR TITLE
fix(core): resolving design values [ALT-1222]

### DIFF
--- a/packages/core/src/__fixtures__/designTokens.ts
+++ b/packages/core/src/__fixtures__/designTokens.ts
@@ -6,7 +6,7 @@ export const designTokensFixture: DesignTokensDefinition = {
     font: 'black',
     danger: 'red',
     warning: 'orange',
-    succcess: 'green',
+    success: 'green',
   },
   spacing: {
     xs: '0.5 rem',

--- a/packages/core/src/__fixtures__/designTokens.ts
+++ b/packages/core/src/__fixtures__/designTokens.ts
@@ -1,0 +1,60 @@
+import { DesignTokensDefinition } from '../types';
+
+export const designTokensFixture: DesignTokensDefinition = {
+  color: {
+    bg: 'white',
+    font: 'black',
+    danger: 'red',
+    warning: 'orange',
+    succcess: 'green',
+  },
+  spacing: {
+    xs: '0.5 rem',
+    s: '1rem',
+    m: '1.5rem',
+    l: '2rem',
+  },
+  sizing: {
+    quarter: '25%',
+    half: '50%',
+    threeQuarters: '75%',
+    full: '100%',
+  },
+  border: {
+    borderless: {
+      width: '0px',
+      style: 'solid',
+      color: 'transparent',
+    },
+    default: {
+      width: '1px',
+      style: 'solid',
+      color: 'black',
+    },
+    bold: {
+      width: '3px',
+      style: 'solid',
+      color: 'black',
+    },
+  },
+  fontSize: {
+    default: '1rem',
+    small: '0.75rem',
+    large: '1.5rem',
+  },
+  lineHeight: {
+    default: '1.5',
+    small: '1.25',
+    large: '2',
+  },
+  letterSpacing: {
+    default: 'normal',
+    tight: '0.5px',
+    wide: '2px',
+  },
+  textColor: {
+    default: 'black',
+    muted: 'gray',
+    accent: 'blue',
+  },
+};

--- a/packages/core/src/utils/breakpoints.spec.ts
+++ b/packages/core/src/utils/breakpoints.spec.ts
@@ -4,7 +4,7 @@ import { getActiveBreakpointIndex, getValueForBreakpoint, mediaQueryMatcher } fr
 import { describe, it, expect } from 'vitest';
 import { defineDesignTokens } from '../registries';
 
-describe('getValueForBreakpoint', () => {
+describe('getValueForBreakpoint for css values', () => {
   const breakpoints = createBreakpoints();
   const variableName = 'cfBackgroundColor';
   const [desktopIndex, tabletIndex, mobileIndex] = [0, 1, 2];
@@ -20,11 +20,6 @@ describe('getValueForBreakpoint', () => {
   };
   const valuesByBreakpointWithoutTabletAndMobile = {
     desktop: desktopValue,
-  };
-  const valuesByBreakpointWithDesignTokens = {
-    desktop: '${sizing.half}',
-    tablet: '${sizing.threeQuarters}',
-    mobile: '${sizing.full}',
   };
 
   describe('when rendering a desktop view', () => {
@@ -101,31 +96,183 @@ describe('getValueForBreakpoint', () => {
       expect(value).toEqual(desktopValue);
     });
   });
+});
 
-  describe('when using design tokens', () => {
-    beforeEach(() => {
-      defineDesignTokens(designTokensFixture);
-    });
+describe('getValueForBreakpoint for design tokens', () => {
+  const breakpoints = createBreakpoints();
+  const variableName = 'cfBackgroundColor';
+  const [desktopIndex, tabletIndex, mobileIndex] = [0, 1, 2];
+  const [desktopTokenValue, tabletTokenValue, mobileTokenValue] = [
+    '${color.danger}',
+    '${color.warning}',
+    '${color.success}',
+  ];
+  const [desktopResolvedValue, tabletResolvedValue, mobileResolvedValue] = [
+    'red',
+    'orange',
+    'green',
+  ];
+  const valuesByBreakpoint = {
+    desktop: desktopTokenValue,
+    tablet: tabletTokenValue,
+    mobile: mobileTokenValue,
+  };
+  const valuesByBreakpointWithoutMobile = {
+    desktop: desktopTokenValue,
+    tablet: tabletTokenValue,
+  };
+  const valuesByBreakpointWithoutTabletAndMobile = {
+    desktop: desktopTokenValue,
+  };
 
-    it('resolves the design token', () => {
+  beforeEach(() => {
+    defineDesignTokens(designTokensFixture);
+  });
+
+  describe('when rendering a desktop view', () => {
+    it('renders desktop with design token resolved', () => {
       const value = getValueForBreakpoint(
-        valuesByBreakpointWithDesignTokens,
+        valuesByBreakpoint,
         breakpoints,
         desktopIndex,
-        'cfWidth',
+        variableName,
       );
-      expect(value).toEqual('50%');
+      expect(value).toEqual(desktopResolvedValue);
     });
-
-    it('can resolve the raw design token value', () => {
+    it('renders desktop with design token in string template format', () => {
       const value = getValueForBreakpoint(
-        valuesByBreakpointWithDesignTokens,
+        valuesByBreakpoint,
         breakpoints,
         desktopIndex,
-        'cfWidth',
-        false, // disable resolving design token
+        variableName,
+        false,
       );
-      expect(value).toEqual('${sizing.half}');
+      expect(value).toEqual(desktopTokenValue);
+    });
+  });
+
+  describe('when rendering a tablet view', () => {
+    it('renders tablet with design token resolved', () => {
+      const value = getValueForBreakpoint(
+        valuesByBreakpoint,
+        breakpoints,
+        tabletIndex,
+        variableName,
+      );
+      expect(value).toEqual(tabletResolvedValue);
+    });
+    it('falls back to the desktop value with design token resolved', () => {
+      const value = getValueForBreakpoint(
+        valuesByBreakpointWithoutTabletAndMobile,
+        breakpoints,
+        tabletIndex,
+        variableName,
+      );
+      expect(value).toEqual(desktopResolvedValue);
+    });
+
+    it('renders tablet with design token in string template format', () => {
+      const value = getValueForBreakpoint(
+        valuesByBreakpoint,
+        breakpoints,
+        tabletIndex,
+        variableName,
+        false,
+      );
+      expect(value).toEqual(tabletTokenValue);
+    });
+    it('falls back to the desktop value with design token in string template format', () => {
+      const value = getValueForBreakpoint(
+        valuesByBreakpointWithoutTabletAndMobile,
+        breakpoints,
+        tabletIndex,
+        variableName,
+        false,
+      );
+      expect(value).toEqual(desktopTokenValue);
+    });
+  });
+
+  describe('when rendering a mobile view', () => {
+    it('renders the mobile value with design token resolved', () => {
+      const value = getValueForBreakpoint(
+        valuesByBreakpoint,
+        breakpoints,
+        mobileIndex,
+        variableName,
+      );
+      expect(value).toEqual(mobileResolvedValue);
+    });
+    it('falls back to the tablet value with design token resolved', () => {
+      const value = getValueForBreakpoint(
+        valuesByBreakpointWithoutMobile,
+        breakpoints,
+        mobileIndex,
+        variableName,
+      );
+      expect(value).toEqual(tabletResolvedValue);
+    });
+    it('falls back to the desktop value with design token resolved', () => {
+      const value = getValueForBreakpoint(
+        valuesByBreakpointWithoutTabletAndMobile,
+        breakpoints,
+        mobileIndex,
+        variableName,
+      );
+      expect(value).toEqual(desktopResolvedValue);
+    });
+
+    it('renders the mobile value with design token in string template format', () => {
+      const value = getValueForBreakpoint(
+        valuesByBreakpoint,
+        breakpoints,
+        mobileIndex,
+        variableName,
+        false,
+      );
+      expect(value).toEqual(mobileTokenValue);
+    });
+    it('falls back to the tablet value with design token in string template format', () => {
+      const value = getValueForBreakpoint(
+        valuesByBreakpointWithoutMobile,
+        breakpoints,
+        mobileIndex,
+        variableName,
+        false,
+      );
+      expect(value).toEqual(tabletTokenValue);
+    });
+    it('falls back to the desktop value with design token in string template format', () => {
+      const value = getValueForBreakpoint(
+        valuesByBreakpointWithoutTabletAndMobile,
+        breakpoints,
+        mobileIndex,
+        variableName,
+        false,
+      );
+      expect(value).toEqual(desktopTokenValue);
+    });
+  });
+
+  describe('when rendering a view without a matching breakpoint', () => {
+    it('falls back to the desktop value with design token resolved', () => {
+      const value = getValueForBreakpoint(
+        valuesByBreakpointWithoutTabletAndMobile,
+        breakpoints,
+        3,
+        variableName,
+      );
+      expect(value).toEqual(desktopResolvedValue);
+    });
+    it('falls back to the desktop value with design token in string template format', () => {
+      const value = getValueForBreakpoint(
+        valuesByBreakpointWithoutTabletAndMobile,
+        breakpoints,
+        3,
+        variableName,
+        false,
+      );
+      expect(value).toEqual(desktopTokenValue);
     });
   });
 });

--- a/packages/core/src/utils/breakpoints.spec.ts
+++ b/packages/core/src/utils/breakpoints.spec.ts
@@ -108,9 +108,9 @@ describe('getValueForBreakpoint for design tokens', () => {
     '${color.success}',
   ];
   const [desktopResolvedValue, tabletResolvedValue, mobileResolvedValue] = [
-    'red',
-    'orange',
-    'green',
+    designTokensFixture.color!.danger,
+    designTokensFixture.color!.warning,
+    designTokensFixture.color!.success,
   ];
   const valuesByBreakpoint = {
     desktop: desktopTokenValue,

--- a/packages/core/src/utils/breakpoints.spec.ts
+++ b/packages/core/src/utils/breakpoints.spec.ts
@@ -1,6 +1,8 @@
 import { createBreakpoints } from '@/__fixtures__/breakpoints';
+import { designTokensFixture } from '@/__fixtures__/designTokens';
 import { getActiveBreakpointIndex, getValueForBreakpoint, mediaQueryMatcher } from './breakpoints';
 import { describe, it, expect } from 'vitest';
+import { defineDesignTokens } from '../registries';
 
 describe('getValueForBreakpoint', () => {
   const breakpoints = createBreakpoints();
@@ -18,6 +20,11 @@ describe('getValueForBreakpoint', () => {
   };
   const valuesByBreakpointWithoutTabletAndMobile = {
     desktop: desktopValue,
+  };
+  const valuesByBreakpointWithDesignTokens = {
+    desktop: '${sizing.half}',
+    tablet: '${sizing.threeQuarters}',
+    mobile: '${sizing.full}',
   };
 
   describe('when rendering a desktop view', () => {
@@ -92,6 +99,33 @@ describe('getValueForBreakpoint', () => {
         variableName,
       );
       expect(value).toEqual(desktopValue);
+    });
+  });
+
+  describe('when using design tokens', () => {
+    beforeEach(() => {
+      defineDesignTokens(designTokensFixture);
+    });
+
+    it('resolves the design token', () => {
+      const value = getValueForBreakpoint(
+        valuesByBreakpointWithDesignTokens,
+        breakpoints,
+        desktopIndex,
+        'cfWidth',
+      );
+      expect(value).toEqual('50%');
+    });
+
+    it('can resolve the raw design token value', () => {
+      const value = getValueForBreakpoint(
+        valuesByBreakpointWithDesignTokens,
+        breakpoints,
+        desktopIndex,
+        'cfWidth',
+        false, // disable resolving design token
+      );
+      expect(value).toEqual('${sizing.half}');
     });
   });
 });

--- a/packages/core/src/utils/breakpoints.ts
+++ b/packages/core/src/utils/breakpoints.ts
@@ -100,6 +100,7 @@ export const getValueForBreakpoint = (
   breakpoints: Breakpoint[],
   activeBreakpointIndex: number,
   variableName: string,
+  resolveDesignTokens = true,
 ) => {
   const eventuallyResolveDesignTokens = (value: PrimitiveValue) => {
     // For some built-in design propertier, we support design tokens
@@ -116,14 +117,20 @@ export const getValueForBreakpoint = (
       const breakpointId = breakpoints[index]?.id;
       if (isValidBreakpointValue(valuesByBreakpoint[breakpointId])) {
         // If the value is defined, we use it and stop the breakpoints cascade
-        return eventuallyResolveDesignTokens(valuesByBreakpoint[breakpointId]);
+        if (resolveDesignTokens) {
+          return eventuallyResolveDesignTokens(valuesByBreakpoint[breakpointId]);
+        }
+        return valuesByBreakpoint[breakpointId];
       }
     }
     // If no breakpoint matched, we search and apply the fallback breakpoint
     const fallbackBreakpointIndex = getFallbackBreakpointIndex(breakpoints);
     const fallbackBreakpointId = breakpoints[fallbackBreakpointIndex]?.id;
     if (isValidBreakpointValue(valuesByBreakpoint[fallbackBreakpointId])) {
-      return eventuallyResolveDesignTokens(valuesByBreakpoint[fallbackBreakpointId]);
+      if (resolveDesignTokens) {
+        return eventuallyResolveDesignTokens(valuesByBreakpoint[fallbackBreakpointId]);
+      }
+      return valuesByBreakpoint[fallbackBreakpointId];
     }
   } else {
     // Old design properties did not support breakpoints, keep for backward compatibility

--- a/packages/core/src/utils/breakpoints.ts
+++ b/packages/core/src/utils/breakpoints.ts
@@ -103,7 +103,7 @@ export const getValueForBreakpoint = (
   resolveDesignTokens = true,
 ) => {
   const eventuallyResolveDesignTokens = (value: PrimitiveValue) => {
-    // For some built-in design propertier, we support design tokens
+    // For some built-in design properties, we support design tokens
     if (builtInStylesWithDesignTokens.includes(variableName)) {
       return getDesignTokenRegistration(value as string, variableName);
     }

--- a/packages/core/src/utils/styleUtils/ssrStyles.spec.ts
+++ b/packages/core/src/utils/styleUtils/ssrStyles.spec.ts
@@ -859,7 +859,7 @@ describe('flattenDesignTokenRegistry', () => {
         font: 'black',
         danger: 'red',
         warning: 'orange',
-        succcess: 'green',
+        success: 'green',
       },
       spacing: {
         xs: '0.5 rem',
@@ -913,7 +913,7 @@ describe('flattenDesignTokenRegistry', () => {
       'color.font': 'black',
       'color.danger': 'red',
       'color.warning': 'orange',
-      'color.succcess': 'green',
+      'color.success': 'green',
       'spacing.xs': '0.5 rem',
       'spacing.s': '1rem',
       'spacing.m': '1.5rem',

--- a/packages/core/src/utils/styleUtils/ssrStylesDesignTokenResolution.spec.tsx
+++ b/packages/core/src/utils/styleUtils/ssrStylesDesignTokenResolution.spec.tsx
@@ -176,7 +176,7 @@ describe('custom component with builtInStyles which are supporting design tokens
       (customComponent.variables.cfSsrClassName as DesignValue).valuesByBreakpoint
         .desktop as string,
     ).toEqual(
-      'cf-c9e1b7c280ecf05fda4ab04e16644807 cf-2c4e00b479e8209382b0814b0ba1f706 cf-bd9d9646c4500dc3f4a3a7d9974d0e40',
+      'cf-c9e1b7c280ecf05fda4ab04e16644807 cf-511d6b2de57fd63af53a455b9a3c6c20 cf-bd9d9646c4500dc3f4a3a7d9974d0e40',
     );
     expect(
       (customComponent.variables.cfSsrClassName as DesignValue).valuesByBreakpoint.tablet,
@@ -186,7 +186,7 @@ describe('custom component with builtInStyles which are supporting design tokens
     ).not.toBeDefined();
 
     expect(styles).toBe(
-      '.cf-c9e1b7c280ecf05fda4ab04e16644807{margin:2rem;padding:2rem;background-color:white;width:50%;height:25%;border:1px solid black;gap:2rem 2rem;font-size:1rem;font-style:normal;color:black;text-decoration:none;box-sizing:border-box;}@media(max-width:992px){.cf-2c4e00b479e8209382b0814b0ba1f706{margin:1.5rem;padding:1.5rem;background-color:black;width:75%;height:50%;border:3px solid black;gap:1.5rem 1.5rem;font-size:0.75rem;font-style:normal;color:rgba(0, 0, 0, 1);text-decoration:none;box-sizing:border-box;}}@media(max-width:576px){.cf-bd9d9646c4500dc3f4a3a7d9974d0e40{margin:1rem;padding:1rem;background-color:red;width:100%;height:100%;border:0px solid transparent;gap:1rem 1rem;font-size:1.5rem;font-style:normal;color:orange;text-decoration:none;box-sizing:border-box;}}',
+      '.cf-c9e1b7c280ecf05fda4ab04e16644807{margin:2rem;padding:2rem;background-color:white;width:50%;height:25%;border:1px solid black;gap:2rem 2rem;font-size:1rem;font-style:normal;color:black;text-decoration:none;box-sizing:border-box;}@media(max-width:992px){.cf-511d6b2de57fd63af53a455b9a3c6c20{margin:1.5rem;padding:1.5rem;background-color:black;width:75%;height:50%;border:3px solid black;gap:1.5rem 1.5rem;font-size:0.75rem;font-style:normal;color:green;text-decoration:none;box-sizing:border-box;}}@media(max-width:576px){.cf-bd9d9646c4500dc3f4a3a7d9974d0e40{margin:1rem;padding:1rem;background-color:red;width:100%;height:100%;border:0px solid transparent;gap:1rem 1rem;font-size:1.5rem;font-style:normal;color:orange;text-decoration:none;box-sizing:border-box;}}',
     );
   });
 });

--- a/packages/core/src/utils/styleUtils/ssrStylesDesignTokenResolution.spec.tsx
+++ b/packages/core/src/utils/styleUtils/ssrStylesDesignTokenResolution.spec.tsx
@@ -1,65 +1,7 @@
+import { designTokensFixture } from '../../__fixtures__/designTokens';
 import { createExperience, defineDesignTokens, detachExperienceStyles } from '../../index';
-import { DesignTokensDefinition, DesignValue, ExperienceEntry } from '../../types';
+import { DesignValue, ExperienceEntry } from '../../types';
 import { Entry } from 'contentful';
-
-const designTokenRegistry: DesignTokensDefinition = {
-  color: {
-    bg: 'white',
-    font: 'black',
-    danger: 'red',
-    warning: 'orange',
-    succcess: 'green',
-  },
-  spacing: {
-    xs: '0.5 rem',
-    s: '1rem',
-    m: '1.5rem',
-    l: '2rem',
-  },
-  sizing: {
-    quarter: '25%',
-    half: '50%',
-    threeQuarters: '75%',
-    full: '100%',
-  },
-  border: {
-    borderless: {
-      width: '0px',
-      style: 'solid',
-      color: 'transparent',
-    },
-    default: {
-      width: '1px',
-      style: 'solid',
-      color: 'black',
-    },
-    bold: {
-      width: '3px',
-      style: 'solid',
-      color: 'black',
-    },
-  },
-  fontSize: {
-    default: '1rem',
-    small: '0.75rem',
-    large: '1.5rem',
-  },
-  lineHeight: {
-    default: '1.5',
-    small: '1.25',
-    large: '2',
-  },
-  letterSpacing: {
-    default: 'normal',
-    tight: '0.5px',
-    wide: '2px',
-  },
-  textColor: {
-    default: 'black',
-    muted: 'gray',
-    accent: 'blue',
-  },
-};
 
 const experienceEntry: ExperienceEntry = {
   sys: {
@@ -211,7 +153,7 @@ const experienceEntry: ExperienceEntry = {
 
 describe('custom component with builtInStyles which are supporting design tokens', () => {
   beforeEach(() => {
-    defineDesignTokens(designTokenRegistry);
+    defineDesignTokens(designTokensFixture);
   });
 
   it('should populate values with design tokens and extract the css', () => {


### PR DESCRIPTION
Allow `getBreakpointByValue` to return raw design values without resolving design tokens
- When calling this method from the UI, we don't want design tokens to be resolved into values, because we want to design sidebar input to use the string template design token value in order to show the design token badge element.
- When this method is called from the SDK side, we do want any design token values to be resolved into css values
