### PR TITLE
feat: update types for ComponentDefinition variables [ALT-690]

### DIFF
--- a/packages/core/src/definitions/styles.ts
+++ b/packages/core/src/definitions/styles.ts
@@ -1,15 +1,8 @@
 import { DEFAULT_IMAGE_WIDTH } from '@/constants';
-import { ComponentDefinitionVariable, ContainerStyleVariableName } from '../types';
-
-type VariableDefinitions = Partial<
-  Record<
-    ContainerStyleVariableName,
-    ComponentDefinitionVariable<'Text' | 'Boolean' | 'Media' | 'Object' | 'Hyperlink'>
-  >
->;
+import { DesignVariableMap } from '../types';
 
 // These styles get added to every component, user custom or contentful provided
-export const builtInStyles: VariableDefinitions = {
+export const builtInStyles: Partial<DesignVariableMap> = {
   cfVerticalAlignment: {
     validations: {
       in: [
@@ -157,7 +150,7 @@ export const builtInStyles: VariableDefinitions = {
   },
 };
 
-export const optionalBuiltInStyles: VariableDefinitions = {
+export const optionalBuiltInStyles: Partial<DesignVariableMap> = {
   cfFontSize: {
     displayName: 'Font Size',
     type: 'Text',
@@ -326,14 +319,14 @@ export const optionalBuiltInStyles: VariableDefinitions = {
   },
 };
 
-export const sectionBuiltInStyles: VariableDefinitions = {
+export const sectionBuiltInStyles: Partial<DesignVariableMap> = {
   ...builtInStyles,
   cfBorderRadius: optionalBuiltInStyles.cfBorderRadius,
   cfBackgroundImageUrl: optionalBuiltInStyles.cfBackgroundImageUrl,
   cfBackgroundImageOptions: optionalBuiltInStyles.cfBackgroundImageOptions,
 };
 
-export const containerBuiltInStyles: VariableDefinitions = {
+export const containerBuiltInStyles: Partial<DesignVariableMap> = {
   ...builtInStyles,
   cfBorderRadius: optionalBuiltInStyles.cfBorderRadius,
   cfBackgroundImageUrl: optionalBuiltInStyles.cfBackgroundImageUrl,
@@ -355,7 +348,7 @@ export const containerBuiltInStyles: VariableDefinitions = {
   },
 };
 
-export const dividerBuiltInStyles: VariableDefinitions = {
+export const dividerBuiltInStyles: Partial<DesignVariableMap> = {
   cfVisibility: builtInStyles.cfVisibility,
   cfBorderRadius: optionalBuiltInStyles.cfBorderRadius,
   cfMargin: {
@@ -395,7 +388,7 @@ export const dividerBuiltInStyles: VariableDefinitions = {
   },
 };
 
-export const singleColumnBuiltInStyles: VariableDefinitions = {
+export const singleColumnBuiltInStyles: Partial<DesignVariableMap> = {
   cfVisibility: builtInStyles.cfVisibility,
   cfBorderRadius: optionalBuiltInStyles.cfBorderRadius,
   cfBackgroundColor: optionalBuiltInStyles.cfBackgroundColor,
@@ -494,7 +487,7 @@ export const singleColumnBuiltInStyles: VariableDefinitions = {
   },
 };
 
-export const columnsBuiltInStyles: VariableDefinitions = {
+export const columnsBuiltInStyles: Partial<DesignVariableMap> = {
   cfVisibility: builtInStyles.cfVisibility,
   cfBorderRadius: optionalBuiltInStyles.cfBorderRadius,
   cfBackgroundColor: optionalBuiltInStyles.cfBackgroundColor,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -33,6 +33,20 @@ export type {
   ComponentDefinitionPropertyType as ComponentDefinitionVariableType,
 } from '@contentful/experiences-validators';
 
+type ComponentDefinitionVariableTypeMap = {
+  Array: unknown[];
+  Boolean: boolean;
+  Date: string;
+  Hyperlink: string;
+  Link: Record<string, unknown>;
+  Location: { lon: number; lat: number };
+  Media: Record<string, unknown> | string;
+  Number: number;
+  Object: Record<string, unknown>;
+  RichText: string;
+  Text: string;
+};
+
 type ScrollStateKey = keyof typeof SCROLL_STATES;
 export type ScrollState = (typeof SCROLL_STATES)[ScrollStateKey];
 
@@ -56,7 +70,7 @@ export interface Link<T extends string> {
 export type VariableFormats = 'URL'; // | alphaNum | base64 | email | ipAddress
 
 export type ValidationOption<T extends ComponentDefinitionPropertyType> = {
-  value: T extends 'Text' ? string : T extends 'Number' ? number : never;
+  value: ComponentDefinitionVariableTypeMap[T];
   displayName?: string;
 };
 
@@ -72,19 +86,12 @@ export interface ComponentDefinitionVariableBase<T extends ComponentDefinitionPr
   group?: 'style' | 'content';
   description?: string;
   displayName?: string;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  defaultValue?: string | boolean | number | Record<any, any>; //todo: fix typings
+  defaultValue?: ComponentDefinitionVariableTypeMap[T];
 }
 
 export type ComponentDefinitionVariable<
   T extends ComponentDefinitionPropertyType = ComponentDefinitionPropertyType,
-  // K extends ComponentDefinitionVariableArrayItemType = ComponentDefinitionVariableArrayItemType
-> =
-  // T extends 'Link'
-  // ? ComponentDefinitionVariableLink
-  // : T extends 'Array'
-  // ? { items: { type: K } } & ComponentDefinitionVariableArray<K>
-  /*:*/ ComponentDefinitionVariableBase<T>;
+> = ComponentDefinitionVariableBase<T>;
 
 export type ComponentDefinition<
   T extends ComponentDefinitionPropertyType = ComponentDefinitionPropertyType,
@@ -94,8 +101,7 @@ export type ComponentDefinition<
   category?: string;
   thumbnailUrl?: string;
   hyperlinkPattern?: string;
-  variables: Partial<Record<ContainerStyleVariableName, ComponentDefinitionVariable<T>>> &
-    Record<string, ComponentDefinitionVariable<T>>;
+  variables: Partial<DesignVariableMap> & Record<string, ComponentDefinitionVariable<T>>;
   slots?: Record<string, { displayName: string }>;
   builtInStyles?: Array<keyof Omit<StyleProps, 'cfHyperlink' | 'cfOpenInNewTab'>>;
   children?: boolean;
@@ -220,6 +226,52 @@ export type StyleProps = {
   cfColumnSpanLock: boolean;
   cfWrapColumns: boolean;
   cfWrapColumnsCount: string;
+};
+
+/**
+ * Internally defined style variables mapped to each variable type
+ */
+export type DesignVariableTypes = {
+  cfVisibility: 'Boolean';
+  cfHorizontalAlignment: 'Text';
+  cfVerticalAlignment: 'Text';
+  cfMargin: 'Text';
+  cfPadding: 'Text';
+  cfBackgroundColor: 'Text';
+  cfWidth: 'Text';
+  cfMaxWidth: 'Text';
+  cfHeight: 'Text';
+  cfFlexDirection: 'Text';
+  cfFlexWrap: 'Text';
+  cfFlexReverse: 'Boolean';
+  cfBorder: 'Text';
+  cfBorderRadius: 'Text';
+  cfGap: 'Text';
+  cfHyperlink: 'Hyperlink';
+  cfImageAsset: 'Media';
+  cfImageOptions: 'Object';
+  cfBackgroundImageUrl: 'Media';
+  cfBackgroundImageOptions: 'Object';
+  cfOpenInNewTab: 'Boolean';
+  cfFontSize: 'Text';
+  cfFontWeight: 'Text';
+  cfLineHeight: 'Text';
+  cfLetterSpacing: 'Text';
+  cfTextColor: 'Text';
+  cfTextAlign: 'Text';
+  cfTextTransform: 'Text';
+  cfTextBold: 'Boolean';
+  cfTextItalic: 'Boolean';
+  cfTextUnderline: 'Boolean';
+  cfColumns: 'Text';
+  cfColumnSpan: 'Text';
+  cfColumnSpanLock: 'Boolean';
+  cfWrapColumns: 'Boolean';
+  cfWrapColumnsCount: 'Text';
+};
+
+export type DesignVariableMap = {
+  [K in keyof DesignVariableTypes]: ComponentDefinitionVariable<DesignVariableTypes[K]>;
 };
 
 // We might need to replace this with Record<string, string | number> when we want to be React-agnostic

--- a/packages/experience-builder-sdk/src/core/componentRegistry.ts
+++ b/packages/experience-builder-sdk/src/core/componentRegistry.ts
@@ -59,15 +59,19 @@ const applyBuiltInStyleDefinitions = (componentDefinition: ComponentDefinition) 
     clone.builtInStyles = ['cfMargin'];
   }
 
+  if (!clone.variables) {
+    clone.variables = {};
+  }
+
   // Enforce the presence of this property for toggling visibility on any node
   clone.variables['cfVisibility'] = builtInStyleDefinitions['cfVisibility'];
 
-  for (const style of Object.values(clone.builtInStyles || [])) {
+  for (const style of clone.builtInStyles || []) {
     if (builtInStyleDefinitions[style]) {
-      clone.variables[style] = builtInStyleDefinitions[style];
+      clone.variables[style] = builtInStyleDefinitions[style] as any; // TODO: fix type
     }
     if (optionalBuiltInStyles[style]) {
-      clone.variables[style] = optionalBuiltInStyles[style];
+      clone.variables[style] = optionalBuiltInStyles[style] as any; // TODO: fix type
     }
   }
   return clone;
@@ -396,7 +400,7 @@ export const createAssemblyRegistration = ({
   const definition = {
     id: definitionId,
     name: definitionName || 'Component',
-    variables: {} as ComponentDefinition['variables'],
+    variables: {},
     children: true,
     category: ASSEMBLY_DEFAULT_CATEGORY,
   };

--- a/packages/visual-editor/src/store/registries.ts
+++ b/packages/visual-editor/src/store/registries.ts
@@ -1,8 +1,4 @@
-import type {
-  ComponentRegistration,
-  ComponentDefinition,
-  Link,
-} from '@contentful/experiences-core/types';
+import type { ComponentRegistration, Link } from '@contentful/experiences-core/types';
 
 import { ASSEMBLY_DEFAULT_CATEGORY } from '@contentful/experiences-core/constants';
 
@@ -42,7 +38,7 @@ export const createAssemblyRegistration = ({
   const definition = {
     id: definitionId,
     name: definitionName || 'Component',
-    variables: {} as ComponentDefinition['variables'],
+    variables: {},
     children: true,
     category: ASSEMBLY_DEFAULT_CATEGORY,
   };


### PR DESCRIPTION
## Purpose

This branch updates the types for `ComponentDefinition.variables` to map out the data type for each built-in design variable.

## Approach

Previously when accessing a component definition variable, the type could be a long list of possibilities, like this:

![Screenshot 2024-12-02 at 3 58 09 PM](https://github.com/user-attachments/assets/2786b30c-baa1-404c-8e99-79f503aa0d9b)

Developers would then use type casting to make the type more specific and accurate in the UI, like this:
```ts
cfImageOptions as ComponentDefinitionVariable<'Object'> | undefined
```

After these changes, the type casting is no longer needed for the built-in variables because the types will infer correctly:

![Screenshot 2024-12-02 at 3 25 45 PM](https://github.com/user-attachments/assets/a425d97e-8b15-4106-947b-7d93d0463809)

## Comparison

These changes will allow us to remove the type casting for component definition variables from `<SectionStyles>` and a few other components in the UI, along the lines of:

![Screenshot 2024-12-02 at 3 51 43 PM](https://github.com/user-attachments/assets/4663ff30-96c6-4d4f-ba77-e8b0e1f11eaf)



