### PR TITLE
[ALT-1246] feat: add custom rating to the marketing template

### DIFF
--- a/packages/templates/nextjs-marketing-demo/src/components/CustomRatingComponentRegistration.tsx
+++ b/packages/templates/nextjs-marketing-demo/src/components/CustomRatingComponentRegistration.tsx
@@ -1,0 +1,48 @@
+import { Rate } from 'antd';
+
+export const CustomRatingComponentRegistration = {
+  component: Rate,
+  definition: {
+    id: 'custom-rating',
+    name: 'Custom Rating',
+    category: 'Custom Components',
+    variables: {
+      disabled: {
+        displayName: 'Read only',
+        type: 'Boolean',
+        defaultValue: true,
+        group: 'style',
+      },
+      value: {
+        displayName: 'Stars',
+        type: 'Number',
+        defaultValue: 5,
+        group: 'style',
+        validations: {
+          in: [
+            {
+              value: 1,
+              displayName: 'One Star',
+            },
+            {
+              value: 2,
+              displayName: 'Two Star',
+            },
+            {
+              value: 3,
+              displayName: 'Three Star',
+            },
+            {
+              value: 4,
+              displayName: 'Four Star',
+            },
+            {
+              value: 5,
+              displayName: 'Five Star',
+            },
+          ],
+        },
+      },
+    },
+  },
+};

--- a/packages/templates/nextjs-marketing-demo/src/studio-config.ts
+++ b/packages/templates/nextjs-marketing-demo/src/studio-config.ts
@@ -1,4 +1,5 @@
 import { defineComponents } from '@contentful/experiences-sdk-react';
 import { ButtonComponentRegistration } from './components/ButtonComponentRegistration';
+import { CustomRatingComponentRegistration } from '@/components/CustomRatingComponentRegistration';
 
-defineComponents([ButtonComponentRegistration]);
+defineComponents([ButtonComponentRegistration, CustomRatingComponentRegistration]);


### PR DESCRIPTION
## Purpose
Get the Ant Customer Rating component into the template demo app https://ant.design/components/rate

<img width="1693" alt="Screenshot 2024-09-24 at 1 40 50 PM" src="https://github.com/user-attachments/assets/94ce4247-25ad-43f3-8c92-48ca85965eb2">
<img width="1586" alt="Screenshot 2024-09-24 at 1 41 00 PM" src="https://github.com/user-attachments/assets/d07a811f-eeaa-425c-8bec-51beb2572594">
