### PR TITLE
feat: allow componentSettings and usedComponents fields within the same entity [SPA-2426]

### DIFF
--- a/packages/validators/src/schemas/v2023_09_28/experience.ts
+++ b/packages/validators/src/schemas/v2023_09_28/experience.ts
@@ -212,23 +212,6 @@ export const breakpointsRefinement = (value: Breakpoint[], ctx: z.RefinementCtx)
   }
 };
 
-const componentSettingsRefinement = (value, ctx: z.RefinementCtx) => {
-  const { componentSettings, usedComponents } = value as ExperienceFields;
-
-  if (!componentSettings || !usedComponents) {
-    return;
-  }
-  const localeKey = Object.keys(componentSettings ?? {})[0];
-
-  if (componentSettings[localeKey] !== undefined && usedComponents[localeKey] !== undefined) {
-    ctx.addIssue({
-      code: z.ZodIssueCode.custom,
-      message: `'componentSettings' field cannot be used in conjunction with 'usedComponents' field`,
-      path: ['componentSettings', localeKey],
-    });
-  }
-};
-
 const ComponentTreeSchema = z
   .object({
     breakpoints: z.array(BreakpointSchema).superRefine(breakpointsRefinement),
@@ -239,15 +222,13 @@ const ComponentTreeSchema = z
 
 const localeWrapper = (fieldSchema: any) => z.record(z.string(), fieldSchema);
 
-export const ExperienceFieldsCMAShapeSchema = z
-  .object({
-    componentTree: localeWrapper(ComponentTreeSchema),
-    dataSource: localeWrapper(DataSourceSchema),
-    unboundValues: localeWrapper(UnboundValuesSchema),
-    usedComponents: localeWrapper(UsedComponentsSchema).optional(),
-    componentSettings: localeWrapper(ComponentSettingsSchema).optional(),
-  })
-  .superRefine(componentSettingsRefinement);
+export const ExperienceFieldsCMAShapeSchema = z.object({
+  componentTree: localeWrapper(ComponentTreeSchema),
+  dataSource: localeWrapper(DataSourceSchema),
+  unboundValues: localeWrapper(UnboundValuesSchema),
+  usedComponents: localeWrapper(UsedComponentsSchema).optional(),
+  componentSettings: localeWrapper(ComponentSettingsSchema).optional(),
+});
 
 export type ExperienceFields = z.infer<typeof ExperienceFieldsCMAShapeSchema>;
 export type ExperienceDataSource = z.infer<typeof DataSourceSchema>;

--- a/packages/validators/src/validators/tests/componentSettings.spec.ts
+++ b/packages/validators/src/validators/tests/componentSettings.spec.ts
@@ -74,7 +74,7 @@ describe('componentSettings', () => {
     expect(result.errors?.[0]).toEqual(expectedError);
   });
 
-  it('fails if componentSettings is used in conjuction with usedComponents', () => {
+  it('passes if componentSettings is used in conjuction with usedComponents', () => {
     const updatedPattern = {
       ...experiencePattern,
       fields: {
@@ -87,14 +87,14 @@ describe('componentSettings', () => {
 
     const result = validateExperienceFields(updatedPattern, schemaVersion);
 
-    const expectedError = {
-      name: 'custom',
-      details:
-        "'componentSettings' field cannot be used in conjunction with 'usedComponents' field",
-      path: ['componentSettings', 'en-US'],
-    };
+    expect(result.success).toBe(true);
+    expect(result.errors).toBeUndefined();
+  });
 
-    expect(result.success).toBe(false);
-    expect(result.errors).toEqual([expectedError]);
+  it('passes if componentSettings is used NOT in conjuction with usedComponents', () => {
+    const result = validateExperienceFields(experiencePattern, schemaVersion);
+
+    expect(result.success).toBe(true);
+    expect(result.errors).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Purpose

## Approach

Removed the check that triggered a custom error when both fields were spotted within the same entity

<!--
Remember when merging:
- Use "Squash and merge" when merging changes into development.
- Use "Create a merge commit" when releasing changes into next and main.

Three important notes on pull requests:
- In general, you should ask yourself whether this code change will improve or worsen the overall code quality. Any new tech debt will probably never be cleaned up.
- Please remember that newly introduced logic should be validated and protected through testing.
- Take a look at PR guides:
  Google's Code Review Guidelines: https://google.github.io/eng-practices/
  Blockly - Writing a Good Pull Request: https://developers.google.com/blockly/guides/contribute/get-started/write_a_good_pr
-->
