### PR TITLE
fix: add divider to list of optionalBuiltInComponents [ALT-1325]

### DIFF
--- a/packages/experience-builder-sdk/src/core/componentRegistry.ts
+++ b/packages/experience-builder-sdk/src/core/componentRegistry.ts
@@ -173,6 +173,7 @@ export const optionalBuiltInComponents = [
   DEFAULT_COMPONENT_REGISTRATIONS.image.definition.id,
   DEFAULT_COMPONENT_REGISTRATIONS.richText.definition.id,
   DEFAULT_COMPONENT_REGISTRATIONS.text.definition.id,
+  DEFAULT_COMPONENT_REGISTRATIONS.divider.definition.id,
 ];
 
 export const sendRegisteredComponentsMessage = () => {


### PR DESCRIPTION
## Purpose

Adds the divider component to the list of optionalBuiltInComponents so that it can be set to not be available.
