### PR TITLE
chore: update PR template to include reminder when merging []

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,10 +3,14 @@
 ## Approach
 
 <!--
+Remember when merging:
+- Use "Squash and merge" when merging changes into development.
+- Use "Create a merge commit" when releasing changes into next and main.
 
-Three important notes on Pull Requests:
+Three important notes on pull requests:
 - In general, you should ask yourself whether this code change will improve or worsen the overall code quality. Any new tech debt will probably never be cleaned up.
 - Please remember that newly introduced logic should be validated and protected through testing.
-- Take a look at PR guides such as Google's [Google’s Code Review Guidelines](https://google.github.io/eng-practices/) and [Blockly - Writing a Good Pull Request](https://developers.google.com/blockly/guides/contribute/get-started/write_a_good_pr)
-
+- Take a look at PR guides:
+  Google's Code Review Guidelines: https://google.github.io/eng-practices/
+  Blockly - Writing a Good Pull Request: https://developers.google.com/blockly/guides/contribute/get-started/write_a_good_pr
 -->


### PR DESCRIPTION
> [!TIP]
> 1. Use "Squash and merge" when merging changes into `development`.
> 2. Use "Create a merge commit" when releasing changes into `next` and `main`.

**Squash and Merge**: When merging feature branches into the `development` branch, prefer to use this merge setting to keep the history clean and focused. When a PR contains multiple commits, this setting will squash all commits into a single commit which provides a cleaner revert potential and easier git bisecting.

**Merge Commits**: When merging changes into the `next` and `main` branches, always use this merge setting to preserve the full history and context of changes, which is important for the publish workflow to handle versioning and generating change logs.

Github remembers your previous merge setting each time you merge a PR, so please be diligent when choosing how to merge each PR to help keep the history nice and tidy 🙇

