### PR TITLE
feat(nextjs-marketing-demo): show extra footer info for debugging

### DIFF
--- a/packages/experience-builder-sdk/src/index.ts
+++ b/packages/experience-builder-sdk/src/index.ts
@@ -1,4 +1,5 @@
 import { SDK_VERSION } from './sdkVersion';
+export { SDK_VERSION as version };
 
 export { ExperienceRoot } from './ExperienceRoot';
 export { useFetchById, useFetchBySlug } from './hooks';

--- a/packages/templates/nextjs-marketing-demo/src/app/globals.css
+++ b/packages/templates/nextjs-marketing-demo/src/app/globals.css
@@ -1,9 +1,14 @@
 :root {
-  --white: #fff;
-  --background: --white;
-  --foreground: #171717;
-  --footer: #434343;
-  --sunset-orange-2: #FFE7BA;
+  /**
+   * Colors
+   * https://ant.design/docs/spec/colors
+   */
+  --gray-1: #fff;
+  --gray-5: #d9d9d9;
+  --gray-7: #8c8c8c;
+  --gray-9: #434343;
+  --gray-12: #141414;
+  --orange-2: #ffe7ba;
 }
 
 html,
@@ -13,8 +18,8 @@ body {
 }
 
 body {
-  color: var(--foreground);
-  background: var(--background);
+  color: var(--gray-12);
+  background: var(--gray-1);
   font-family: Arial, Helvetica, sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;

--- a/packages/templates/nextjs-marketing-demo/src/app/page.module.css
+++ b/packages/templates/nextjs-marketing-demo/src/app/page.module.css
@@ -1,19 +1,19 @@
 div.layout {
-  background: var(--background);
+  background: var(--gray-1);
   display: flex;
   flex-direction: column;
   min-height: 100vh;
 }
 
 header.header {
-  background: var(--background);
+  background: var(--gray-1);
 }
 
 main.content {
-  background: var(--background);
+  background: var(--gray-1);
   flex: 1;
 }
 
 footer.footer {
-  background: var(--footer);
+  background: var(--gray-9);
 }

--- a/packages/templates/nextjs-marketing-demo/src/components/Footer/Footer.tsx
+++ b/packages/templates/nextjs-marketing-demo/src/components/Footer/Footer.tsx
@@ -3,6 +3,7 @@ import { Menu, Typography, Flex } from 'antd';
 import Container from '../Container';
 import FooterNav from './FooterNav';
 import styles from './styles.module.css';
+import FooterDebugging from './FooterDebugging';
 
 const socials = [
   { key: 'instagram', label: 'Instagram' },
@@ -26,9 +27,12 @@ const Footer: React.FC = () => {
           </Flex>
         </Flex>
         <Flex justify="flex-end" vertical={false}>
-          <Typography className={styles.copyright}>
-            Altitude Design &copy;{new Date().getFullYear()}
-          </Typography>
+          <Flex align="flex-end" vertical>
+            <Typography className={styles.copyright}>
+              Altitude Design &copy;{new Date().getFullYear()}
+            </Typography>
+            <FooterDebugging />
+          </Flex>
         </Flex>
       </Flex>
     </Container>

--- a/packages/templates/nextjs-marketing-demo/src/components/Footer/FooterDebugging.tsx
+++ b/packages/templates/nextjs-marketing-demo/src/components/Footer/FooterDebugging.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+import React from 'react';
+import { useSearchParams } from 'next/navigation';
+import { version as sdkVersion } from '@contentful/experiences-sdk-react';
+import { version as reactVersion } from 'react/package.json';
+import { Divider, Flex, Typography } from 'antd';
+import styles from './styles.module.css';
+
+const FooterDebugging: React.FC = () => {
+  const searchParams = useSearchParams();
+  const isDebugMode = searchParams.has('debug');
+
+  if (!isDebugMode) {
+    return null;
+  }
+
+  return (
+    <Flex align="center" vertical={false} className={styles.debugInfo}>
+      <Typography className={styles.darkText}>Experiences SDK v{sdkVersion}</Typography>
+      <Divider type="vertical" className={styles.divider} />
+      <Typography className={styles.darkText}>React v{reactVersion}</Typography>
+    </Flex>
+  );
+};
+
+export default FooterDebugging;

--- a/packages/templates/nextjs-marketing-demo/src/components/Footer/styles.module.css
+++ b/packages/templates/nextjs-marketing-demo/src/components/Footer/styles.module.css
@@ -7,20 +7,28 @@ ul.menu {
 
 ul.menu :global li.ant-menu-item-selected::after,
 ul.menu :global li.ant-menu-item-active::after {
-  border-bottom-color: var(--sunset-orange-2) !important;
+  border-bottom-color: var(--orange-2) !important;
 }
 
 ul.menu li span {
-  color: var(--sunset-orange-2);
+  color: var(--orange-2);
 }
 
 article.heading {
-  color: var(--white);
+  color: var(--gray-1);
   padding: 0 1rem;
 }
 
 article.copyright {
-  color: var(--white);
+  color: var(--gray-1);
+  padding: 0 1rem;
+}
+
+article.darkText {
+  color: var(--gray-7);
+}
+
+div.debugInfo {
   padding: 0 1rem;
 }
 
@@ -35,4 +43,9 @@ div.nav {
   flex-direction: row;
   align-items: center;
   gap: 8px;
+}
+
+div.divider {
+  height: 1rem;
+  background: var(--gray-7);
 }

--- a/packages/templates/nextjs-marketing-demo/src/components/Header/styles.module.css
+++ b/packages/templates/nextjs-marketing-demo/src/components/Header/styles.module.css
@@ -16,6 +16,10 @@ ul.mobileMenu {
   border-bottom: 1px solid transparent;
 }
 
+ul.mobileMenu :global li.ant-menu-overflow-item::after {
+  border-bottom-color: transparent !important;
+}
+
 .nav {
   display: flex;
   flex: 1;


### PR DESCRIPTION
## Purpose

Exports the `version` from the SDK package.

Updates the marketing demo template so that you can add `debug` to the URL query string to get additional debug info in the footer (displays the version of the Experiences SDK and React).

<img width="944" alt="Screenshot 2024-11-22 at 7 21 51 PM" src="https://github.com/user-attachments/assets/a56ee961-053c-4a1f-9b4e-95f1cf2c3bce">

