### PR TITLE
fix: allow rendering falsy breakpoint values in SSR [SPA-2375]

### DIFF
--- a/packages/core/src/utils/breakpoints.ts
+++ b/packages/core/src/utils/breakpoints.ts
@@ -91,7 +91,7 @@ const builtInStylesWithDesignTokens = [
   'cfMaxWidth',
 ];
 
-const isValidBreakpointValue = (value: PrimitiveValue) => {
+export const isValidBreakpointValue = (value: PrimitiveValue) => {
   return value !== undefined && value !== null && value !== '';
 };
 

--- a/packages/core/src/utils/styleUtils/ssrStyles.ts
+++ b/packages/core/src/utils/styleUtils/ssrStyles.ts
@@ -7,7 +7,12 @@ import {
   ExperienceDataSource,
   ExperienceUnboundValues,
 } from '@contentful/experiences-validators';
-import { buildCfStyles, checkIsAssemblyNode, toCSSAttribute } from '@/utils';
+import {
+  buildCfStyles,
+  checkIsAssemblyNode,
+  isValidBreakpointValue,
+  toCSSAttribute,
+} from '@/utils';
 import { builtInStyles, optionalBuiltInStyles } from '@/definitions';
 import { designTokensRegistry } from '@/registries';
 import {
@@ -590,7 +595,7 @@ export const indexByBreakpoint = ({
     for (const [breakpointId, variableValue] of Object.entries(
       resolvedVariableData.valuesByBreakpoint,
     )) {
-      if (typeof variableValue !== 'boolean' && !variableValue) {
+      if (!isValidBreakpointValue(variableValue)) {
         continue;
       }
 


### PR DESCRIPTION
## Purpose

Falsy breakpoint values like `false` or `0` would be currently not be rendered by our SSR logic.

## Approach

We now check explicitly for values that are not supported/ empty. So far these are `null`, `undefined`, and empty strings.

Update:
I just found out that this was fixed [yesterday](https://github.com/contentful/experience-builder/pull/748) as well by @ChidinmaOrajiaku. If you agree, I will still add this change to allow `0` as well and explicitly rule out "empty values".