### PR TITLE
fix: width applied to both wrapping div and img [ALT-1293]

### DIFF
--- a/packages/components/src/components/Image/Image.css
+++ b/packages/components/src/components/Image/Image.css
@@ -2,6 +2,8 @@
 
 .cf-no-image {
   position: relative;
+  height: 100%;
+  width: 100%;
 }
 
 .cf-no-image img {

--- a/packages/components/src/components/Image/Image.css
+++ b/packages/components/src/components/Image/Image.css
@@ -1,18 +1,12 @@
 @import url('../variables.css');
 
-.cf-no-image {
-  position: relative;
-  height: 100%;
-  width: 100%;
-}
-
-.cf-no-image img {
+img.cf-placeholder-image {
   background-color: var(--cf-color-gray100);
   outline-offset: -2px;
   outline: 2px solid rgba(var(--cf-color-gray400-rgb), 0.5);
 }
 
-.cf-no-image svg {
+svg.cf-placeholder-icon {
   position: absolute;
   top: 50%;
   left: 50%;
@@ -23,6 +17,6 @@
   max-width: 100%;
 }
 
-.cf-no-image svg path {
+svg.cf-placeholder-icon path {
   fill: var(--cf-color-gray400);
 }

--- a/packages/components/src/components/Image/Image.cy.tsx
+++ b/packages/components/src/components/Image/Image.cy.tsx
@@ -27,9 +27,8 @@ describe('Image', () => {
 
   it('renders default image when no src or cfImageAsset are specified', () => {
     cy.mount(<Image />);
-    cy.get('.cf-no-image').should('exist');
-    cy.get('.cf-no-image img').should('exist');
-    cy.get('.cf-no-image svg').should('exist');
+    cy.get('img.cf-placeholder-image').should('exist');
+    cy.get('svg.cf-placeholder-icon').should('exist');
   });
 
   it('renders at the proper width', () => {

--- a/packages/components/src/components/Image/Image.tsx
+++ b/packages/components/src/components/Image/Image.tsx
@@ -1,5 +1,6 @@
-import { OptimizedImageAsset } from '@contentful/experiences-core/types';
 import React from 'react';
+import { combineClasses } from '@/utils/combineClasses';
+import { OptimizedImageAsset } from '@contentful/experiences-core/types';
 import './Image.css';
 
 export interface ImageProps extends React.ImgHTMLAttributes<HTMLImageElement> {
@@ -9,19 +10,23 @@ export interface ImageProps extends React.ImgHTMLAttributes<HTMLImageElement> {
 export const Image: React.FC<ImageProps> = ({ className = '', src, cfImageAsset, ...props }) => {
   if (!cfImageAsset && !src) {
     return (
-      <div className="cf-no-image">
+      <>
         <img
-          className={className}
+          className={combineClasses('cf-placeholder-image', className)}
           src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAA"
           {...props}
         />
-        <svg fill="none" viewBox="0 0 17 16" xmlns="http://www.w3.org/2000/svg">
+        <svg
+          className="cf-placeholder-icon"
+          fill="none"
+          viewBox="0 0 17 16"
+          xmlns="http://www.w3.org/2000/svg">
           <path
             fill="#fff"
             d="M13.5 2h-10a1 1 0 0 0-1 1v10a1 1 0 0 0 1 1h10a1 1 0 0 0 1-1V3a1 1 0 0 0-1-1m-10 1h10v4.836l-1.543-1.543a1 1 0 0 0-1.414 0L3.836 13H3.5zm10 10H5.25l6-6 2.25 2.25zm-7-5.5a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3m0-2a.5.5 0 1 1 0 1 .5.5 0 0 1 0-1"
           />
         </svg>
-      </div>
+      </>
     );
   }
 

--- a/packages/core/src/utils/components.ts
+++ b/packages/core/src/utils/components.ts
@@ -42,7 +42,7 @@ export const isComponentAllowedOnRoot = ({ type, category, componentId }: Compon
   componentId === CONTENTFUL_COMPONENTS.divider.id;
 
 export const isStructureWithRelativeHeight = (componentId?: string, height?: string | number) => {
-  return isContentfulStructureComponent(componentId) && height?.toString().endsWith('%');
+  return isContentfulStructureComponent(componentId) && !height?.toString().endsWith('px');
 };
 
 const stylesToKeep = ['cfImageAsset'];

--- a/packages/core/src/utils/components.ts
+++ b/packages/core/src/utils/components.ts
@@ -1,12 +1,9 @@
-import { omit } from 'lodash-es';
 import {
   ASSEMBLY_BLOCK_NODE_TYPE,
   ASSEMBLY_DEFAULT_CATEGORY,
   ASSEMBLY_NODE_TYPE,
-  CF_STYLE_ATTRIBUTES,
   CONTENTFUL_COMPONENTS,
 } from '../constants';
-import type { PrimitiveValue } from '../types';
 
 const structureComponentIds = new Set([
   CONTENTFUL_COMPONENTS.section.id,
@@ -43,12 +40,4 @@ export const isComponentAllowedOnRoot = ({ type, category, componentId }: Compon
 
 export const isStructureWithRelativeHeight = (componentId?: string, height?: string | number) => {
   return isContentfulStructureComponent(componentId) && !height?.toString().endsWith('px');
-};
-
-const stylesToKeep = ['cfImageAsset'];
-const stylesToRemove = CF_STYLE_ATTRIBUTES.filter((style) => !stylesToKeep.includes(style));
-const propsToRemove = ['cfHyperlink', 'cfOpenInNewTab', 'cfSsrClassName'];
-
-export const sanitizeNodeProps = (nodeProps: Record<PropertyKey, PrimitiveValue>) => {
-  return omit(nodeProps, stylesToRemove, propsToRemove);
 };

--- a/packages/core/src/utils/components.ts
+++ b/packages/core/src/utils/components.ts
@@ -39,5 +39,5 @@ export const isComponentAllowedOnRoot = ({ type, category, componentId }: Compon
   componentId === CONTENTFUL_COMPONENTS.divider.id;
 
 export const isStructureWithRelativeHeight = (componentId?: string, height?: string | number) => {
-  return isContentfulStructureComponent(componentId) && !height?.toString().endsWith('px');
+  return isContentfulStructureComponent(componentId) && height?.toString().endsWith('%');
 };

--- a/packages/core/src/utils/components.ts
+++ b/packages/core/src/utils/components.ts
@@ -1,9 +1,12 @@
+import { omit } from 'lodash-es';
 import {
   ASSEMBLY_BLOCK_NODE_TYPE,
   ASSEMBLY_DEFAULT_CATEGORY,
   ASSEMBLY_NODE_TYPE,
+  CF_STYLE_ATTRIBUTES,
   CONTENTFUL_COMPONENTS,
 } from '../constants';
+import type { PrimitiveValue } from '../types';
 
 const structureComponentIds = new Set([
   CONTENTFUL_COMPONENTS.section.id,
@@ -40,4 +43,12 @@ export const isComponentAllowedOnRoot = ({ type, category, componentId }: Compon
 
 export const isStructureWithRelativeHeight = (componentId?: string, height?: string | number) => {
   return isContentfulStructureComponent(componentId) && height?.toString().endsWith('%');
+};
+
+const stylesToKeep = ['cfImageAsset'];
+const stylesToRemove = CF_STYLE_ATTRIBUTES.filter((style) => !stylesToKeep.includes(style));
+const propsToRemove = ['cfHyperlink', 'cfOpenInNewTab', 'cfSsrClassName'];
+
+export const sanitizeNodeProps = (nodeProps: Record<PropertyKey, PrimitiveValue>) => {
+  return omit(nodeProps, stylesToRemove, propsToRemove);
 };

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -11,3 +11,4 @@ export * from './isLink';
 export * from './pathSchema';
 export * from './resolveHyperlinkPattern';
 export * from './patternUtils';
+export * from './sanitizeNodeProps';

--- a/packages/core/src/utils/sanitizeNodeProps.ts
+++ b/packages/core/src/utils/sanitizeNodeProps.ts
@@ -1,0 +1,11 @@
+import { omit } from 'lodash-es';
+import { CF_STYLE_ATTRIBUTES } from '../constants';
+import type { PrimitiveValue } from '../types';
+
+const stylesToKeep = ['cfImageAsset'];
+const stylesToRemove = CF_STYLE_ATTRIBUTES.filter((style) => !stylesToKeep.includes(style));
+const propsToRemove = ['cfHyperlink', 'cfOpenInNewTab', 'cfSsrClassName'];
+
+export const sanitizeNodeProps = (nodeProps: Record<PropertyKey, PrimitiveValue>) => {
+  return omit(nodeProps, stylesToRemove, propsToRemove);
+};

--- a/packages/experience-builder-sdk/src/blocks/preview/CompositionBlock.tsx
+++ b/packages/experience-builder-sdk/src/blocks/preview/CompositionBlock.tsx
@@ -1,9 +1,11 @@
 import React, { useMemo } from 'react';
 import type { UnresolvedLink } from 'contentful';
-import { omit } from 'lodash-es';
-import { EntityStore, resolveHyperlinkPattern } from '@contentful/experiences-core';
 import {
-  CF_STYLE_ATTRIBUTES,
+  EntityStore,
+  resolveHyperlinkPattern,
+  sanitizeNodeProps,
+} from '@contentful/experiences-core';
+import {
   CONTENTFUL_COMPONENTS,
   HYPERLINK_DEFAULT_PATTERN,
 } from '@contentful/experiences-core/constants';
@@ -26,6 +28,7 @@ import {
 
 import { resolveAssembly } from '../../core/preview/assemblyUtils';
 import { Entry } from 'contentful';
+import PreviewUnboundImage from './PreviewUnboundImage';
 
 type CompositionBlockProps = {
   node: ComponentTreeNode;
@@ -263,14 +266,17 @@ export const CompositionBlock = ({
     );
   }
 
-  //List explicit style props that will end up being passed to the component
-  const stylesToKeep = ['cfImageAsset'];
-  const stylesToRemove = CF_STYLE_ATTRIBUTES.filter((style) => !stylesToKeep.includes(style));
+  if (
+    node.definitionId === CONTENTFUL_COMPONENTS.image.id &&
+    node.variables.cfImageAsset?.type === 'UnboundValue'
+  ) {
+    return <PreviewUnboundImage node={node} nodeProps={nodeProps} component={component} />;
+  }
 
   return React.createElement(
     component,
     {
-      ...omit(nodeProps, stylesToRemove, ['cfHyperlink', 'cfOpenInNewTab', 'cfSsrClassName']),
+      ...sanitizeNodeProps(nodeProps),
       className,
     },
     children ?? (typeof nodeProps.children === 'string' ? nodeProps.children : null),

--- a/packages/experience-builder-sdk/src/blocks/preview/PreviewUnboundImage.tsx
+++ b/packages/experience-builder-sdk/src/blocks/preview/PreviewUnboundImage.tsx
@@ -22,7 +22,9 @@ const PreviewUnboundImage: React.FC<PreviewUnboundImageProps> = ({
   nodeProps,
   component,
 }) => {
-  const wrapperStyle: CSSProperties = {};
+  const wrapperStyle: CSSProperties = {
+    position: 'relative',
+  };
 
   const modifiedNodeProps = { ...nodeProps };
   if (typeof modifiedNodeProps.cfImageOptions === 'object') {
@@ -43,7 +45,7 @@ const PreviewUnboundImage: React.FC<PreviewUnboundImageProps> = ({
   const className = useClassName({ props: modifiedNodeProps, node });
 
   return (
-    <div style={wrapperStyle}>
+    <div className="cf-preview-unbound-image" style={wrapperStyle}>
       {React.createElement(component, {
         ...sanitizeNodeProps(modifiedNodeProps),
         className,

--- a/packages/experience-builder-sdk/src/blocks/preview/PreviewUnboundImage.tsx
+++ b/packages/experience-builder-sdk/src/blocks/preview/PreviewUnboundImage.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import type {
+  ComponentTreeNode,
+  CSSProperties,
+  PrimitiveValue,
+} from '@contentful/experiences-core/types';
+import { sanitizeNodeProps } from '@contentful/experiences-core';
+import { useClassName } from '../../hooks/useClassName';
+
+interface PreviewUnboundImageProps {
+  node: ComponentTreeNode;
+  nodeProps: Record<PropertyKey, PrimitiveValue>;
+  component: React.ElementType;
+}
+
+/**
+ * This component is used to render a placeholder Image component in the preview
+ * when the image is unbound. It applies the Image size styles to a wrapping div.
+ */
+const PreviewUnboundImage: React.FC<PreviewUnboundImageProps> = ({
+  node,
+  nodeProps,
+  component,
+}) => {
+  const wrapperStyle: CSSProperties = {};
+
+  const modifiedNodeProps = { ...nodeProps };
+  if (typeof modifiedNodeProps.cfImageOptions === 'object') {
+    const { width, height, ...restImageOptions } = modifiedNodeProps.cfImageOptions;
+
+    // Apply the Image size styles to the wrapping div
+    wrapperStyle.height = String(height);
+    wrapperStyle.width = String(width);
+
+    // Set the Image height and width to 100% to fill the wrapping div
+    modifiedNodeProps.cfImageOptions = {
+      ...restImageOptions,
+      height: '100%',
+      width: '100%',
+    };
+  }
+
+  const className = useClassName({ props: modifiedNodeProps, node });
+
+  return (
+    <div style={wrapperStyle}>
+      {React.createElement(component, {
+        ...sanitizeNodeProps(modifiedNodeProps),
+        className,
+      })}
+    </div>
+  );
+};
+
+export default PreviewUnboundImage;

--- a/packages/visual-editor/src/hooks/useComponent.tsx
+++ b/packages/visual-editor/src/hooks/useComponent.tsx
@@ -65,7 +65,7 @@ export const useComponent = ({
 
   const componentId = node.data.id;
 
-  const { componentProps, sizeStyles } = useComponentProps({
+  const { componentProps, wrapperStyles } = useComponentProps({
     node,
     areEntitiesFetched,
     resolveDesignValue,
@@ -114,7 +114,7 @@ export const useComponent = ({
     return (
       <Tag
         {...rest}
-        style={{ ...style, ...sizeStyles }}
+        style={{ ...style, ...wrapperStyles }}
         ref={(refNode: HTMLElement | null) => {
           if (innerRef && refNode) innerRef(refNode);
         }}>

--- a/packages/visual-editor/src/hooks/useComponentProps.ts
+++ b/packages/visual-editor/src/hooks/useComponentProps.ts
@@ -223,12 +223,12 @@ export const useComponentProps = ({
 
   // Move size styles to the wrapping div and override the component styles
   const overrideStyles: CSSProperties = {};
-  const sizeStyles: CSSProperties = {
+  const wrapperStyles: CSSProperties = {
     width: cfStyles.width,
     maxWidth: cfStyles.maxWidth,
   };
   if (!isStructureComponent) {
-    sizeStyles.height = cfStyles.height;
+    wrapperStyles.height = cfStyles.height;
     overrideStyles.height = '100%';
     overrideStyles.width = '100%';
   }
@@ -264,7 +264,7 @@ export const useComponentProps = ({
     ...(definition?.children ? { children: renderDropzone(node) } : {}),
   };
 
-  return { componentProps, sizeStyles };
+  return { componentProps, wrapperStyles };
 };
 
 const addExtraDropzonePadding = (padding: string) =>

--- a/packages/visual-editor/src/hooks/useComponentProps.ts
+++ b/packages/visual-editor/src/hooks/useComponentProps.ts
@@ -230,8 +230,6 @@ export const useComponentProps = ({
   if (!isStructureComponent) {
     sizeStyles.height = cfStyles.height;
     overrideStyles.height = '100%';
-  }
-  if (cfStyles.width) {
     overrideStyles.width = '100%';
   }
 

--- a/packages/visual-editor/src/hooks/useComponentProps.ts
+++ b/packages/visual-editor/src/hooks/useComponentProps.ts
@@ -218,20 +218,28 @@ export const useComponentProps = ({
 
   const cfStyles = useMemo(() => buildCfStyles(props as StyleProps), [props]);
 
-  const sizeStyles: CSSProperties = {
-    width: cfStyles.width,
-    maxWidth: cfStyles.maxWidth,
-    maxHeight: cfStyles.maxHeight,
-  };
-
   const isAssemblyBlock = node.type === 'assemblyBlock';
   const isSingleColumn = node?.data.blockId === CONTENTFUL_COMPONENTS.columns.id;
   const isStructureComponent = isContentfulStructureComponent(node?.data.blockId);
+
+  const sizeStyles: CSSProperties = {
+    width: cfStyles.width,
+    maxWidth: cfStyles.maxWidth,
+  };
+  if (!isStructureComponent) {
+    sizeStyles.height = cfStyles.height;
+  }
+
+  const overrideSizeStyles = {
+    height: sizeStyles.height ? '100%' : cfStyles.height,
+    width: sizeStyles.width ? '100%' : undefined,
+  };
 
   // Styles that will be applied to the component element
   const componentClass = useEditorModeClassName({
     styles: {
       ...cfStyles,
+      ...overrideSizeStyles,
       ...(isEmptyZone &&
         isStructureWithRelativeHeight(node?.data.blockId, cfStyles.height) && {
           minHeight: EMPTY_CONTAINER_HEIGHT,

--- a/packages/visual-editor/src/hooks/useComponentProps.ts
+++ b/packages/visual-editor/src/hooks/useComponentProps.ts
@@ -228,9 +228,13 @@ export const useComponentProps = ({
     maxWidth: cfStyles.maxWidth,
   };
   if (!isStructureComponent) {
-    wrapperStyles.height = cfStyles.height;
-    overrideStyles.height = '100%';
-    overrideStyles.width = '100%';
+    if (cfStyles.height) {
+      wrapperStyles.height = cfStyles.height;
+      overrideStyles.height = '100%';
+    }
+    if (cfStyles.width) {
+      overrideStyles.width = '100%';
+    }
   }
 
   // Styles that will be applied to the component element


### PR DESCRIPTION
## Purpose

Fixes a bug where the `width` style is being applied to both the wrapping div and element. 

This was especially noticeable when using percent widths on an Image component because the double-width makes the image half the expected size.

## Approach

For editor mode, I updated `useCompnoentProps` to set the height and width to `100%` when those styles are applied to the wrapping div.

For delivery mode, I added a new `PreviewUnboundImage` component in the SDK.  This component replicates the same behavior as editor mode for the unbound image placeholder element. A wrapping is styled with the image component's height and width, and the placeholder element is styled with `100%` height and width to match the editor mode appearance.


https://github.com/user-attachments/assets/4d51edd4-1cb8-479c-a37c-c4c4ee6653ca


https://github.com/user-attachments/assets/5f7b2440-c6e3-454c-bb75-a19a613c94be


