### PR TITLE
fix: update display name for text variable in the Heading component []

### DIFF
--- a/.github/workflows/vercel.yaml
+++ b/.github/workflows/vercel.yaml
@@ -27,6 +27,12 @@ jobs:
       - name: Install dependencies
         run: |
           npm ci
+      - name: Build dependencies
+        run: |
+          npm run build --prefix ./packages/core
+          npm run build --prefix ./packages/components
+          npm run build --prefix ./packages/visual-editor
+          npm run build --prefix ./packages/experience-builder-sdk
       - name: Restore the build folders
         uses: actions/cache/restore@v4
         with:

--- a/.github/workflows/vercel.yaml
+++ b/.github/workflows/vercel.yaml
@@ -27,12 +27,6 @@ jobs:
       - name: Install dependencies
         run: |
           npm ci
-      - name: Build dependencies
-        run: |
-          npm run build --prefix ./packages/core
-          npm run build --prefix ./packages/components
-          npm run build --prefix ./packages/visual-editor
-          npm run build --prefix ./packages/experience-builder-sdk
       - name: Restore the build folders
         uses: actions/cache/restore@v4
         with:

--- a/.github/workflows/vercel.yaml
+++ b/.github/workflows/vercel.yaml
@@ -27,10 +27,6 @@ jobs:
       - name: Install dependencies
         run: |
           npm ci
-      - name: Build dependencies
-        run: |
-          npm run build --workspace=@contentful/experiences-sdk-react
-          npm run build --workspace=@contentful/experiences-components-react
       - name: Restore the build folders
         uses: actions/cache/restore@v4
         with:
@@ -85,3 +81,4 @@ jobs:
           fi
           vercel build --token=${{ secrets.VERCEL_TOKEN }}
           vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }}
+     

--- a/.github/workflows/vercel.yaml
+++ b/.github/workflows/vercel.yaml
@@ -27,6 +27,10 @@ jobs:
       - name: Install dependencies
         run: |
           npm ci
+      - name: Build dependencies
+        run: |
+          npm run build --workspace=@contentful/experiences-sdk-react
+          npm run build --workspace=@contentful/experiences-components-react
       - name: Restore the build folders
         uses: actions/cache/restore@v4
         with:
@@ -81,4 +85,3 @@ jobs:
           fi
           vercel build --token=${{ secrets.VERCEL_TOKEN }}
           vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }}
-     

--- a/package-lock.json
+++ b/package-lock.json
@@ -39583,6 +39583,10 @@
         "node": ">=4"
       }
     },
+    "node_modules/studio-experiences-react-app": {
+      "resolved": "packages/create-contentful-studio-experiences/studio-experiences-react-app",
+      "link": true
+    },
     "node_modules/style-inject": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/style-inject/-/style-inject-0.3.0.tgz",
@@ -44114,7 +44118,6 @@
     },
     "packages/create-contentful-studio-experiences/studio-experiences-react-app": {
       "version": "0.0.0",
-      "extraneous": true,
       "dependencies": {
         "@contentful/experiences-sdk-react": "^1.9.0",
         "react": "^18.3.1",

--- a/packages/components/src/components/Heading/index.ts
+++ b/packages/components/src/components/Heading/index.ts
@@ -61,7 +61,7 @@ export const HeadingComponentDefinition: ComponentDefinition = {
     },
     // Component specific variables
     text: {
-      displayName: 'text',
+      displayName: 'Text',
       type: 'Text',
       description: 'The text to display in the heading.',
       defaultValue: 'Heading',

--- a/packages/test-apps/react-vite/package.json
+++ b/packages/test-apps/react-vite/package.json
@@ -8,7 +8,6 @@
     "start": "vite",
     "prebuild": "rimraf dist",
     "build": "tsc && vite build",
-    "build:vercel": "npm run build --prefix ../../core && npm run build --prefix ../../components && npm run build --prefix ../../visual-editor && npm run build --prefix ../../experience-builder-sdk && npm run build",
     "lint": "eslint src --ext '.ts,.tsx,.js,.jsx' --max-warnings 0 --ignore-path ../../../.eslintignore",
     "lint:fix": "eslint src --ext '.ts,.tsx,.js,.jsx' --fix",
     "preview": "vite preview",

--- a/packages/test-apps/react-vite/package.json
+++ b/packages/test-apps/react-vite/package.json
@@ -8,7 +8,7 @@
     "start": "vite",
     "prebuild": "rimraf dist",
     "build": "tsc && vite build",
-    "build:vercel": "npm run build --prefix ../core && npm run build --prefix ../components && npm run build",
+    "build:vercel": "npm run build --prefix ../../components && npm run build --prefix ../../validators && npm run build --prefix ../../core && npm run build --prefix ../../visual-editor && npm run build --prefix ../../experience-builder-sdk && npm run build",
     "lint": "eslint src --ext '.ts,.tsx,.js,.jsx' --max-warnings 0 --ignore-path ../../../.eslintignore",
     "lint:fix": "eslint src --ext '.ts,.tsx,.js,.jsx' --fix",
     "preview": "vite preview",

--- a/packages/test-apps/react-vite/package.json
+++ b/packages/test-apps/react-vite/package.json
@@ -8,7 +8,7 @@
     "start": "vite",
     "prebuild": "rimraf dist",
     "build": "tsc && vite build",
-    "build:vercel": "npm run build --prefix ../../components && npm run build --prefix ../../validators && npm run build --prefix ../../core && npm run build --prefix ../../visual-editor && npm run build --prefix ../../experience-builder-sdk && npm run build",
+    "build:vercel": "npm run build --prefix ../../core && npm run build --prefix ../../components && npm run build --prefix ../../visual-editor && npm run build --prefix ../../experience-builder-sdk && npm run build",
     "lint": "eslint src --ext '.ts,.tsx,.js,.jsx' --max-warnings 0 --ignore-path ../../../.eslintignore",
     "lint:fix": "eslint src --ext '.ts,.tsx,.js,.jsx' --fix",
     "preview": "vite preview",


### PR DESCRIPTION
## Purpose

This is a small change that has annoyed me for a long time.

The real purpose for making this change is I want to kick off a fresh deployment for the react-vite test app in vercel to see if it will update the SDK for this hosted app running in prod.
