### PR TITLE
fix: make pattern height take 100% of available space [ALT-1294]

### DIFF
--- a/packages/visual-editor/src/components/DraggableBlock/styles.module.css
+++ b/packages/visual-editor/src/components/DraggableBlock/styles.module.css
@@ -28,6 +28,7 @@
 
 .Dropzone.isAssembly {
   width: 100%;
+  height: 100%;
 }
 
 .DraggableComponent:is(.Dropzone).isDragging {


### PR DESCRIPTION
## Purpose

Bug where even if user set a pattern to 100% height, the editor did not show it as such

https://contentful.atlassian.net/browse/ALT-1294

## Approach

patterns create both an assembly div and a child div of that for the assemblyBlock. AssemblyBlock has the styles the user selected for the pattern while assembly is mostly a wrapper and only had 100% width on it. If we add 100% height too then the user should see their styles as expected.

<img width="1213" alt="Screenshot 2024-10-08 at 10 54 42 AM" src="https://github.com/user-attachments/assets/fc6f9c09-a5ad-47e0-baee-37820bcdd1b8">
