### PR TITLE
[ALT-1308] fix: target width now applies the background image url css properly

### DIFF
--- a/packages/core/src/utils/transformers/transformBoundContentValue.spec.ts
+++ b/packages/core/src/utils/transformers/transformBoundContentValue.spec.ts
@@ -121,6 +121,7 @@ describe('transformBoundContentValue', () => {
             return {
               quality: '100%',
               format: 'jpg',
+              targetSize: '1060px',
             };
           }
           if (variableName === 'cfWidth') {
@@ -142,6 +143,37 @@ describe('transformBoundContentValue', () => {
         expect(result.url).toEqual(assets[0].fields.file?.url + '?w=1024&fm=jpg');
       });
 
+      it('should transform value to OptimizedBackgroundImageAsset to targetValue when targetValue is lower than asset width', () => {
+        const binding: UnresolvedLink<'Asset'> = {
+          sys: { type: 'Link', linkType: 'Asset', id: 'asset1' },
+        };
+        const resolveDesignValue = vitest.fn((_, variableName) => {
+          if (variableName === 'cfBackgroundImageOptions') {
+            return {
+              quality: '100%',
+              format: 'jpg',
+              targetSize: '300px',
+            };
+          }
+          if (variableName === 'cfWidth') {
+            return '1024px';
+          }
+        });
+        const variableName = 'cfBackgroundImageUrl';
+
+        const path = (variables.image as BoundValue).path;
+        const result = transformBoundContentValue(
+          variablesWithImageOptions,
+          entityStore,
+          binding,
+          resolveDesignValue,
+          variableName,
+          variableType,
+          path,
+        ) as OptimizedBackgroundImageAsset;
+        expect(result.url).toEqual(assets[0].fields.file?.url + '?w=600&fm=jpg');
+      });
+
       it('when the component doesnt have a width variable, it should still transform value to OptimizedBackgroundImageAsset', () => {
         const binding: UnresolvedLink<'Asset'> = {
           sys: { type: 'Link', linkType: 'Asset', id: 'asset1' },
@@ -151,6 +183,7 @@ describe('transformBoundContentValue', () => {
             return {
               quality: '100%',
               format: 'jpg',
+              targetSize: '1060px',
             };
           }
           if (variableName === 'cfWidth') {

--- a/packages/core/src/utils/utils.ts
+++ b/packages/core/src/utils/utils.ts
@@ -153,3 +153,35 @@ export const checkIsAssemblyEntry = (entry: Entry): boolean => {
 
 export const checkIsAssemblyDefinition = (component?: ComponentDefinition) =>
   component?.category === ASSEMBLY_DEFAULT_CATEGORY;
+
+interface ParsedValue {
+  value: number;
+  unit: 'px' | 'em' | 'rem';
+}
+
+export function parseCSSValue(input: string): ParsedValue | null {
+  const regex = /^(\d+(\.\d+)?)(px|em|rem)$/;
+  const match = input.match(regex);
+
+  if (match) {
+    return {
+      value: parseFloat(match[1]),
+      unit: match[3] as 'px' | 'em' | 'rem',
+    };
+  }
+
+  return null;
+}
+
+export function getTargetValueInPixels(targetWidthObject: ParsedValue) {
+  switch (targetWidthObject.unit) {
+    case 'px':
+      return targetWidthObject.value;
+    case 'em':
+      return targetWidthObject.value * 16;
+    case 'rem':
+      return targetWidthObject.value * 16;
+    default:
+      return targetWidthObject.value;
+  }
+}


### PR DESCRIPTION
## Purpose
Previously the css url for the background image would ignore the target width, but now setting the target width appropriately changes the background image url when its value is less than the asset width.

https://github.com/user-attachments/assets/687bc2d0-529a-4121-b9e8-3654ea071c94

