### PR TITLE
fix: dnd between custom components and patterns [ALT-1230]

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,4 +1,1 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
 npx commitlint --edit 

--- a/.husky/post-commit
+++ b/.husky/post-commit
@@ -1,4 +1,1 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
 rm -rf reports dist

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,1 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
 npx lint-staged

--- a/package-lock.json
+++ b/package-lock.json
@@ -2507,6 +2507,7 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {

--- a/packages/visual-editor/src/components/DraggableBlock/EditorBlock.tsx
+++ b/packages/visual-editor/src/components/DraggableBlock/EditorBlock.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo, useRef } from 'react';
-import { isContentfulStructureComponent, sendMessage } from '@contentful/experiences-core';
+import { sendMessage } from '@contentful/experiences-core';
 import { useSelectedInstanceCoordinates } from '@/hooks/useSelectedInstanceCoordinates';
 import { useEditorStore } from '@/store/editor';
 import { useComponent } from '@/hooks/useComponent';

--- a/packages/visual-editor/src/components/DraggableBlock/EditorBlock.tsx
+++ b/packages/visual-editor/src/components/DraggableBlock/EditorBlock.tsx
@@ -79,7 +79,6 @@ export const EditorBlock: React.FC<EditorBlockProps> = ({
   const isContainer = node.data.blockId === CONTENTFUL_COMPONENTS.container.id;
   const isAssemblyBlock = node.type === ASSEMBLY_BLOCK_NODE_TYPE;
   const isAssembly = node.type === ASSEMBLY_NODE_TYPE;
-  const isStructureComponent = isContentfulStructureComponent(node.data.blockId);
   const isSlotComponent = Boolean(node.data.slotId);
   const isDragDisabled = isAssemblyBlock || (isSingleColumn && isWrapped) || isSlotComponent;
   const isEmptyZone = useMemo(() => {
@@ -139,7 +138,7 @@ export const EditorBlock: React.FC<EditorBlockProps> = ({
         label={displayName || 'No label specified'}
       />
       <Placeholder {...placeholder} id={componentId} />
-      {isStructureComponent && userIsDragging && (
+      {userIsDragging && (
         <Hitboxes parentZoneId={zoneId} zoneId={componentId} isEmptyZone={isEmptyZone} />
       )}
     </>

--- a/packages/visual-editor/src/components/DraggableBlock/EditorBlock.tsx
+++ b/packages/visual-editor/src/components/DraggableBlock/EditorBlock.tsx
@@ -138,7 +138,7 @@ export const EditorBlock: React.FC<EditorBlockProps> = ({
         label={displayName || 'No label specified'}
       />
       <Placeholder {...placeholder} id={componentId} />
-      {userIsDragging && (
+      {userIsDragging && !isAssemblyBlock && (
         <Hitboxes parentZoneId={zoneId} zoneId={componentId} isEmptyZone={isEmptyZone} />
       )}
     </>

--- a/packages/visual-editor/src/components/DraggableHelpers/Placeholder.tsx
+++ b/packages/visual-editor/src/components/DraggableHelpers/Placeholder.tsx
@@ -96,8 +96,12 @@ const calcNewComponentStyles = (params: CalcStylesParams): CSSProperties => {
 
   const width = isHorizontal ? DRAGGABLE_WIDTH : dropzoneSizes.width - horizontalPadding;
   const height = isHorizontal ? dropzoneSizes.height - verticalPadding : DRAGGABLE_HEIGHT;
-  const top = isHorizontal ? calcOffsetTop(element, height, elementSizes.height) : -height;
-  const left = isHorizontal ? -width : calcOffsetLeft(element, width, elementSizes.width);
+  const top = isHorizontal
+    ? calcOffsetTop(element.parentElement, height, elementSizes.height)
+    : -height;
+  const left = isHorizontal
+    ? -width
+    : calcOffsetLeft(element.parentElement, width, elementSizes.width);
 
   return {
     width,
@@ -150,8 +154,12 @@ const calcMovementStyles = (params: CalcStylesParams): CSSProperties => {
 
   const width = isHorizontal ? draggableSizes.width : dropzoneSizes.width - horizontalPadding;
   const height = isHorizontal ? dropzoneSizes.height - verticalPadding : draggableSizes.height;
-  const top = isHorizontal ? calcOffsetTop(element, height, elementSizes.height) : -height;
-  const left = isHorizontal ? -width : calcOffsetLeft(element, width, elementSizes.width);
+  const top = isHorizontal
+    ? calcOffsetTop(element.parentElement, height, elementSizes.height)
+    : -height;
+  const left = isHorizontal
+    ? -width
+    : calcOffsetLeft(element.parentElement, width, elementSizes.width);
 
   return {
     width,


### PR DESCRIPTION
## Purpose
Fixes a bug where we couldn't drop or move a component between patterns or custom components.

Ticket: https://contentful.atlassian.net/browse/ALT-1230

Also fixes a styling bug with the blue placeholder so that it aligns properly in respect to flex direction of the parent element. 

Chore: cleanup husky configs for v10

https://github.com/user-attachments/assets/0be6624a-b764-4292-982e-4802f4bc2e59

