### PR TITLE
[DRAFT] feat: carousel component base [ALT-1425]

### DIFF
--- a/packages/components/src/components/Carousel/Carousel.tsx
+++ b/packages/components/src/components/Carousel/Carousel.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { combineClasses } from '@/utils/combineClasses';
+
+interface CarouselProps {
+  className?: string;
+  children?: React.ReactNode;
+}
+
+export const Carousel: React.FC<CarouselProps> = ({ className, children, ...props }) => {
+  return (
+    <div className={combineClasses(className, 'cf-carousel')} {...props}>
+      {children}
+    </div>
+  );
+};

--- a/packages/components/src/components/Carousel/index.ts
+++ b/packages/components/src/components/Carousel/index.ts
@@ -1,0 +1,28 @@
+import {
+  CONTENTFUL_COMPONENTS,
+  CONTENTFUL_DEFAULT_CATEGORY,
+} from '@contentful/experiences-core/constants';
+import { ComponentDefinition } from '@contentful/experiences-core/types';
+
+export { Carousel } from './Carousel';
+
+export const carouselDefinition: ComponentDefinition = {
+  id: CONTENTFUL_COMPONENTS.carousel.id,
+  name: CONTENTFUL_COMPONENTS.carousel.name,
+  category: CONTENTFUL_DEFAULT_CATEGORY,
+  children: true,
+  builtInStyles: [
+    'cfPadding',
+    'cfMargin',
+    'cfHeight',
+    'cfWidth',
+    'cfMaxWidth',
+    'cfBorderRadius',
+    'cfBackgroundColor',
+    'cfBorder',
+  ],
+  variables: {},
+  tooltip: {
+    description: 'Drop onto the canvas to add a carousel.',
+  },
+};

--- a/packages/components/src/components/index.ts
+++ b/packages/components/src/components/index.ts
@@ -7,3 +7,4 @@ export * from './ContentfulContainer';
 export * from './Divider';
 export * from './Columns';
 export * from './Assembly';
+export * from './Carousel';

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -111,6 +111,10 @@ export const CONTENTFUL_COMPONENTS = {
     id: 'contentful-divider',
     name: 'Divider',
   },
+  carousel: {
+    id: 'contentful-carousel',
+    name: 'Carousel',
+  },
 };
 
 export const ASSEMBLY_NODE_TYPE = 'assembly';


### PR DESCRIPTION
## Purpose

- Adds the base Carousel component (basic div that accepts children; more functionality to be added later)
- Uses dynamic imports to only load the basic built-in components when needed

## Approach

The `defineComponents` method includes an `options` parameter with `enabledBuiltInComponents` to disable built-in components.

Due to the use of dynamic imports, host applications must call `defineComponents([])` to register the basic built-in components now, even if no custom components are being registered, since this is the point where basic built-in components are dynamically imported and registered now.

## TODO

- [ ] Incorporate experimental flag for the Carousel component
