### PR TITLE
fix: rename editorWrapperWidth option to wrapContainerWidth [ALT-1358]

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -113,7 +113,7 @@ export type ComponentRegistration = {
     /** @deprecated use wrapContainer instead */
     wrapContainerTag?: keyof JSX.IntrinsicElements;
     wrapContainer?: keyof JSX.IntrinsicElements | React.ReactElement;
-    editorWrapperWidth?: React.CSSProperties['width'];
+    wrapContainerWidth?: React.CSSProperties['width'];
   };
 };
 

--- a/packages/templates/react-vite-ts/.gitignore
+++ b/packages/templates/react-vite-ts/.gitignore
@@ -22,3 +22,6 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+# TS cache
+*.tsbuildinfo

--- a/packages/test-apps/react-vite/src/studio-config.ts
+++ b/packages/test-apps/react-vite/src/studio-config.ts
@@ -16,7 +16,7 @@ defineComponents([
       variables: {},
     },
     options: {
-      editorWrapperWidth: '50%',
+      wrapContainerWidth: '50%',
     },
   },
   {

--- a/packages/visual-editor/src/hooks/useComponentProps.spec.ts
+++ b/packages/visual-editor/src/hooks/useComponentProps.spec.ts
@@ -267,7 +267,7 @@ describe('useComponentProps', () => {
     };
 
     ['50%', '100%'].forEach((width) => {
-      it(`should set the wrapper width to ${width} using the component registration option editorWrapperWidth`, () => {
+      it(`should set the wrapper width to ${width} using the wrapContainerWidth option`, () => {
         const { result } = renderHook(() =>
           useComponentProps({
             node,
@@ -276,14 +276,14 @@ describe('useComponentProps', () => {
             renderDropzone,
             definition,
             userIsDragging,
-            options: { editorWrapperWidth: width },
+            options: { wrapContainerWidth: width },
           }),
         );
 
-        // The wrapper width should be set to the editorWrapperWidth
+        // The wrapper width should be set to the wrapContainerWidth value
         expect(result.current.wrapperStyles.width).toEqual(width);
 
-        // The component width should be set to 100% !important to fill the wrapper
+        // The component width should be set to 100% to fill the wrapper
         expect(result.current.componentStyles.width).toEqual('100%');
       });
     });

--- a/packages/visual-editor/src/hooks/useComponentProps.ts
+++ b/packages/visual-editor/src/hooks/useComponentProps.ts
@@ -227,7 +227,7 @@ export const useComponentProps = ({
 
   // Move size styles to the wrapping div and override the component styles
   const overrideStyles: CSSProperties = {};
-  const wrapperStyles: CSSProperties = { width: options?.editorWrapperWidth };
+  const wrapperStyles: CSSProperties = { width: options?.wrapContainerWidth };
 
   if (requiresDragWrapper) {
     if (cfStyles.width) wrapperStyles.width = cfStyles.width;


### PR DESCRIPTION
## Purpose

This is a fast follow change for #800 to rename the `editorWrapperWidth` option to `wrapContainerWidth` so its consistent with the other options like `wrapComponent` (boolean) and `wrapContainer` (react element)
