### PR TITLE
fix: update NextJS apps to import config server side so design tokens are registered [ALT-1314]

### DIFF
--- a/examples/next-app-router/src/app/[locale]/[slug]/page.tsx
+++ b/examples/next-app-router/src/app/[locale]/[slug]/page.tsx
@@ -1,6 +1,7 @@
 import Experience from '@/components/Experience';
 import { getExperience } from '@/getExperience';
 import { detachExperienceStyles } from '@contentful/experiences-sdk-react';
+import '../../studio-config';
 
 type Page = {
   params: { locale?: string; slug?: string; preview?: string };

--- a/packages/templates/nextjs-marketing-demo/src/app/[locale]/[slug]/page.tsx
+++ b/packages/templates/nextjs-marketing-demo/src/app/[locale]/[slug]/page.tsx
@@ -10,6 +10,7 @@ import {
   Content as LayoutContent,
 } from 'antd/es/layout/layout';
 import styles from '@/app/page.module.css';
+import '../../../studio-config';
 
 type Page = {
   params: { locale?: string; slug?: string; preview?: string };

--- a/packages/test-apps/nextjs/src/app/[[...slug]]/page.tsx
+++ b/packages/test-apps/nextjs/src/app/[[...slug]]/page.tsx
@@ -1,6 +1,7 @@
 import Experience from '@/components/Experience';
 import { getExperience } from '@/utils/getExperience';
 import { detachExperienceStyles } from '@contentful/experiences-sdk-react';
+import '../../studio-config';
 
 type Page = {
   params: { locale?: string; slug?: string; preview?: string };

--- a/packages/test-apps/nextjs/src/studio-config.ts
+++ b/packages/test-apps/nextjs/src/studio-config.ts
@@ -1,4 +1,8 @@
-import { defineComponents, defineBreakpoints } from '@contentful/experiences-sdk-react';
+import {
+  defineComponents,
+  defineBreakpoints,
+  defineDesignTokens,
+} from '@contentful/experiences-sdk-react';
 import ComponentWithChildren from './components/ComponentWithChildren';
 import { LinkComponent } from './components/LinkComponent';
 import { CustomImageComponent } from './components/CustomImageComponent';
@@ -192,3 +196,30 @@ defineBreakpoints([
     previewSize: '390px',
   },
 ]);
+
+defineDesignTokens({
+  spacing: { XS: '4px', S: '16px', M: '32px', L: '64px', XL: '128px' },
+  sizing: { XS: '16px', S: '100px', M: '300px', L: '600px', XL: '1024px' },
+  color: {
+    Slate: '#94a3b8',
+    Azure: 'azure',
+    Orange: '#fdba74',
+    Blue: '#0000ff',
+  },
+  border: {
+    Azure: { width: '1px', style: 'solid', color: 'azure' },
+    Hero: { width: '2px', style: 'dashed', color: '#ffaabb' },
+    Card: { width: '1px', style: 'solid', color: '#ffccbb' },
+    Carousel: { width: '2px', style: 'dotted', color: 'rgba(30, 25, 25, 0.75)' },
+  },
+  fontSize: { XS: '12px', SM: '14px', MD: '16px', LG: '24px', XL: '32px' },
+  lineHeight: { XS: '1', SM: '1.25', MD: '1.5', LG: '200%' },
+  letterSpacing: {
+    None: '0',
+    XS: '0.05em',
+    SM: '0.1em',
+    MD: '0.15em',
+    LG: '0.2em',
+  },
+  textColor: { Dark: '#1a1a1a', Light: '#efefef', Slate: '#94a3b8' },
+});


### PR DESCRIPTION
## Purpose

Design tokens were not being used for our internal apps on NextJS in SSR.

## Approach

The config to register components and design tokens was only being called in client components, so when the CSS was generated server side, it was unable to look up the design tokens being used.

This PR updates the apps to also include the configuration file on server side pages as well as client side pages.

<!--
Remember when merging:
- Use "Squash and merge" when merging changes into development.
- Use "Create a merge commit" when releasing changes into next and main.

Three important notes on pull requests:
- In general, you should ask yourself whether this code change will improve or worsen the overall code quality. Any new tech debt will probably never be cleaned up.
- Please remember that newly introduced logic should be validated and protected through testing.
- Take a look at PR guides:
  Google's Code Review Guidelines: https://google.github.io/eng-practices/
  Blockly - Writing a Good Pull Request: https://developers.google.com/blockly/guides/contribute/get-started/write_a_good_pr
-->
