### PR TITLE
fix: use the correct description for hyperlink behaviour property [SPA-2398]

### DIFF
--- a/packages/core/src/definitions/styles.ts
+++ b/packages/core/src/definitions/styles.ts
@@ -153,7 +153,7 @@ export const builtInStyles: VariableDefinitions = {
     displayName: 'Hyperlink behaviour',
     type: 'Boolean',
     defaultValue: false,
-    description: 'To open hyperlink in new Tab or not',
+    description: 'Open in new tab',
   },
 };
 


### PR DESCRIPTION
## Purpose

As we're using the description field for boolean content properties, the hyperlink behaviour is now having the correct description "Open in new tab"