### PR TITLE
fix: change container/columns default Margin value [ALT-1388]

### DIFF
--- a/packages/core/src/definitions/styles.ts
+++ b/packages/core/src/definitions/styles.ts
@@ -343,7 +343,8 @@ export const containerBuiltInStyles: VariableDefinitions = {
     type: 'Text',
     group: 'style',
     description: 'The margin of the container',
-    defaultValue: '0 auto 0 auto',
+    // Note: The UI overwrites '0 Auto 0 Auto' as the default value for top-level containers
+    defaultValue: '0 0 0 0',
   },
   cfMaxWidth: {
     displayName: 'Max Width',
@@ -504,7 +505,8 @@ export const columnsBuiltInStyles: VariableDefinitions = {
     type: 'Text',
     group: 'style',
     description: 'The margin of the columns',
-    defaultValue: '0 auto 0 auto',
+    // Note: The UI overwrites '0 Auto 0 Auto' as the default value for top-level columns
+    defaultValue: '0 0 0 0',
   },
   cfWidth: {
     displayName: 'Width',


### PR DESCRIPTION
## Purpose

Changes the Container and Columns default margin value back to `0 0 0 0` and added a comment to mention that the UI overrides the value to `0 Auto 0 Auto` when these components are added at the root/top-level

