### PR TITLE
fix: resolve fetched entities for experiences [ALT-1146]

### DIFF
--- a/packages/core/src/fetchers/fetchAllEntities.spec.ts
+++ b/packages/core/src/fetchers/fetchAllEntities.spec.ts
@@ -60,7 +60,7 @@ describe('fetchAllEntries', () => {
     expect(result.items).toHaveLength(100);
   });
 
-  it.only('should resolve entries that are embedded into rich text fields', async () => {
+  it('should resolve entries that are embedded into rich text fields', async () => {
     const entryThatsEmbeddedIntoRichText = createEntry('entry-with-embedded-entry', {
       sys: {
         id: 'abc123',

--- a/packages/core/src/fetchers/fetchAllEntities.spec.ts
+++ b/packages/core/src/fetchers/fetchAllEntities.spec.ts
@@ -168,7 +168,7 @@ describe('fetchAllEntries', () => {
       locale: 'en-US',
       skip: 90,
       limit: 10,
-      include: 10,
+      include: 2,
     });
     expect(result.items).toHaveLength(100);
   });
@@ -194,7 +194,7 @@ describe('fetchAllEntries', () => {
       locale: 'en-US',
       skip: 0,
       limit: 1,
-      include: 10,
+      include: 2,
     });
   });
 });
@@ -250,7 +250,7 @@ describe('fetchAllAssets', () => {
       client: mockClient,
       locale: 'en-US',
       limit: 20,
-      include: 10,
+      include: 2,
     };
 
     const result = await fetchAllAssets(params);

--- a/packages/core/src/fetchers/fetchAllEntities.ts
+++ b/packages/core/src/fetchers/fetchAllEntities.ts
@@ -47,7 +47,7 @@ export const fetchAllEntries = async ({
       items,
       includes,
       total: responseTotal,
-    } = await client.getEntries({ 'sys.id[in]': ids, locale, limit, skip, include: 10 });
+    } = await client.getEntries({ 'sys.id[in]': ids, locale, limit, skip, include: 2 });
 
     responseItems.push(...(items as Entry[]));
     responseIncludes?.Entry?.push(...(includes?.Entry || []));

--- a/packages/core/src/fetchers/fetchAllEntities.ts
+++ b/packages/core/src/fetchers/fetchAllEntities.ts
@@ -43,13 +43,11 @@ export const fetchAllEntries = async ({
       };
     }
 
-    const query = { 'sys.id[in]': ids, locale, limit, skip };
-
     const {
       items,
       includes,
       total: responseTotal,
-    } = await client.withoutLinkResolution.getEntries({ ...query });
+    } = await client.getEntries({ 'sys.id[in]': ids, locale, limit, skip, include: 10 });
 
     responseItems.push(...(items as Entry[]));
     responseIncludes?.Entry?.push(...(includes?.Entry || []));

--- a/packages/core/src/fetchers/fetchReferencedEntities.spec.ts
+++ b/packages/core/src/fetchers/fetchReferencedEntities.spec.ts
@@ -96,7 +96,7 @@ describe('fetchReferencedEntities', () => {
       'sys.id[in]': entries.map((entry) => entry.sys.id),
       limit: 100,
       skip: 0,
-      include: 10,
+      include: 2,
     });
 
     expect(res).toEqual({

--- a/packages/core/src/fetchers/fetchReferencedEntities.spec.ts
+++ b/packages/core/src/fetchers/fetchReferencedEntities.spec.ts
@@ -7,9 +7,7 @@ import { fetchReferencedEntities } from './fetchReferencedEntities';
 
 const mockClient = {
   getAssets: vi.fn(),
-  withoutLinkResolution: {
-    getEntries: vi.fn(),
-  },
+  getEntries: vi.fn(),
 } as unknown as ContentfulClientApi<undefined>;
 
 vi.mock('@/deep-binding/DeepReference', async (importOriginal) => {
@@ -76,7 +74,7 @@ describe('fetchReferencedEntities', () => {
   it('should fetch referenced entities', async () => {
     (mockClient.getAssets as Mock).mockResolvedValue({ items: assets });
 
-    (mockClient.withoutLinkResolution.getEntries as Mock).mockResolvedValue({ items: entries });
+    (mockClient.getEntries as Mock).mockResolvedValue({ items: entries });
 
     (gatherDeepReferencesFromExperienceEntry as Mock).mockReturnValue([]);
 
@@ -93,11 +91,12 @@ describe('fetchReferencedEntities', () => {
       'sys.id[in]': assets.map((asset) => asset.sys.id),
     });
 
-    expect(mockClient.withoutLinkResolution.getEntries).toHaveBeenCalledWith({
+    expect(mockClient.getEntries).toHaveBeenCalledWith({
       locale: 'en-US',
       'sys.id[in]': entries.map((entry) => entry.sys.id),
       limit: 100,
       skip: 0,
+      include: 10,
     });
 
     expect(res).toEqual({
@@ -111,7 +110,7 @@ describe('fetchReferencedEntities handling deep-references', () => {
   it('should call gatherDeepReferencesFromExperienceEntry()', async () => {
     (mockClient.getAssets as Mock).mockResolvedValue({ items: assets });
 
-    (mockClient.withoutLinkResolution.getEntries as Mock).mockResolvedValue({ items: entries });
+    (mockClient.getEntries as Mock).mockResolvedValue({ items: entries });
 
     (gatherDeepReferencesFromExperienceEntry as Mock).mockReturnValue([]);
     fetchReferencedEntities({

--- a/packages/core/src/fetchers/fetchers.spec.ts
+++ b/packages/core/src/fetchers/fetchers.spec.ts
@@ -9,9 +9,6 @@ import { describe, beforeEach, it, expect, vi, Mock } from 'vitest';
 const mockClient = {
   getAssets: vi.fn(),
   getEntries: vi.fn(),
-  withoutLinkResolution: {
-    getEntries: vi.fn(),
-  },
 } as unknown as ContentfulClientApi<undefined>;
 
 describe('fetchExperience', () => {
@@ -23,7 +20,7 @@ describe('fetchExperience', () => {
 
     // used by fetchExperience()->fetchReferencedEntities()
     (mockClient.getAssets as Mock).mockResolvedValue({ items: assets });
-    (mockClient.withoutLinkResolution.getEntries as Mock).mockResolvedValue({
+    (mockClient.getEntries as Mock).mockResolvedValueOnce({
       items: entries,
       includes: { Asset: assets },
     });

--- a/packages/experience-builder-sdk/src/hooks/useFetchById.spec.ts
+++ b/packages/experience-builder-sdk/src/hooks/useFetchById.spec.ts
@@ -15,8 +15,13 @@ let clientMock: ContentfulClientApi<undefined>;
 describe('useFetchById', () => {
   beforeEach(() => {
     clientMock = {
-      getEntries: jest.fn().mockImplementation(() => {
-        return Promise.resolve({ items: [experienceEntry] });
+      getEntries: jest.fn().mockImplementation((query: any) => {
+        if (query['sys.id'] === 'composition-id') {
+          //fetching the experience entry
+          return Promise.resolve({ items: [experienceEntry] });
+        }
+        //fetching the bound entities
+        return Promise.resolve({ items: entries });
       }),
       getAssets: jest.fn().mockResolvedValue({ items: assets }),
     } as unknown as ContentfulClientApi<undefined>;
@@ -64,11 +69,12 @@ describe('useFetchById', () => {
         locale: localeCode,
       });
 
-      expect(clientMock.getEntries).toHaveBeenNthCalledWith(1, {
+      expect(clientMock.getEntries).toHaveBeenNthCalledWith(2, {
         limit: 100,
         skip: 0,
         'sys.id[in]': entries.map((entry) => entry.sys.id),
         locale: localeCode,
+        include: 10,
       });
 
       expect(clientMock.getAssets).toHaveBeenCalledWith({

--- a/packages/experience-builder-sdk/src/hooks/useFetchById.spec.ts
+++ b/packages/experience-builder-sdk/src/hooks/useFetchById.spec.ts
@@ -74,7 +74,7 @@ describe('useFetchById', () => {
         skip: 0,
         'sys.id[in]': entries.map((entry) => entry.sys.id),
         locale: localeCode,
-        include: 10,
+        include: 2,
       });
 
       expect(clientMock.getAssets).toHaveBeenCalledWith({

--- a/packages/experience-builder-sdk/src/hooks/useFetchById.spec.ts
+++ b/packages/experience-builder-sdk/src/hooks/useFetchById.spec.ts
@@ -19,11 +19,6 @@ describe('useFetchById', () => {
         return Promise.resolve({ items: [experienceEntry] });
       }),
       getAssets: jest.fn().mockResolvedValue({ items: assets }),
-      withoutLinkResolution: {
-        getEntries: jest.fn().mockImplementation(() => {
-          return Promise.resolve({ items: entries });
-        }),
-      },
     } as unknown as ContentfulClientApi<undefined>;
   });
 
@@ -69,7 +64,7 @@ describe('useFetchById', () => {
         locale: localeCode,
       });
 
-      expect(clientMock.withoutLinkResolution.getEntries).toHaveBeenNthCalledWith(1, {
+      expect(clientMock.getEntries).toHaveBeenNthCalledWith(1, {
         limit: 100,
         skip: 0,
         'sys.id[in]': entries.map((entry) => entry.sys.id),

--- a/packages/experience-builder-sdk/src/hooks/useFetchBySlug.spec.ts
+++ b/packages/experience-builder-sdk/src/hooks/useFetchBySlug.spec.ts
@@ -158,7 +158,6 @@ describe('useFetchBySlug', () => {
     await waitFor(() => {
       expect(result.current.error).toBeUndefined();
       expect(clientMock.getEntries).toHaveBeenCalledTimes(1);
-      expect(clientMock.getEntries).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/packages/experience-builder-sdk/src/hooks/useFetchBySlug.spec.ts
+++ b/packages/experience-builder-sdk/src/hooks/useFetchBySlug.spec.ts
@@ -20,12 +20,6 @@ describe('useFetchBySlug', () => {
         return Promise.resolve({ items: [experienceEntry] });
       }),
       getAssets: jest.fn().mockResolvedValue({ items: assets }),
-      withoutLinkResolution: {
-        getEntries: jest.fn().mockImplementation((_query) => {
-          // { 'sys.id[in]': [ 'entry1', 'entry2' ], locale: 'en-US' }
-          return Promise.resolve({ items: entries });
-        }),
-      },
     } as unknown as ContentfulClientApi<undefined>;
   });
 
@@ -77,7 +71,7 @@ describe('useFetchBySlug', () => {
         locale: localeCode,
       });
 
-      expect(clientMock.withoutLinkResolution.getEntries).toHaveBeenNthCalledWith(1, {
+      expect(clientMock.getEntries).toHaveBeenNthCalledWith(1, {
         limit: 100,
         skip: 0,
         'sys.id[in]': entries.map((entry) => entry.sys.id),
@@ -159,7 +153,7 @@ describe('useFetchBySlug', () => {
     await waitFor(() => {
       expect(result.current.error).toBeUndefined();
       expect(clientMock.getEntries).toHaveBeenCalledTimes(1);
-      expect(clientMock.withoutLinkResolution.getEntries).toHaveBeenCalledTimes(1);
+      expect(clientMock.getEntries).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/packages/experience-builder-sdk/src/hooks/useFetchBySlug.spec.ts
+++ b/packages/experience-builder-sdk/src/hooks/useFetchBySlug.spec.ts
@@ -80,7 +80,7 @@ describe('useFetchBySlug', () => {
         skip: 0,
         'sys.id[in]': entries.map((entry) => entry.sys.id),
         locale: localeCode,
-        include: 10,
+        include: 2,
       });
 
       expect(clientMock.getAssets).toHaveBeenCalledWith({

--- a/packages/experience-builder-sdk/src/hooks/useFetchBySlug.spec.ts
+++ b/packages/experience-builder-sdk/src/hooks/useFetchBySlug.spec.ts
@@ -15,9 +15,13 @@ let clientMock: ContentfulClientApi<undefined>;
 describe('useFetchBySlug', () => {
   beforeEach(() => {
     clientMock = {
-      getEntries: jest.fn().mockImplementation((_query) => {
-        // { content_type: 'layout', locale: 'en-US', 'fields.slug': 'hello-world' }
-        return Promise.resolve({ items: [experienceEntry] });
+      getEntries: jest.fn().mockImplementation((query: any) => {
+        if (query['fields.slug'] === 'hello-world') {
+          //fetching the experience entry
+          return Promise.resolve({ items: [experienceEntry] });
+        }
+        //fetching the bound entities
+        return Promise.resolve({ items: entries });
       }),
       getAssets: jest.fn().mockResolvedValue({ items: assets }),
     } as unknown as ContentfulClientApi<undefined>;
@@ -71,11 +75,12 @@ describe('useFetchBySlug', () => {
         locale: localeCode,
       });
 
-      expect(clientMock.getEntries).toHaveBeenNthCalledWith(1, {
+      expect(clientMock.getEntries).toHaveBeenNthCalledWith(2, {
         limit: 100,
         skip: 0,
         'sys.id[in]': entries.map((entry) => entry.sys.id),
         locale: localeCode,
+        include: 10,
       });
 
       expect(clientMock.getAssets).toHaveBeenCalledWith({


### PR DESCRIPTION
## Purpose

Removes the `withoutLinkResolution` chain modifier so that any entries embedded into the fetched entry are resolved in its response. Fixes bug [ALT-1146].

This change also brings in line how the experiences are fetched in delivery and editor modes to be (a bit) more aligned. For instance, the call to fetch the entities in the UI included referenced entities up to 10 levels deep. The query was modified to add the "includes: 10" parameter so that querying the data in each place is more like the other.

## Approach

<!--
Remember when merging:
- Use "Squash and merge" when merging changes into development.
- Use "Create a merge commit" when releasing changes into next and main.

Three important notes on pull requests:
- In general, you should ask yourself whether this code change will improve or worsen the overall code quality. Any new tech debt will probably never be cleaned up.
- Please remember that newly introduced logic should be validated and protected through testing.
- Take a look at PR guides:
  Google's Code Review Guidelines: https://google.github.io/eng-practices/
  Blockly - Writing a Good Pull Request: https://developers.google.com/blockly/guides/contribute/get-started/write_a_good_pr
-->


[ALT-1146]: https://contentful.atlassian.net/browse/ALT-1146?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ