### PR TITLE
fix: dropzone hitboxes when moving patterns on the canvas [ALT-1391]

### DIFF
--- a/packages/visual-editor/src/components/DraggableBlock/styles.module.css
+++ b/packages/visual-editor/src/components/DraggableBlock/styles.module.css
@@ -26,13 +26,13 @@
   outline-offset: -1px;
 }
 
+.DraggableComponent.isDragging.Dropzone {
+  pointer-events: all;
+}
+
 .Dropzone.isAssembly {
   width: 100%;
   height: 100%;
-}
-
-.DraggableComponent:is(.Dropzone).isDragging {
-  pointer-events: all;
 }
 
 .isRoot,
@@ -66,7 +66,7 @@
 .DraggableClone,
 .DropzoneClone *,
 .DraggableClone * {
-  pointer-events: none;
+  pointer-events: none !important;
 }
 
 .DraggableComponent:not(.isDragging) :not(.DraggableComponent) {


### PR DESCRIPTION
## Purpose

This css change makes it so moving a pattern on the canvas will activate the dropzone hitboxes more reliably.

## Approach

While debugging the issue, I noticed that the `e.target` in `VisualEditorRoot` was constantly reporting the `DraggableClone` element as the mouse move target, which would then fail to find a closest Dropzone element to the Clone. This would only happen when moving a Pattern on the canvas.

https://github.com/contentful/experience-builder/blob/5057733477861701f2ec6fc06cb16f36c0b0333d/packages/visual-editor/src/components/VisualEditorRoot.tsx#L30

I noticed when dragging a Pattern and quickly moving my mouse back and forth over the Dropzone container, the mouse pointer position would desync and "breaks free" from the Clone element's position, and then the `e.target` would successfully find the closest Dropzone element.

Essentially the fix was to slap an `!important` on the `pointer-events: none` rule targeting drag/drop Clone elements.  I tried to find a way to change other css rules to avoid needing to use `!important` but I couldn't find a working combination for that approach.
