### PR TITLE
feat(nextjs-marketing-demo): add design tokens and card cover slot [ALT-1272]

### DIFF
--- a/packages/templates/nextjs-marketing-demo/src/components/CardComponentRegistration.tsx
+++ b/packages/templates/nextjs-marketing-demo/src/components/CardComponentRegistration.tsx
@@ -2,43 +2,18 @@ import React from 'react';
 import { Card } from 'antd';
 
 type CardComponentProps = {
+  coverSlot: React.ReactNode;
   title: string;
   description: string;
-  coverImageUrl?: string;
-  coverImageAltText?: string;
   bordered: boolean;
   hoverable: boolean;
   size: 'default' | 'small';
 };
 
 export const CardComponentRegistration = {
-  component: ({
-    title,
-    description,
-    bordered,
-    hoverable,
-    size,
-    coverImageUrl,
-    coverImageAltText,
-  }: CardComponentProps) => {
+  component: ({ coverSlot, title, description, bordered, hoverable, size }: CardComponentProps) => {
     return (
-      <Card
-        hoverable={hoverable}
-        bordered={bordered}
-        size={size}
-        style={{ width: 375, maxWidth: '100%' }}
-        cover={
-          coverImageUrl && (
-            <div style={{ overflow: 'hidden', height: 300 }}>
-              {/* eslint-disable-next-line @next/next/no-img-element */}
-              <img
-                src={coverImageUrl}
-                alt={coverImageAltText ?? 'cover image'}
-                style={{ width: '100%' }}
-              />
-            </div>
-          )
-        }>
+      <Card hoverable={hoverable} bordered={bordered} size={size} cover={coverSlot}>
         <Card.Meta title={title} description={description} />
       </Card>
     );
@@ -47,6 +22,11 @@ export const CardComponentRegistration = {
     id: 'custom-card',
     name: 'Card',
     category: 'Custom Components',
+    slots: {
+      coverSlot: {
+        displayName: 'Cover Slot',
+      },
+    },
     variables: {
       title: {
         displayName: 'Title',
@@ -57,14 +37,6 @@ export const CardComponentRegistration = {
         displayName: 'Description',
         type: 'Text',
         defaultValue: 'Description',
-      },
-      coverImageUrl: {
-        displayName: 'Cover Image URL',
-        type: 'Media',
-      },
-      coverImageAltText: {
-        displayName: 'Cover Image Alt Text',
-        type: 'Text',
       },
       bordered: {
         displayName: 'Bordered',

--- a/packages/templates/nextjs-marketing-demo/src/studio-config.ts
+++ b/packages/templates/nextjs-marketing-demo/src/studio-config.ts
@@ -1,4 +1,4 @@
-import { defineComponents } from '@contentful/experiences-sdk-react';
+import { defineComponents, defineDesignTokens } from '@contentful/experiences-sdk-react';
 import { ButtonComponentRegistration } from './components/ButtonComponentRegistration';
 import { RatingStarsComponentRegistration } from '@/components/RatingStarsComponentRegistration';
 import { CardComponentRegistration } from './components/CardComponentRegistration';
@@ -8,3 +8,132 @@ defineComponents([
   RatingStarsComponentRegistration,
   CardComponentRegistration,
 ]);
+
+const textColorTokens = {
+  Primary: '#1890ff',
+  Heading: '#262626',
+  HeadingInverse: '#ffffff',
+  Paragraph: '#262626',
+  ParagraphLight: '#878787',
+  ParagraphInverse: '#ffffff',
+};
+
+const fontSizeTokens = {
+  XS: '14px',
+  S: '16px',
+  M: '20px',
+  L: '24px',
+  XL: '32px',
+  '2XL': '48px',
+  '3XL': '64px',
+  '4XL': '84px',
+};
+
+const lineHeightTokens = {
+  Paragraph: '150%',
+  Heading: '125%',
+};
+
+defineDesignTokens({
+  textColor: textColorTokens,
+  fontSize: fontSizeTokens,
+  lineHeight: lineHeightTokens,
+  color: {
+    Neutral: '#fafafa',
+    Warm: '#faf4f3',
+    Red: '#fff1f0',
+    Orange: '#fff7e6',
+    Gold: '#fffbe6',
+    Lime: '#fcffe6',
+    Cyan: '#e6fffb',
+    Blue: '#e6f7ff',
+    Purple: '#f9f0ff',
+    Magenta: '#fff0f6',
+  },
+  spacing: {
+    XXS: '8px',
+    XS: '12px',
+    S: '16px',
+    M: '24px',
+    L: '32px',
+    XL: '40px',
+    '2XL': '48px',
+    '3XL': '64px',
+    '4XL': '128px',
+  },
+  sizing: {
+    Layout: '960px',
+    'Content Block': '480px',
+  },
+  border: {
+    Card: {
+      width: '1px',
+      style: 'solid',
+      color: '#fafafa',
+    },
+    'Card Bold': {
+      width: '2px',
+      style: 'solid',
+      color: '#f0f0f0',
+    },
+  },
+  borderRadius: {
+    M: '8px',
+  },
+  text: {
+    'Hero H1': {
+      fontSize: fontSizeTokens['3XL'],
+      fontWeight: '600',
+      lineHeight: lineHeightTokens.Heading,
+      color: textColorTokens.ParagraphInverse,
+    },
+    'Hero Paragraph': {
+      fontSize: fontSizeTokens.S,
+      fontWeight: '500',
+      lineHeight: lineHeightTokens.Paragraph,
+      color: textColorTokens.ParagraphInverse,
+    },
+    H1: {
+      fontSize: fontSizeTokens['3XL'],
+      fontWeight: '600',
+      lineHeight: lineHeightTokens.Heading,
+      color: textColorTokens.Heading,
+    },
+    H2: {
+      fontSize: fontSizeTokens.XL,
+      fontWeight: '600',
+      lineHeight: lineHeightTokens.Heading,
+      color: textColorTokens.Heading,
+    },
+    H3: {
+      fontSize: fontSizeTokens.L,
+      fontWeight: '600',
+      lineHeight: lineHeightTokens.Heading,
+      color: textColorTokens.Heading,
+    },
+    H4: {
+      fontSize: fontSizeTokens.M,
+      fontWeight: '600',
+      lineHeight: lineHeightTokens.Heading,
+      color: textColorTokens.Heading,
+    },
+    H5: {
+      fontSize: fontSizeTokens.S,
+      fontWeight: '600',
+      lineHeight: lineHeightTokens.Heading,
+      color: textColorTokens.Heading,
+    },
+    Paragraph: {
+      fontSize: fontSizeTokens.S,
+      fontWeight: '500',
+      lineHeight: lineHeightTokens.Paragraph,
+      color: textColorTokens.Paragraph,
+    },
+    'Paragraph Large': {
+      fontSize: fontSizeTokens.M,
+      fontWeight: '500',
+      lineHeight: lineHeightTokens.Paragraph,
+      color: textColorTokens.Paragraph,
+    },
+  },
+});


### PR DESCRIPTION
## Purpose

Changes for the marketing demo app:
* Add design tokens to match the figma design
* Change the Card component to use a Slot for the cover (image) area