### PR TITLE
feat: resolve entries that are embedded into bound entries [ALT-1368]

### DIFF
--- a/packages/core/src/fetchers/fetchAllEntities.spec.ts
+++ b/packages/core/src/fetchers/fetchAllEntities.spec.ts
@@ -84,6 +84,7 @@ describe('fetchAllEntries', () => {
     const result = await fetchAllEntries(params);
 
     expect(mockClient.withoutLinkResolution.getEntries).toHaveBeenNthCalledWith(11, {
+      include: 2,
       'sys.id[in]': params.ids,
       locale: 'en-US',
       skip: 90,
@@ -111,6 +112,7 @@ describe('fetchAllEntries', () => {
     }
 
     expect(mockClient.withoutLinkResolution.getEntries).toHaveBeenNthCalledWith(5, {
+      include: 2,
       'sys.id[in]': params.ids,
       locale: 'en-US',
       skip: 0,

--- a/packages/core/src/fetchers/fetchAllEntities.ts
+++ b/packages/core/src/fetchers/fetchAllEntities.ts
@@ -43,7 +43,7 @@ export const fetchAllEntries = async ({
       };
     }
 
-    const query = { 'sys.id[in]': ids, locale, limit, skip };
+    const query = { 'sys.id[in]': ids, locale, limit, skip, include: 2 as 2 | undefined };
 
     const {
       items,

--- a/packages/core/src/fetchers/fetchReferencedEntities.spec.ts
+++ b/packages/core/src/fetchers/fetchReferencedEntities.spec.ts
@@ -95,6 +95,7 @@ describe('fetchReferencedEntities', () => {
 
     expect(mockClient.withoutLinkResolution.getEntries).toHaveBeenCalledWith({
       locale: 'en-US',
+      include: 2,
       'sys.id[in]': entries.map((entry) => entry.sys.id),
       limit: 100,
       skip: 0,

--- a/packages/core/src/test/__fixtures__/entities.ts
+++ b/packages/core/src/test/__fixtures__/entities.ts
@@ -6,6 +6,7 @@ export const entityIds = {
   ENTRY1: 'entry1',
   ENTRY2: 'entry2',
   ENTRY_WITH_EMBEDDED_ENTRY: 'entryWithEmbeddedEntry',
+  ENTRY_WITH_EMBEDDED_ENTRIES: 'entryWithEmbeddedEntries',
   ENTRY_WITH_ANOTHER_EMBEDDED_ENTRY: 'entryWithAnotherEmbeddedEntry',
   ENTRY_WITH_EMBEDDED_ENTRY_IN_RICH_TEXT: 'entryWithEmbeddedEntryInRichText',
   ENTRY_WITH_EMBEDDED_ASSET_IN_RICH_TEXT: 'entryWithEmbeddedAssetInRichText',
@@ -140,6 +141,59 @@ export const entryWithEmbeddedEntry: Entry = {
   },
 };
 
+export const entryWithEmbeddedEntries: Entry = {
+  sys: {
+    id: entityIds.ENTRY_WITH_EMBEDDED_ENTRIES,
+    type: 'Entry',
+    contentType: {
+      sys: {
+        id: 'bar',
+        type: 'Link',
+        linkType: 'ContentType',
+      },
+    },
+    createdAt: '2020-01-01T00:00:00.000Z',
+    updatedAt: '2020-01-01T00:00:00.000Z',
+    revision: 10,
+    space: {
+      sys: {
+        type: 'Link',
+        linkType: 'Space',
+        id: 'cfexampleapi',
+      },
+    },
+    environment: {
+      sys: {
+        id: 'master',
+        type: 'Link',
+        linkType: 'Environment',
+      },
+    },
+    locale: 'en-US',
+  },
+  fields: {
+    referencedEntries: [
+      {
+        sys: {
+          type: 'Link',
+          linkType: 'Entry',
+          id: entityIds.ENTRY_WITH_EMBEDDED_ENTRY,
+        },
+      },
+      {
+        sys: {
+          type: 'Link',
+          linkType: 'Entry',
+          id: entityIds.ENTRY_WITH_ANOTHER_EMBEDDED_ENTRY,
+        },
+      },
+    ],
+  },
+  metadata: {
+    tags: [],
+  },
+};
+
 export const entryWithAnotherEmbeddedEntry: Entry = {
   sys: {
     id: entityIds.ENTRY_WITH_ANOTHER_EMBEDDED_ENTRY,
@@ -175,7 +229,7 @@ export const entryWithAnotherEmbeddedEntry: Entry = {
       sys: {
         type: 'Link',
         linkType: 'Entry',
-        id: entityIds.ENTRY1,
+        id: entityIds.ENTRY2,
       },
     },
   },

--- a/packages/core/src/test/__fixtures__/entities.ts
+++ b/packages/core/src/test/__fixtures__/entities.ts
@@ -5,6 +5,8 @@ import type { PartialDeep } from 'type-fest';
 export const entityIds = {
   ENTRY1: 'entry1',
   ENTRY2: 'entry2',
+  ENTRY_WITH_EMBEDDED_ENTRY_IN_RICH_TEXT: 'entryWithEmbeddedEntryInRichText',
+  ENTRY_WITH_EMBEDDED_ASSET_IN_RICH_TEXT: 'entryWithEmbeddedAssetInRichText',
   ASSET1: 'asset1',
 };
 export const entries: Entry[] = [
@@ -90,6 +92,118 @@ export const entries: Entry[] = [
     },
   },
 ];
+
+export const entryWithEmbeddedEntryInRichText: Entry = {
+  sys: {
+    id: entityIds.ENTRY_WITH_EMBEDDED_ENTRY_IN_RICH_TEXT,
+    type: 'Entry',
+    contentType: {
+      sys: {
+        id: 'bar',
+        type: 'Link',
+        linkType: 'ContentType',
+      },
+    },
+    createdAt: '2020-01-01T00:00:00.000Z',
+    updatedAt: '2020-01-01T00:00:00.000Z',
+    revision: 10,
+    space: {
+      sys: {
+        type: 'Link',
+        linkType: 'Space',
+        id: 'cfexampleapi',
+      },
+    },
+    environment: {
+      sys: {
+        id: 'master',
+        type: 'Link',
+        linkType: 'Environment',
+      },
+    },
+    locale: 'en-US',
+  },
+  fields: {
+    body: {
+      nodeType: 'document',
+      data: {},
+      content: [
+        {
+          nodeType: 'embedded-entry-block',
+          data: {
+            target: {
+              sys: {
+                id: entityIds.ENTRY1,
+                type: 'Link',
+                linkType: 'Entry',
+              },
+            },
+          },
+          content: [],
+        },
+      ],
+    },
+  },
+  metadata: {
+    tags: [],
+  },
+};
+export const entryWithEmbeddedAssetInRichText: Entry = {
+  sys: {
+    id: entityIds.ENTRY_WITH_EMBEDDED_ASSET_IN_RICH_TEXT,
+    type: 'Entry',
+    contentType: {
+      sys: {
+        id: 'bar',
+        type: 'Link',
+        linkType: 'ContentType',
+      },
+    },
+    createdAt: '2020-01-01T00:00:00.000Z',
+    updatedAt: '2020-01-01T00:00:00.000Z',
+    revision: 10,
+    space: {
+      sys: {
+        type: 'Link',
+        linkType: 'Space',
+        id: 'cfexampleapi',
+      },
+    },
+    environment: {
+      sys: {
+        id: 'master',
+        type: 'Link',
+        linkType: 'Environment',
+      },
+    },
+    locale: 'en-US',
+  },
+  fields: {
+    body: {
+      nodeType: 'document',
+      data: {},
+      content: [
+        {
+          nodeType: 'embedded-asset-block',
+          data: {
+            target: {
+              sys: {
+                id: entityIds.ASSET1,
+                type: 'Link',
+                linkType: 'Asset',
+              },
+            },
+          },
+          content: [],
+        },
+      ],
+    },
+  },
+  metadata: {
+    tags: [],
+  },
+};
+
 export const assets: Asset[] = [
   {
     sys: {

--- a/packages/core/src/test/__fixtures__/entities.ts
+++ b/packages/core/src/test/__fixtures__/entities.ts
@@ -5,10 +5,13 @@ import type { PartialDeep } from 'type-fest';
 export const entityIds = {
   ENTRY1: 'entry1',
   ENTRY2: 'entry2',
+  ENTRY_WITH_EMBEDDED_ENTRY: 'entryWithEmbeddedEntry',
+  ENTRY_WITH_ANOTHER_EMBEDDED_ENTRY: 'entryWithAnotherEmbeddedEntry',
   ENTRY_WITH_EMBEDDED_ENTRY_IN_RICH_TEXT: 'entryWithEmbeddedEntryInRichText',
   ENTRY_WITH_EMBEDDED_ASSET_IN_RICH_TEXT: 'entryWithEmbeddedAssetInRichText',
   ASSET1: 'asset1',
 };
+
 export const entries: Entry[] = [
   {
     sys: {
@@ -93,6 +96,94 @@ export const entries: Entry[] = [
   },
 ];
 
+export const entryWithEmbeddedEntry: Entry = {
+  sys: {
+    id: entityIds.ENTRY_WITH_EMBEDDED_ENTRY,
+    type: 'Entry',
+    contentType: {
+      sys: {
+        id: 'bar',
+        type: 'Link',
+        linkType: 'ContentType',
+      },
+    },
+    createdAt: '2020-01-01T00:00:00.000Z',
+    updatedAt: '2020-01-01T00:00:00.000Z',
+    revision: 10,
+    space: {
+      sys: {
+        type: 'Link',
+        linkType: 'Space',
+        id: 'cfexampleapi',
+      },
+    },
+    environment: {
+      sys: {
+        id: 'master',
+        type: 'Link',
+        linkType: 'Environment',
+      },
+    },
+    locale: 'en-US',
+  },
+  fields: {
+    referencedEntry: {
+      sys: {
+        type: 'Link',
+        linkType: 'Entry',
+        id: entityIds.ENTRY_WITH_ANOTHER_EMBEDDED_ENTRY,
+      },
+    },
+  },
+  metadata: {
+    tags: [],
+  },
+};
+
+export const entryWithAnotherEmbeddedEntry: Entry = {
+  sys: {
+    id: entityIds.ENTRY_WITH_ANOTHER_EMBEDDED_ENTRY,
+    type: 'Entry',
+    contentType: {
+      sys: {
+        id: 'bar',
+        type: 'Link',
+        linkType: 'ContentType',
+      },
+    },
+    createdAt: '2020-01-01T00:00:00.000Z',
+    updatedAt: '2020-01-01T00:00:00.000Z',
+    revision: 10,
+    space: {
+      sys: {
+        type: 'Link',
+        linkType: 'Space',
+        id: 'cfexampleapi',
+      },
+    },
+    environment: {
+      sys: {
+        id: 'master',
+        type: 'Link',
+        linkType: 'Environment',
+      },
+    },
+    locale: 'en-US',
+  },
+  fields: {
+    referencedEntry: {
+      sys: {
+        type: 'Link',
+        linkType: 'Entry',
+        id: entityIds.ENTRY1,
+      },
+    },
+  },
+  metadata: {
+    tags: [],
+  },
+};
+
 export const entryWithEmbeddedEntryInRichText: Entry = {
   sys: {
     id: entityIds.ENTRY_WITH_EMBEDDED_ENTRY_IN_RICH_TEXT,
@@ -148,6 +239,7 @@ export const entryWithEmbeddedEntryInRichText: Entry = {
     tags: [],
   },
 };
+
 export const entryWithEmbeddedAssetInRichText: Entry = {
   sys: {
     id: entityIds.ENTRY_WITH_EMBEDDED_ASSET_IN_RICH_TEXT,

--- a/packages/core/src/utils/transformers/getArrayValue.ts
+++ b/packages/core/src/utils/transformers/getArrayValue.ts
@@ -26,7 +26,24 @@ export function getArrayValue(
     if (typeof value === 'string') {
       return value;
     } else if (value?.sys?.type === 'Link') {
-      return entityStore.getEntityFromLink(value);
+      const resolvedEntity = entityStore.getEntityFromLink(value);
+      if (!resolvedEntity) {
+        return;
+      }
+      //resolve any embedded links - we currently only support 2 levels deep
+      const fieldKeys = Object.keys(resolvedEntity.fields || {});
+      fieldKeys.forEach((fieldKey) => {
+        const field = resolvedEntity.fields[fieldKey];
+        if (field && field.sys?.type === 'Link') {
+          const entity = entityStore.getEntityFromLink(field);
+          if (entity) {
+            resolvedEntity.fields[fieldKey] = entity;
+          }
+        }
+      });
+
+      return resolvedEntity;
+      // return entityStore.getEntityFromLink(value);
     } else {
       console.warn(`Expected value to be a string or Link, but got: ${JSON.stringify(value)}`);
       return undefined;

--- a/packages/core/src/utils/transformers/getArrayValue.ts
+++ b/packages/core/src/utils/transformers/getArrayValue.ts
@@ -31,9 +31,8 @@ export function getArrayValue(
         return;
       }
       //resolve any embedded links - we currently only support 2 levels deep
-      const fieldKeys = Object.keys(resolvedEntity.fields || {});
-      fieldKeys.forEach((fieldKey) => {
-        const field = resolvedEntity.fields[fieldKey];
+      const fields = resolvedEntity.fields || {};
+      Object.entries(fields).forEach(([fieldKey, field]) => {
         if (field && field.sys?.type === 'Link') {
           const entity = entityStore.getEntityFromLink(field);
           if (entity) {
@@ -43,7 +42,6 @@ export function getArrayValue(
       });
 
       return resolvedEntity;
-      // return entityStore.getEntityFromLink(value);
     } else {
       console.warn(`Expected value to be a string or Link, but got: ${JSON.stringify(value)}`);
       return undefined;

--- a/packages/core/src/utils/transformers/getResolvedEntryFromLink.ts
+++ b/packages/core/src/utils/transformers/getResolvedEntryFromLink.ts
@@ -20,5 +20,22 @@ export function getResolvedEntryFromLink(
 
   //Look up the reference in the entity store
   const resolvedEntity = entityStore.getEntityFromLink(value);
+
+  if (!resolvedEntity) {
+    return;
+  }
+
+  //resolve any embedded links - we currently only support 2 levels deep
+  const fieldKeys = Object.keys(resolvedEntity.fields || {});
+  fieldKeys.forEach((fieldKey) => {
+    const field = resolvedEntity.fields[fieldKey];
+    if (field && field.sys?.type === 'Link') {
+      const entity = entityStore.getEntityFromLink(field);
+      if (entity) {
+        resolvedEntity.fields[fieldKey] = entity;
+      }
+    }
+  });
+
   return resolvedEntity;
 }

--- a/packages/core/src/utils/transformers/getResolvedEntryFromLink.ts
+++ b/packages/core/src/utils/transformers/getResolvedEntryFromLink.ts
@@ -26,9 +26,8 @@ export function getResolvedEntryFromLink(
   }
 
   //resolve any embedded links - we currently only support 2 levels deep
-  const fieldKeys = Object.keys(resolvedEntity.fields || {});
-  fieldKeys.forEach((fieldKey) => {
-    const field = resolvedEntity.fields[fieldKey];
+  const fields = resolvedEntity.fields || {};
+  Object.entries(fields).forEach(([fieldKey, field]) => {
     if (field && field.sys?.type === 'Link') {
       const entity = entityStore.getEntityFromLink(field);
       if (entity) {

--- a/packages/core/src/utils/transformers/getResolvedEntryFromLink.ts
+++ b/packages/core/src/utils/transformers/getResolvedEntryFromLink.ts
@@ -34,6 +34,16 @@ export function getResolvedEntryFromLink(
       if (entity) {
         resolvedEntity.fields[fieldKey] = entity;
       }
+    } else if (field && Array.isArray(field)) {
+      resolvedEntity.fields[fieldKey] = field.map((innerField) => {
+        if (innerField && innerField.sys?.type === 'Link') {
+          const entity = entityStore.getEntityFromLink(innerField);
+          if (entity) {
+            return entity;
+          }
+        }
+        return innerField;
+      });
     }
   });
 

--- a/packages/core/src/utils/transformers/transformBoundContentValue.spec.ts
+++ b/packages/core/src/utils/transformers/transformBoundContentValue.spec.ts
@@ -9,6 +9,7 @@ import {
   entryWithEmbeddedEntryInRichText,
   entryWithEmbeddedEntry,
   entryWithAnotherEmbeddedEntry,
+  entryWithEmbeddedEntries,
 } from '@/test/__fixtures__/entities';
 import {
   BoundValue,
@@ -23,6 +24,7 @@ const entityStore = new EditorModeEntityStore({
   entities: [
     ...entities,
     entryWithEmbeddedEntry,
+    entryWithEmbeddedEntries,
     entryWithAnotherEmbeddedEntry,
     entryWithEmbeddedEntryInRichText,
     entryWithEmbeddedAssetInRichText,
@@ -47,6 +49,9 @@ const componentDefinition: ComponentDefinition = {
     image: {
       type: 'Media',
     },
+    referencedEntries: {
+      type: 'Array',
+    },
   },
 };
 
@@ -69,7 +74,11 @@ const variables: ComponentTreeNode['variables'] = {
   },
   referencedEntry: {
     type: 'BoundValue',
-    path: '/uuid3/fields/referencedEntry/~locale',
+    path: '/uuid4/fields/referencedEntry/~locale',
+  },
+  referencedEntries: {
+    type: 'BoundValue',
+    path: '/uuid5/fields/referencedEntries/~locale',
   },
 };
 
@@ -321,7 +330,38 @@ describe('transformBoundContentValue', () => {
         path,
       );
       // @ts-expect-error -- deep referenced entry doesn't type well
-      expect(result?.fields.referencedEntry.fields.title).toEqual('Entry 1');
+      expect(result?.fields.referencedEntry.fields.title).toEqual('Entry 2');
+    });
+  });
+
+  describe('when the variable type is an "Array"', () => {
+    it('referenced entries in the array should have their references resolved', () => {
+      const variableName = 'referencedEntries';
+      const resolveDesignValue = vitest.fn();
+      const binding: UnresolvedLink<'Entry'> = {
+        sys: {
+          type: 'Link',
+          linkType: 'Entry',
+          id: entityIds.ENTRY_WITH_EMBEDDED_ENTRIES,
+        },
+      };
+
+      const path = (variables.referencedEntries as BoundValue).path;
+      const result = transformBoundContentValue(
+        variables,
+        entityStore,
+        binding,
+        resolveDesignValue,
+        variableName,
+        componentDefinition.variables.referencedEntries,
+        path,
+      );
+      // @ts-expect-error -- deep referenced entry doesn't type well
+      expect(result[0]?.fields.referencedEntry.fields.referencedEntry.fields.title).toEqual(
+        'Entry 2',
+      );
+      // @ts-expect-error -- deep referenced entry doesn't type well
+      expect(result[1]?.fields.referencedEntry.fields.title).toEqual('Entry 2');
     });
   });
 });

--- a/packages/core/src/utils/transformers/transformBoundContentValue.ts
+++ b/packages/core/src/utils/transformers/transformBoundContentValue.ts
@@ -38,7 +38,7 @@ export const transformBoundContentValue = (
         path,
       );
     case 'RichText':
-      return transformRichText(entityOrAsset, path);
+      return transformRichText(entityOrAsset, entityStore, path);
     case 'Array':
       return getArrayValue(entityOrAsset, path, entityStore);
     case 'Link':

--- a/packages/core/src/utils/transformers/transformRichText.ts
+++ b/packages/core/src/utils/transformers/transformRichText.ts
@@ -1,9 +1,11 @@
 import { BLOCKS, Document as RichTextDocument } from '@contentful/rich-text-types';
 import { getBoundValue } from './getBoundValue';
 import { Asset, Entry } from 'contentful';
+import { EntityStoreBase } from '@/entity';
 
 export const transformRichText = (
   entryOrAsset: Entry | Asset,
+  entityStore: EntityStoreBase,
   path,
 ): RichTextDocument | undefined => {
   const value = getBoundValue(entryOrAsset, path);
@@ -28,6 +30,16 @@ export const transformRichText = (
     };
   }
   if (typeof value === 'object' && value.nodeType === BLOCKS.DOCUMENT) {
+    //resolve any embedded links
+    const richTextDocument = value as RichTextDocument;
+    richTextDocument.content.forEach((node) => {
+      if (node.nodeType === BLOCKS.EMBEDDED_ENTRY && node.data.target.sys.type === 'Link') {
+        const entity = entityStore.getEntityFromLink(node.data.target);
+        if (entity) {
+          node.data.target = entity;
+        }
+      }
+    });
     return value as RichTextDocument;
   }
   return undefined;

--- a/packages/core/src/utils/transformers/transformRichText.ts
+++ b/packages/core/src/utils/transformers/transformRichText.ts
@@ -33,7 +33,10 @@ export const transformRichText = (
     //resolve any embedded links
     const richTextDocument = value as RichTextDocument;
     richTextDocument.content.forEach((node) => {
-      if (node.nodeType === BLOCKS.EMBEDDED_ENTRY && node.data.target.sys.type === 'Link') {
+      if (
+        (node.nodeType === BLOCKS.EMBEDDED_ENTRY || node.nodeType === BLOCKS.EMBEDDED_ASSET) &&
+        node.data.target.sys.type === 'Link'
+      ) {
         const entity = entityStore.getEntityFromLink(node.data.target);
         if (entity) {
           node.data.target = entity;

--- a/packages/core/src/utils/transformers/transformRichText.ts
+++ b/packages/core/src/utils/transformers/transformRichText.ts
@@ -30,7 +30,7 @@ export const transformRichText = (
     };
   }
   if (typeof value === 'object' && value.nodeType === BLOCKS.DOCUMENT) {
-    //resolve any embedded links
+    //resolve any embedded links - we currently only support resolving embedded in the first entry
     const richTextDocument = value as RichTextDocument;
     richTextDocument.content.forEach((node) => {
       if (

--- a/packages/experience-builder-sdk/src/hooks/useFetchById.spec.ts
+++ b/packages/experience-builder-sdk/src/hooks/useFetchById.spec.ts
@@ -70,6 +70,7 @@ describe('useFetchById', () => {
       });
 
       expect(clientMock.withoutLinkResolution.getEntries).toHaveBeenNthCalledWith(1, {
+        include: 2,
         limit: 100,
         skip: 0,
         'sys.id[in]': entries.map((entry) => entry.sys.id),

--- a/packages/experience-builder-sdk/src/hooks/useFetchBySlug.spec.ts
+++ b/packages/experience-builder-sdk/src/hooks/useFetchBySlug.spec.ts
@@ -78,6 +78,7 @@ describe('useFetchBySlug', () => {
       });
 
       expect(clientMock.withoutLinkResolution.getEntries).toHaveBeenNthCalledWith(1, {
+        include: 2,
         limit: 100,
         skip: 0,
         'sys.id[in]': entries.map((entry) => entry.sys.id),


### PR DESCRIPTION
## Purpose

We have several instances where if we bind an entry to a component variable, any referenced entities in that entry are not resolved, and therefore not available as a passed in prop to the component.

Instances where this can occur:
An entry bound into a rich text field
An entry bound to another entry that itself has references to another entry
A list of entries/assets bound to an array variable type where some of which could have references as well

Pretty much any case where a bound entity would have a reference to another entry.

## Approach

Initially, this was attempted to be solved by removing the `withoutLinkResolution` call to the fetch entities API. This automatically resolved any referenced entries no matter how they were referenced. However, this caused issues elsewhere, so we had to do this manually in the transform methods for each specific variable type that could have referenced entries (Array, Link, and RichText).

<!--
Remember when merging:
- Use "Squash and merge" when merging changes into development.
- Use "Create a merge commit" when releasing changes into next and main.

Three important notes on pull requests:
- In general, you should ask yourself whether this code change will improve or worsen the overall code quality. Any new tech debt will probably never be cleaned up.
- Please remember that newly introduced logic should be validated and protected through testing.
- Take a look at PR guides:
  Google's Code Review Guidelines: https://google.github.io/eng-practices/
  Blockly - Writing a Good Pull Request: https://developers.google.com/blockly/guides/contribute/get-started/write_a_good_pr
-->
