### PR TITLE
fix: improve performance of styles generation []

### DIFF
--- a/packages/visual-editor/src/hooks/useComponentProps.ts
+++ b/packages/visual-editor/src/hooks/useComponentProps.ts
@@ -225,38 +225,55 @@ export const useComponentProps = ({
   const isSingleColumn = node?.data.blockId === CONTENTFUL_COMPONENTS.columns.id;
   const isStructureComponent = isContentfulStructureComponent(node?.data.blockId);
 
-  // Move size styles to the wrapping div and override the component styles
-  const overrideStyles: CSSProperties = {};
-  const wrapperStyles: CSSProperties = { width: options?.wrapContainerWidth };
+  const { overrideStyles, wrapperStyles } = useMemo(() => {
+    // Move size styles to the wrapping div and override the component styles
+    const overrideStyles: CSSProperties = {};
+    const wrapperStyles: CSSProperties = { width: options?.wrapContainerWidth };
 
-  if (requiresDragWrapper) {
-    if (cfStyles.width) wrapperStyles.width = cfStyles.width;
-    if (cfStyles.height) wrapperStyles.height = cfStyles.height;
-    if (cfStyles.maxWidth) wrapperStyles.maxWidth = cfStyles.maxWidth;
-    if (cfStyles.margin) wrapperStyles.margin = cfStyles.margin;
-  }
+    if (requiresDragWrapper) {
+      if (cfStyles.width) wrapperStyles.width = cfStyles.width;
+      if (cfStyles.height) wrapperStyles.height = cfStyles.height;
+      if (cfStyles.maxWidth) wrapperStyles.maxWidth = cfStyles.maxWidth;
+      if (cfStyles.margin) wrapperStyles.margin = cfStyles.margin;
+    }
 
-  // Override component styles to fill the wrapper
-  if (wrapperStyles.width) overrideStyles.width = '100%';
-  if (wrapperStyles.height) overrideStyles.height = '100%';
-  if (wrapperStyles.margin) overrideStyles.margin = '0';
-  if (wrapperStyles.maxWidth) overrideStyles.maxWidth = 'none';
+    // Override component styles to fill the wrapper
+    if (wrapperStyles.width) overrideStyles.width = '100%';
+    if (wrapperStyles.height) overrideStyles.height = '100%';
+    if (wrapperStyles.margin) overrideStyles.margin = '0';
+    if (wrapperStyles.maxWidth) overrideStyles.maxWidth = 'none';
+
+    return { overrideStyles, wrapperStyles };
+  }, [cfStyles, options?.wrapContainerWidth, requiresDragWrapper]);
 
   // Styles that will be applied to the component element
-  const componentStyles = {
-    ...cfStyles,
-    ...overrideStyles,
-    ...(isEmptyZone &&
-      isStructureWithRelativeHeight(node?.data.blockId, cfStyles.height) && {
-        minHeight: EMPTY_CONTAINER_HEIGHT,
-      }),
-    ...(userIsDragging &&
-      isStructureComponent &&
-      !isSingleColumn &&
-      !isAssemblyBlock && {
-        padding: addExtraDropzonePadding(cfStyles.padding?.toString() || '0 0 0 0'),
-      }),
-  };
+  // This has to be memoized to avoid recreating the styles in useEditorModeClassName on every render
+  const componentStyles = useMemo(
+    () => ({
+      ...cfStyles,
+      ...overrideStyles,
+      ...(isEmptyZone &&
+        isStructureWithRelativeHeight(node?.data.blockId, cfStyles.height) && {
+          minHeight: EMPTY_CONTAINER_HEIGHT,
+        }),
+      ...(userIsDragging &&
+        isStructureComponent &&
+        !isSingleColumn &&
+        !isAssemblyBlock && {
+          padding: addExtraDropzonePadding(cfStyles.padding?.toString() || '0 0 0 0'),
+        }),
+    }),
+    [
+      cfStyles,
+      isAssemblyBlock,
+      isEmptyZone,
+      isSingleColumn,
+      isStructureComponent,
+      node?.data.blockId,
+      overrideStyles,
+      userIsDragging,
+    ],
+  );
 
   const componentClass = useEditorModeClassName({
     styles: componentStyles,

--- a/packages/visual-editor/src/hooks/useEditorModeClassName.spec.ts
+++ b/packages/visual-editor/src/hooks/useEditorModeClassName.spec.ts
@@ -2,11 +2,10 @@ import { CSSProperties } from 'react';
 import { renderHook } from '@testing-library/react';
 import { useEditorModeClassName } from './useEditorModeClassName';
 import { describe, it, expect, vi } from 'vitest';
+import { buildStyleTag } from '@contentful/experiences-core';
 
 describe('useEditorModeClassName', () => {
-  // TODO: address me
-  // the test doesn't reflect the reality
-  // because buildCfStyles function never returns an empty object
+  // This case is currently not occurring but the function is ensured to handle this case correctly
   describe('when given an empty set of styles', () => {
     it('should yield an empty class name', () => {
       const { result } = renderHook(() =>
@@ -41,6 +40,34 @@ describe('useEditorModeClassName', () => {
 
       expect(querySelectorSpy).toHaveBeenCalledWith(`[data-cf-styles="${result.current}"]`);
       expect(innerHTMLSetterMock).toHaveBeenCalledWith(expect.any(String));
+    });
+  });
+
+  describe('when the node id is missing', () => {
+    const previousStyles = { color: 'red' };
+    const previousClassName = buildStyleTag({ styles: previousStyles, nodeId: '' })[0];
+    const nextStyles = { color: 'blue' };
+    const nextClassName = buildStyleTag({ styles: nextStyles, nodeId: '' })[0];
+
+    it('should remove an outdated style tag', () => {
+      const querySelectorSpy = vi.spyOn(document, 'querySelector');
+      const removeChildSpy = vi.spyOn(document.head, 'removeChild').mockImplementation(vi.fn());
+      const fakeStyleNode = document.createElement('style');
+
+      const { rerender } = renderHook((styles: typeof previousStyles = previousStyles) =>
+        useEditorModeClassName({ styles, nodeId: '' }),
+      );
+      expect(querySelectorSpy).toHaveBeenCalledWith(`[data-cf-styles="${previousClassName}"]`);
+
+      querySelectorSpy.mockImplementation((selector) => {
+        if (selector.includes(previousClassName)) {
+          return fakeStyleNode;
+        }
+        return null;
+      });
+      rerender(nextStyles);
+      expect(querySelectorSpy).toHaveBeenCalledWith(`[data-cf-styles="${nextClassName}"]`);
+      expect(removeChildSpy).toHaveBeenCalledWith(fakeStyleNode);
     });
   });
 });

--- a/packages/visual-editor/src/hooks/useEditorModeClassName.ts
+++ b/packages/visual-editor/src/hooks/useEditorModeClassName.ts
@@ -23,22 +23,35 @@ export const useEditorModeClassName = ({
       return;
     }
 
-    const [className, styleRule] = buildStyleTag({ styles, nodeId });
+    const [newClassName, styleRules] = buildStyleTag({ styles, nodeId });
+    addStylesTag(newClassName, styleRules);
 
-    setClassName(className);
-
-    const existingTag = document.querySelector(`[data-cf-styles="${className}"]`);
-
-    if (existingTag) {
-      existingTag.innerHTML = styleRule;
-      return;
+    if (className !== newClassName) {
+      setClassName(newClassName);
+      // Clean up: remove outdated styles from DOM
+      removeStylesTag(className);
     }
-
-    const styleTag = document.createElement('style');
-    styleTag.dataset['cfStyles'] = className;
-
-    document.head.appendChild(styleTag).innerHTML = styleRule;
-  }, [styles, nodeId]);
+  }, [styles, nodeId, className]);
 
   return className;
+};
+
+const removeStylesTag = (className: string) => {
+  const existingTag = document.querySelector(`[data-cf-styles="${className}"]`);
+  if (existingTag) {
+    document.head.removeChild(existingTag);
+  }
+};
+
+const addStylesTag = (className: string, styleRules: string) => {
+  const existingTag = document.querySelector(`[data-cf-styles="${className}"]`);
+
+  if (existingTag) {
+    existingTag.innerHTML = styleRules;
+    return;
+  }
+
+  const styleTag = document.createElement('style');
+  styleTag.dataset['cfStyles'] = className;
+  document.head.appendChild(styleTag).innerHTML = styleRules;
 };


### PR DESCRIPTION
## Purpose

When [this SDK error](https://contentful.sentry.io/issues/6019374985/?alert_rule_id=15048860&alert_type=issue&notification_uuid=5d6c2561-db7c-47ce-a2d7-ef5ebaf293b5&project=8049&referrer=slack) popped up today, I started looking into the code where this error originated from. It seems like, we recreate the styles too often.

## Approach

In `useComponentProps` we re-create the styles map `componentStyles` on every render which in turn will add them to the DOM again and again on every render. I added a `useMemo` to only regenerate the styles map when necessary and there save us from changing the DOM styles on every render.

Additionally, I improved the logic `useEditorModeClassName` to clean up old styles if they are not used anymore. This is only relevant to nodes without IDs which theoretically shouldn't happen but I wanted make the hook save against this case, so I added a `removeStylesTag` logic.