### PR TITLE
fix: dont shrink button height when empty [SPA-2459]

### DIFF
--- a/packages/components/src/components/Button/Button.css
+++ b/packages/components/src/components/Button/Button.css
@@ -1,0 +1,5 @@
+/* If the label is empty, still render the normal height by adding this pseudo element */
+.cf-button:empty::before {
+  content: '';
+  display: inline-block;
+}

--- a/packages/components/src/components/Button/Button.tsx
+++ b/packages/components/src/components/Button/Button.tsx
@@ -1,5 +1,6 @@
 import { combineClasses } from '@/utils/combineClasses';
 import React from 'react';
+import './Button.css';
 
 export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   /**


### PR DESCRIPTION
## Purpose

When the label value of a button is empty (explicitly set via manual binding tab), the button rendered as a small square.

<img width="47" alt="Screenshot 2024-10-28 at 14 05 12" src="https://github.com/user-attachments/assets/71b684ff-a25b-41ba-9988-587471371926">
<img width="746" alt="Screenshot 2024-10-28 at 14 05 09" src="https://github.com/user-attachments/assets/9e959b59-c9a7-475d-bb18-7315981857da">

## Approach
To ensure that the button always renders in the correct height with a normal line height, we add a pseudo element when it's `:empty`

<img width="41" alt="Screenshot 2024-10-28 at 14 07 08" src="https://github.com/user-attachments/assets/d64f547c-04ae-4fd0-a250-e2cc27de553b">
