### PR TITLE
fix: react on changes of breakpoint when tree is the same [SPA-2487]

### DIFF
--- a/packages/visual-editor/src/store/tree.ts
+++ b/packages/visual-editor/src/store/tree.ts
@@ -41,10 +41,6 @@ export interface TreeStore {
   ) => void;
 }
 
-const isAssemblyNode = (node: ExperienceTreeNode) => {
-  return node.type === ASSEMBLY_NODE_TYPE;
-};
-
 export const useTreeStore = create<TreeStore>((set, get) => ({
   tree: {
     root: {
@@ -109,15 +105,7 @@ export const useTreeStore = create<TreeStore>((set, get) => ({
      * rerendering the entire tree.
      */
     const treeDiff = getTreeDiffs({ ...currentTree.root }, { ...tree.root }, currentTree);
-
-    const currentBreakpoints = (currentTree?.root?.data?.breakpoints ?? []).slice().sort();
-    const newBreakpoints = (tree?.root?.data?.breakpoints ?? []).slice().sort();
-    let didBreakpointsChange = false;
-    if (newBreakpoints.length && newBreakpoints.length !== currentBreakpoints.length) {
-      didBreakpointsChange = newBreakpoints.some(
-        (value, index) => currentBreakpoints[index] !== value,
-      );
-    }
+    const didBreakpointsChange = hasBreakpointDiffs(currentTree, tree);
 
     // The current and updated tree are the same, no tree update required.
     // Special case: Breakpoints changed (e.g. empty experience gets reloaded or breakpoints updated)
@@ -191,8 +179,24 @@ export const useTreeStore = create<TreeStore>((set, get) => ({
   },
 }));
 
+const hasBreakpointDiffs = (currentTree: ExperienceTree, newTree: ExperienceTree) => {
+  const currentBreakpoints = (currentTree?.root?.data?.breakpoints ?? []).slice().sort();
+  const newBreakpoints = (newTree?.root?.data?.breakpoints ?? []).slice().sort();
+  let didBreakpointsChange = false;
+  if (newBreakpoints.length && newBreakpoints.length !== currentBreakpoints.length) {
+    didBreakpointsChange = newBreakpoints.some(
+      (value, index) => currentBreakpoints[index] !== value,
+    );
+  }
+  return didBreakpointsChange;
+};
+
+const isAssemblyNode = (node: ExperienceTreeNode) => {
+  return node.type === ASSEMBLY_NODE_TYPE;
+};
+
 // Serialize and deserialize an object again to remove all functions and references.
 // Some people refer to this as "Plain Old JavaScript Object" (POJO) as it solely contains plain data.
-function cloneDeepAsPOJO(obj) {
+const cloneDeepAsPOJO = (obj: unknown) => {
   return JSON.parse(JSON.stringify(obj));
-}
+};

--- a/packages/visual-editor/src/store/tree.ts
+++ b/packages/visual-editor/src/store/tree.ts
@@ -110,8 +110,18 @@ export const useTreeStore = create<TreeStore>((set, get) => ({
      */
     const treeDiff = getTreeDiffs({ ...currentTree.root }, { ...tree.root }, currentTree);
 
+    const currentBreakpoints = (currentTree?.root?.data?.breakpoints ?? []).slice().sort();
+    const newBreakpoints = (tree?.root?.data?.breakpoints ?? []).slice().sort();
+    let didBreakpointsChange = false;
+    if (newBreakpoints.length && newBreakpoints.length !== currentBreakpoints.length) {
+      didBreakpointsChange = newBreakpoints.some(
+        (value, index) => currentBreakpoints[index] !== value,
+      );
+    }
+
     // The current and updated tree are the same, no tree update required.
-    if (!treeDiff.length) {
+    // Special case: Breakpoints changed (e.g. empty experience gets reloaded or breakpoints updated)
+    if (!treeDiff.length && !didBreakpointsChange) {
       console.debug(
         `[exp-builder.visual-editor::updateTree()]: During smart-diffing no diffs. Skipping tree update.`,
       );

--- a/packages/visual-editor/src/store/tree.ts
+++ b/packages/visual-editor/src/store/tree.ts
@@ -17,6 +17,7 @@ import {
 import { getTreeDiffs } from '@/utils/getTreeDiff';
 import { treeVisit } from '@/utils/treeTraversal';
 import { ASSEMBLY_NODE_TYPE } from '@contentful/experiences-core/constants';
+import { isEqual } from 'lodash-es';
 export interface TreeStore {
   tree: ExperienceTree;
   breakpoints: Breakpoint[];
@@ -180,15 +181,11 @@ export const useTreeStore = create<TreeStore>((set, get) => ({
 }));
 
 const hasBreakpointDiffs = (currentTree: ExperienceTree, newTree: ExperienceTree) => {
-  const currentBreakpoints = (currentTree?.root?.data?.breakpoints ?? []).slice().sort();
-  const newBreakpoints = (newTree?.root?.data?.breakpoints ?? []).slice().sort();
-  let didBreakpointsChange = false;
-  if (newBreakpoints.length && newBreakpoints.length !== currentBreakpoints.length) {
-    didBreakpointsChange = newBreakpoints.some(
-      (value, index) => currentBreakpoints[index] !== value,
-    );
-  }
-  return didBreakpointsChange;
+  const currentBreakpoints = currentTree?.root?.data?.breakpoints ?? [];
+  const newBreakpoints = newTree?.root?.data?.breakpoints ?? [];
+  // Consider any difference as a change (id, name, previewSize).
+  // Even the order of breakpoints matters as it affects the rendering in useBreakpoints.
+  return !isEqual(currentBreakpoints, newBreakpoints);
 };
 
 const isAssemblyNode = (node: ExperienceTreeNode) => {


### PR DESCRIPTION
## Purpose
When testing initialisation with custom breakpoints for [this fix PR](https://github.com/contentful/user_interface/pull/24124#issuecomment-2486324029), I realised that the diffing logic will ignore breakpoint changes if the tree didn't change.

## Approach
Even if the tree is empty (and thus an empty tree diff), we accept a change of the breakpoint settings.