### PR TITLE
fix: default width to 100% when component doesn't have a width variable [ALT-956]

### DIFF
--- a/packages/core/src/test/__fixtures__/entities.ts
+++ b/packages/core/src/test/__fixtures__/entities.ts
@@ -120,6 +120,13 @@ export const assets: Asset[] = [
         url: 'https://test.com/test.jpg',
         fileName: 'example.jpg',
         contentType: '',
+        details: {
+          size: 3147977,
+          image: {
+            width: 1024,
+            height: 1024,
+          },
+        },
       } as AssetFile,
     },
     metadata: {

--- a/packages/core/src/utils/transformers/media/transformMedia.ts
+++ b/packages/core/src/utils/transformers/media/transformMedia.ts
@@ -59,10 +59,11 @@ export const transformMedia = (
   }
 
   if (variableName === 'cfBackgroundImageUrl') {
-    const width = resolveDesignValue(
-      variables['cfWidth']?.type === 'DesignValue' ? variables['cfWidth'].valuesByBreakpoint : {},
-      'cfWidth',
-    );
+    const width =
+      resolveDesignValue(
+        variables['cfWidth']?.type === 'DesignValue' ? variables['cfWidth'].valuesByBreakpoint : {},
+        'cfWidth',
+      ) || '100%';
     const optionsVariableName = 'cfBackgroundImageOptions';
     const options = resolveDesignValue(
       variables[optionsVariableName]?.type === 'DesignValue'

--- a/packages/core/src/utils/transformers/transformBoundContentValue.spec.ts
+++ b/packages/core/src/utils/transformers/transformBoundContentValue.spec.ts
@@ -152,7 +152,7 @@ describe('transformBoundContentValue', () => {
           binding,
           resolveDesignValue,
           variableName,
-          variableType as any,
+          variableType,
           path,
         );
         expect(result).toEqual(assets[0].fields.file?.url);

--- a/packages/core/src/utils/transformers/transformBoundContentValue.spec.ts
+++ b/packages/core/src/utils/transformers/transformBoundContentValue.spec.ts
@@ -1,8 +1,13 @@
 import { EditorModeEntityStore } from '@/entity';
 import { transformBoundContentValue } from './transformBoundContentValue';
 import { entities, assets } from '@/test/__fixtures__/entities';
-import { BoundValue, ComponentDefinition, ComponentTreeNode } from '@/types';
-import { vitest } from 'vitest';
+import {
+  BoundValue,
+  ComponentDefinition,
+  ComponentTreeNode,
+  OptimizedBackgroundImageAsset,
+} from '@/types';
+import { vitest, it, describe } from 'vitest';
 import { UnresolvedLink } from 'contentful';
 
 const entityStore = new EditorModeEntityStore({
@@ -10,7 +15,7 @@ const entityStore = new EditorModeEntityStore({
   locale: 'en-US',
 });
 
-const ComponentDefinition: ComponentDefinition = {
+const componentDefinition: ComponentDefinition = {
   id: 'custom-component',
   name: 'Custom Component',
   variables: {
@@ -42,80 +47,155 @@ const variables: ComponentTreeNode['variables'] = {
 };
 
 describe('transformBoundContentValue', () => {
-  it('should transform bound content value', () => {
-    const binding: UnresolvedLink<'Entry'> = {
-      sys: { type: 'Link', linkType: 'Entry', id: 'entry1' },
-    };
-    const resolveDesignValue = vitest.fn();
-    const variableName = 'title';
+  describe('when variable type is a bound value', () => {
+    it('should transform bound content value', () => {
+      const binding: UnresolvedLink<'Entry'> = {
+        sys: { type: 'Link', linkType: 'Entry', id: 'entry1' },
+      };
+      const resolveDesignValue = vitest.fn();
+      const variableName = 'title';
 
-    const path = (variables.title as BoundValue).path;
-    const result = transformBoundContentValue(
-      variables,
-      entityStore,
-      binding,
-      resolveDesignValue,
-      variableName,
-      ComponentDefinition.variables.title,
-      path,
-    );
-    expect(result).toEqual(entities[0].fields.title);
+      const path = (variables.title as BoundValue).path;
+      const result = transformBoundContentValue(
+        variables,
+        entityStore,
+        binding,
+        resolveDesignValue,
+        variableName,
+        componentDefinition.variables.title,
+        path,
+      );
+      expect(result).toEqual(entities[0].fields.title);
+    });
   });
 
-  it('should transform value if variable type is "Media"', () => {
-    const binding: UnresolvedLink<'Asset'> = {
-      sys: { type: 'Link', linkType: 'Asset', id: 'asset1' },
-    };
-    const resolveDesignValue = vitest.fn();
-    const variableName = 'image';
+  describe('when variable type is "Media"', () => {
+    const variableType = componentDefinition.variables.image;
 
-    const path = (variables.image as BoundValue).path;
-    const result = transformBoundContentValue(
-      variables,
-      entityStore,
-      binding,
-      resolveDesignValue,
-      variableName,
-      ComponentDefinition.variables.image,
-      path,
-    );
-    expect(result).toEqual(assets[0].fields.file?.url);
+    describe('when the variable is a cfBackgroundImageOptions', () => {
+      const variablesWithImageOptions = {
+        ...variables,
+      };
+      it('should transform value to OptimizedBackgroundImageAsset', () => {
+        const binding: UnresolvedLink<'Asset'> = {
+          sys: { type: 'Link', linkType: 'Asset', id: 'asset1' },
+        };
+        const resolveDesignValue = vitest.fn((_, variableName) => {
+          if (variableName === 'cfBackgroundImageOptions') {
+            return {
+              quality: '100%',
+              format: 'jpg',
+            };
+          }
+          if (variableName === 'cfWidth') {
+            return '1024px';
+          }
+        });
+        const variableName = 'cfBackgroundImageUrl';
+
+        const path = (variables.image as BoundValue).path;
+        const result = transformBoundContentValue(
+          variablesWithImageOptions,
+          entityStore,
+          binding,
+          resolveDesignValue,
+          variableName,
+          variableType,
+          path,
+        ) as OptimizedBackgroundImageAsset;
+        expect(result.url).toEqual(assets[0].fields.file?.url + '?w=1024&fm=jpg');
+      });
+
+      it.only('when the component doesnt have a width variable, it should still transform value to OptimizedBackgroundImageAsset', () => {
+        const binding: UnresolvedLink<'Asset'> = {
+          sys: { type: 'Link', linkType: 'Asset', id: 'asset1' },
+        };
+        const resolveDesignValue = vitest.fn((_, variableName) => {
+          if (variableName === 'cfBackgroundImageOptions') {
+            return {
+              quality: '100%',
+              format: 'jpg',
+            };
+          }
+          if (variableName === 'cfWidth') {
+            return undefined; // cfWidth is not defined
+          }
+        });
+        const variableName = 'cfBackgroundImageUrl';
+
+        const path = (variables.image as BoundValue).path;
+        const result = transformBoundContentValue(
+          variablesWithImageOptions,
+          entityStore,
+          binding,
+          resolveDesignValue,
+          variableName,
+          variableType,
+          path,
+        ) as OptimizedBackgroundImageAsset;
+        expect(result.url).toEqual(assets[0].fields.file?.url + '?w=1024&fm=jpg');
+      });
+    });
+
+    describe('when the variable is not a cfImageAsset', () => {
+      it('should transform value if variable type is "Media"', () => {
+        const binding: UnresolvedLink<'Asset'> = {
+          sys: { type: 'Link', linkType: 'Asset', id: 'asset1' },
+        };
+        const resolveDesignValue = vitest.fn();
+        const variableName = 'image';
+
+        const path = (variables.image as BoundValue).path;
+        const result = transformBoundContentValue(
+          variables,
+          entityStore,
+          binding,
+          resolveDesignValue,
+          variableName,
+          variableType as any,
+          path,
+        );
+        expect(result).toEqual(assets[0].fields.file?.url);
+      });
+    });
   });
 
-  it('should transform text to rich text if variable type is "RichText"', () => {
-    const variableName = 'description';
-    const resolveDesignValue = vitest.fn();
-    const binding: UnresolvedLink<'Entry'> = {
-      sys: { type: 'Link', linkType: 'Entry', id: 'entry1' },
-    };
+  describe('when variable type is "RichText"', () => {
+    it('should transform text to rich text if variable type is "RichText"', () => {
+      const variableName = 'description';
+      const resolveDesignValue = vitest.fn();
+      const binding: UnresolvedLink<'Entry'> = {
+        sys: { type: 'Link', linkType: 'Entry', id: 'entry1' },
+      };
 
-    const path = (variables.description as BoundValue).path;
-    const result = transformBoundContentValue(
-      variables,
-      entityStore,
-      binding,
-      resolveDesignValue,
-      variableName,
-      ComponentDefinition.variables.description,
-      path,
-    );
-    expect(result).toEqual({
-      content: [
-        {
-          content: [
-            {
-              data: {},
-              marks: [],
-              nodeType: 'text',
-              value: 'Entry 1',
-            },
-          ],
-          data: {},
-          nodeType: 'paragraph',
-        },
-      ],
-      data: {},
-      nodeType: 'document',
+      const path = (variables.description as BoundValue).path;
+      const result = transformBoundContentValue(
+        variables,
+        entityStore,
+        binding,
+        resolveDesignValue,
+        variableName,
+        componentDefinition.variables.description,
+        path,
+      );
+      expect(result).toEqual({
+        content: [
+          {
+            content: [
+              {
+                data: {},
+                marks: [],
+                nodeType: 'text',
+                value: 'Entry 1',
+              },
+            ],
+            data: {},
+            nodeType: 'paragraph',
+          },
+        ],
+        data: {},
+        nodeType: 'document',
+      });
     });
   });
 });

--- a/packages/core/src/utils/transformers/transformBoundContentValue.spec.ts
+++ b/packages/core/src/utils/transformers/transformBoundContentValue.spec.ts
@@ -106,7 +106,7 @@ describe('transformBoundContentValue', () => {
         expect(result.url).toEqual(assets[0].fields.file?.url + '?w=1024&fm=jpg');
       });
 
-      it.only('when the component doesnt have a width variable, it should still transform value to OptimizedBackgroundImageAsset', () => {
+      it('when the component doesnt have a width variable, it should still transform value to OptimizedBackgroundImageAsset', () => {
         const binding: UnresolvedLink<'Asset'> = {
           sys: { type: 'Link', linkType: 'Asset', id: 'asset1' },
         };


### PR DESCRIPTION
## Purpose

The image optimization code was expecting the component to have a cfWidth variable set, and error if it did not. Since the column component did not have cfWidth, it was erroring when trying to set the background image on a column.

## Approach

When seeing if there is a cfWidth set, if there is not, we default to 100% width instead and let the user set a Target Width on the variable to help with optimization.
