### PR TITLE
fix: don't add client object to fetchBy dependency arrays to fix infinite rerenders [ALT-1447]

### DIFF
--- a/packages/experience-builder-sdk/src/hooks/useFetchById.ts
+++ b/packages/experience-builder-sdk/src/hooks/useFetchById.ts
@@ -23,7 +23,10 @@ export const useFetchById = ({
 
   const fetchMethod = useCallback(() => {
     return fetchById({ id, localeCode, client, experienceTypeId });
-  }, [id, localeCode, client, experienceTypeId]);
+    // we purposely don't want to include the client in the dependencies
+    // as it can cause infinite loops if the user creates the client in the component
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [id, localeCode, experienceTypeId]);
 
   const fetchResult = useFetchByBase(fetchMethod, mode);
 

--- a/packages/experience-builder-sdk/src/hooks/useFetchBySlug.ts
+++ b/packages/experience-builder-sdk/src/hooks/useFetchBySlug.ts
@@ -24,7 +24,10 @@ export const useFetchBySlug = ({
 
   const fetchMethod = useCallback(() => {
     return fetchBySlug({ slug, localeCode, client, experienceTypeId });
-  }, [slug, localeCode, client, experienceTypeId]);
+    // we purposely don't want to include the client in the dependencies as it can cause infinite loops if the
+    // user creates the client in the component
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [slug, localeCode, experienceTypeId]);
 
   const fetchResult = useFetchByBase(fetchMethod, mode);
 


### PR DESCRIPTION
## Purpose

https://contentful.atlassian.net/browse/ALT-1447

## Approach

Removed the client from useEffect dep arrays so it wouldn't cause issues changing. This should be a safe change since the client doesn't typically change during the request.

<!--
Remember when merging:
- Use "Squash and merge" when merging changes into development.
- Use "Create a merge commit" when releasing changes into next and main.

Three important notes on pull requests:
- In general, you should ask yourself whether this code change will improve or worsen the overall code quality. Any new tech debt will probably never be cleaned up.
- Please remember that newly introduced logic should be validated and protected through testing.
- Take a look at PR guides:
  Google's Code Review Guidelines: https://google.github.io/eng-practices/
  Blockly - Writing a Good Pull Request: https://developers.google.com/blockly/guides/contribute/get-started/write_a_good_pr
-->
