### PR TITLE
fix: drag-n-drop error when moving custom components [ALT-1446]

### DIFF
--- a/packages/visual-editor/src/hooks/useComponent.tsx
+++ b/packages/visual-editor/src/hooks/useComponent.tsx
@@ -67,7 +67,7 @@ export const useComponent = ({
   const isAssembly = node.type === 'assembly';
   const isStructureComponent = isContentfulStructureComponent(node.data.blockId);
   const requiresDragWrapper =
-    !isAssembly && !isStructureComponent && !componentRegistration?.options?.wrapComponent;
+    !isAssembly && !isStructureComponent && componentRegistration?.options?.wrapComponent === false;
 
   const { componentProps, wrapperStyles } = useComponentProps({
     node,


### PR DESCRIPTION
## Purpose

Fix error `Invariant failed: Cannot finish a drop animating when no drop is occurring`

This issue first started in version `1.17.2-dev-20241007T1903-dddb811.0` which was released into `1.18.0`

This issue was due to the changes to `useComponent` in https://github.com/contentful/experience-builder/pull/784 which unintentionally made it so the component drag-n-drop wrapper was disabled by default, instead of enabled by default.

https://github.com/user-attachments/assets/ce9f6d2d-0033-4eac-8b2d-dee1a6e57ab2

