### PR TITLE
chore: update intended private packages with private notice [ALT-1269]

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,6 +1,11 @@
 # @contentful/experiences-core
 
+## Private Package Notice
+
+*Note*: This package is not meant to be used directly by the end user. It is a dependency for the Studio Experiences packages. Changes to this package are not guaranteed to follow semantic versioning and may break without notice if used directly.
+
 ### Purpose
+
 - To contain shared code and utilities across the Experiences packages such as constants, types, transformers, and hooks.
 - This means additions to core should be framework agnostic. For example, code that is only compatible with React does not belong in the core package.
 

--- a/packages/validators/README.md
+++ b/packages/validators/README.md
@@ -1,5 +1,9 @@
 # @contentful/experiences-validators
 
+## Private Package Notice
+
+*Note*: This package is not meant to be used directly by the end user. It is a dependency for the Studio Experiences packages. Changes to this package are not guaranteed to follow semantic versioning and may break without notice if used directly.
+
 This package defines schemas and validator functions for experience data structures in the [Experiences SDK](https://www.contentful.com/developers/docs/experiences/set-up-experiences-sdk/). These validators ensure the integrity and correctness of the data used in experiences.
 
 ## Purpose

--- a/packages/visual-editor/README.md
+++ b/packages/visual-editor/README.md
@@ -1,5 +1,9 @@
 # @contentful/experiences-visual-editor-react
 
+## Private Package Notice
+
+*Note*: This package is not meant to be used directly by the end user. It is a dependency for the Studio Experiences packages. Changes to this package are not guaranteed to follow semantic versioning and may break without notice if used directly.
+
 ### Purpose
 - Handles the canvas interaction logic with dragging, hitboxes, dropzones, reparenting, and communicating with the parent frame to ensure a smooth drag and drop experience.
 - Note that this package is framework specific to React.


### PR DESCRIPTION
## Purpose

Adds a private package notice to Core, Validators, and Visual Editor package warning users not to use them directly in their own code.
