### PR TITLE
fix: handle leaking dragProps []

### DIFF
--- a/packages/components/src/components/Button/Button.tsx
+++ b/packages/components/src/components/Button/Button.tsx
@@ -92,6 +92,7 @@ export const Button: React.FC<ButtonProps> = ({
     </button>
   );
 
+  // FIXME: Wrapping <button> with <a> is not ARIA conform. Instead, <a> should look like a button.
   return url ? (
     <a href={url} target={target}>
       {button}

--- a/packages/components/src/components/Divider/ContentfulDivider.tsx
+++ b/packages/components/src/components/Divider/ContentfulDivider.tsx
@@ -3,9 +3,15 @@ import './ContentfulDivider.css';
 
 export type ContentfulDividerProps = {
   className?: string;
+  dragProps?: unknown;
 };
 
-export const ContentfulDivider = ({ className = '', ...props }: ContentfulDividerProps) => {
+export const ContentfulDivider = ({
+  className = '',
+  // We have to exclude this explicitly from rendering as withComponentWrapper is not used
+  dragProps: _,
+  ...props
+}: ContentfulDividerProps) => {
   return (
     <div className="cf-divider" {...props}>
       <hr className={className} />

--- a/packages/experience-builder-sdk/src/core/componentRegistry.ts
+++ b/packages/experience-builder-sdk/src/core/componentRegistry.ts
@@ -136,6 +136,7 @@ const DEFAULT_COMPONENT_REGISTRATIONS = {
     },
   }),
   divider: {
+    // Don't wrap this component `withComponentWrapper`. Need to explicitly ignore dragProps
     component: Components.ContentfulDivider,
     definition: dividerDefinition,
     options: {


### PR DESCRIPTION
## Purpose

![Screenshot 2024-10-24 at 13 34 48](https://github.com/user-attachments/assets/35bef064-ea18-4d7d-b0c9-19926e0431e0)

We're getting this warning when rendering dividers in the canvas. This is because, we're not using `withComponentWrapper`. I'm not sure why but that might be something that @ryunsong-contentful could answer as I don't have context on the creation of the divider.