### PR TITLE
feat: add new cfFlexReverse built in style property [ALT-1277]

### DIFF
--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -134,6 +134,7 @@ export const CF_STYLE_ATTRIBUTES = [
   'cfBackgroundImageOptions',
   'cfFlexDirection',
   'cfFlexWrap',
+  'cfFlexReverse',
   'cfBorder',
   'cfBorderRadius',
   'cfGap',

--- a/packages/core/src/definitions/styles.ts
+++ b/packages/core/src/definitions/styles.ts
@@ -112,6 +112,13 @@ export const builtInStyles: VariableDefinitions = {
     description: 'The orientation of the section',
     defaultValue: 'column',
   },
+  cfFlexReverse: {
+    displayName: 'Reverse Direction',
+    type: 'Boolean',
+    group: 'style',
+    description: 'Toggle the flex direction to be reversed',
+    defaultValue: false,
+  },
   cfFlexWrap: {
     displayName: 'Wrap objects',
     type: 'Text',

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -184,6 +184,7 @@ export type StyleProps = {
   cfHeight: string;
   cfFlexDirection: 'row' | 'column';
   cfFlexWrap: 'nowrap' | 'wrap';
+  cfFlexReverse: boolean;
   cfBorder: string;
   cfBorderRadius: string;
   cfGap: string;

--- a/packages/core/src/utils/styleUtils/stylesUtils.ts
+++ b/packages/core/src/utils/styleUtils/stylesUtils.ts
@@ -41,6 +41,7 @@ export const buildCfStyles = ({
   cfHorizontalAlignment,
   cfVerticalAlignment,
   cfFlexDirection,
+  cfFlexReverse,
   cfFlexWrap,
   cfMargin,
   cfPadding,
@@ -81,7 +82,8 @@ export const buildCfStyles = ({
     borderRadius: cfBorderRadius,
     gap: cfGap,
     ...transformAlignment(cfHorizontalAlignment, cfVerticalAlignment, cfFlexDirection),
-    flexDirection: cfFlexDirection,
+    flexDirection:
+      cfFlexReverse && cfFlexDirection ? `${cfFlexDirection}-reverse` : cfFlexDirection,
     flexWrap: cfFlexWrap,
     ...transformBackgroundImage(cfBackgroundImageUrl, cfBackgroundImageOptions),
     fontSize: cfFontSize,


### PR DESCRIPTION
## Purpose
Adds new cfFlexReverse property that is used to toggle the flex-direction to reverse for a component.

Ticket: https://contentful.atlassian.net/browse/ALT-1277

Related UI PR: https://github.com/contentful/user_interface/pull/23667
