### PR TITLE
test: add optional locale param to react-vite test app [SPA-2467]

### DIFF
--- a/packages/experience-builder-sdk/src/hooks/useClassName.spec.ts
+++ b/packages/experience-builder-sdk/src/hooks/useClassName.spec.ts
@@ -3,22 +3,6 @@ import { useClassName } from './useClassName';
 import { ComponentTreeNode } from '@contentful/experiences-core/types';
 
 describe('useClassName', () => {
-  // This case is currently not occurring but the function is ensured to handle this case correctly
-  describe('when given an empty set of styles', () => {
-    it('should yield an empty class name', () => {
-      const testNode: ComponentTreeNode = {
-        definitionId: 'test-definition-id',
-        children: [],
-        variables: {},
-      };
-      const testProps = {};
-
-      const { result } = renderHook(() => useClassName({ node: testNode, props: testProps }));
-
-      expect(result.current).toStrictEqual('');
-    });
-  });
-
   describe('when styles are given', () => {
     const testNode: ComponentTreeNode = {
       definitionId: 'test-definition-id',

--- a/packages/experience-builder-sdk/src/hooks/useClassName.spec.ts
+++ b/packages/experience-builder-sdk/src/hooks/useClassName.spec.ts
@@ -3,10 +3,8 @@ import { useClassName } from './useClassName';
 import { ComponentTreeNode } from '@contentful/experiences-core/types';
 
 describe('useClassName', () => {
-  // TODO: address me
-  // skipped because the test incorrectly reflects the reality.
-  // buildCfStyles function never returns an empty object
-  describe.skip('when given an empty set of styles', () => {
+  // This case is currently not occurring but the function is ensured to handle this case correctly
+  describe('when given an empty set of styles', () => {
     it('should yield an empty class name', () => {
       const testNode: ComponentTreeNode = {
         definitionId: 'test-definition-id',

--- a/packages/test-apps/react-vite/src/App.tsx
+++ b/packages/test-apps/react-vite/src/App.tsx
@@ -15,6 +15,10 @@ const router = createBrowserRouter([
     path: '/:slug',
     element: <Page />,
   },
+  {
+    path: '/:locale/:slug',
+    element: <Page />,
+  },
 ]);
 
 function App() {

--- a/packages/test-apps/react-vite/src/Page.tsx
+++ b/packages/test-apps/react-vite/src/Page.tsx
@@ -6,8 +6,8 @@ import { useContentfulClient } from './hooks/useContentfulClient';
 import { useContentfulConfig } from './hooks/useContentfulConfig';
 
 export default function Page() {
-  const { slug = 'home-page' } = useParams<{ slug: string }>();
-  const localeCode = 'en-US';
+  const { slug = 'home-page', locale } = useParams<{ slug: string; locale?: string }>();
+  const localeCode = locale ?? 'en-US';
   const { config } = useContentfulConfig();
   const { client } = useContentfulClient();
 


### PR DESCRIPTION
## Purpose

You can now use the locale as URL param with the vite test app by defining the following preview URL:
`http://localhost:5173/{locale}/{entry.fields.slug}`

It will still support the previous version as well.