### PR TITLE
feat: add isEditorMode param to vanilla js fetchers []

### DIFF
--- a/examples/astrojs-ssr/src/components/Experience.tsx
+++ b/examples/astrojs-ssr/src/components/Experience.tsx
@@ -1,9 +1,8 @@
 import React from 'react';
-import { ExperienceRoot } from '@contentful/experiences-sdk-react';
-import type { ExperienceType } from '../getExperience';
+import { Experience, ExperienceRoot } from '@contentful/experiences-sdk-react';
 
 interface ExperienceProps {
-  experience: ExperienceType;
+  experience: Experience;
   locale: string;
 }
 

--- a/examples/astrojs-ssr/src/getExperience.ts
+++ b/examples/astrojs-ssr/src/getExperience.ts
@@ -24,26 +24,17 @@ export const getExperience = async (
   isPreview = false,
   isEditorMode = false,
 ) => {
-  // While in editor mode, the experience is passed to the ExperienceRoot
-  // component by the editor, so we don't fetch it here
-  if (isEditorMode) {
-    return { experience: undefined, error: undefined };
-  }
-
   const client = getConfig(isPreview);
-  let experience: Awaited<ReturnType<typeof fetchBySlug>> | undefined;
-
   try {
-    experience = await fetchBySlug({
+    const experience = await fetchBySlug({
       client,
       slug,
       experienceTypeId,
       localeCode,
+      isEditorMode,
     });
+    return { experience };
   } catch (error) {
-    return { experience, error: error as Error };
+    return { experience: undefined, error: error as Error };
   }
-  return { experience, error: undefined };
 };
-
-export type ExperienceType = Awaited<ReturnType<typeof fetchBySlug>>;

--- a/examples/next-app-router/src/getExperience.ts
+++ b/examples/next-app-router/src/getExperience.ts
@@ -24,24 +24,17 @@ export const getExperience = async (
   isPreview = false,
   isEditorMode = false,
 ) => {
-  // While in editor mode, the experience is passed to the ExperienceRoot
-  // component by the editor, so we don't fetch it here
-  if (isEditorMode) {
-    return { experience: undefined, error: undefined };
-  }
-
   const client = getConfig(isPreview);
-  let experience: Awaited<ReturnType<typeof fetchBySlug>> | undefined;
-
   try {
-    experience = await fetchBySlug({
+    const experience = await fetchBySlug({
       client,
       slug,
       experienceTypeId,
       localeCode,
+      isEditorMode,
     });
+    return { experience };
   } catch (error) {
-    return { experience, error: error as Error };
+    return { experience: undefined, error: error as Error };
   }
-  return { experience, error: undefined };
 };

--- a/examples/next-pages-router/src/getExperience.ts
+++ b/examples/next-pages-router/src/getExperience.ts
@@ -24,24 +24,17 @@ export const getExperience = async (
   isPreview = false,
   isEditorMode = false,
 ) => {
-  // While in editor mode, the experience is passed to the ExperienceRoot
-  // component by the editor, so we don't fetch it here
-  if (isEditorMode) {
-    return { experience: undefined, error: undefined };
-  }
-
   const client = getConfig(isPreview);
-  let experience: Awaited<ReturnType<typeof fetchBySlug>> | undefined;
-
   try {
-    experience = await fetchBySlug({
+    const experience = await fetchBySlug({
       client,
       slug,
       experienceTypeId,
       localeCode,
+      isEditorMode,
     });
+    return { experience };
   } catch (error) {
-    return { experience, error: error as Error };
+    return { experience: undefined, error: error as Error };
   }
-  return { experience, error: undefined };
 };

--- a/packages/core/src/fetchers/fetchById.spec.ts
+++ b/packages/core/src/fetchers/fetchById.spec.ts
@@ -1,0 +1,73 @@
+import { ContentfulClientApi } from 'contentful';
+import { fetchById } from './fetchById';
+import { experienceEntry } from '../test/__fixtures__/experience';
+import { assets, entries } from '../test/__fixtures__/entities';
+import { describe, beforeEach, it, expect, vi } from 'vitest';
+
+const mockClient = {
+  getAssets: vi.fn(),
+  getEntries: vi.fn(),
+  withoutLinkResolution: {
+    getEntries: vi.fn(),
+  },
+} as unknown as ContentfulClientApi<undefined>;
+
+describe('fetchById', () => {
+  beforeEach(() => {
+    vi.mock('./fetchExperienceEntry', () => {
+      const fetchExperienceEntry = async () => {
+        return experienceEntry;
+      };
+      return {
+        fetchExperienceEntry,
+      };
+    });
+
+    vi.mock('./fetchReferencedEntities', () => {
+      const fetchReferencedEntities = async () => {
+        return { entries, assets };
+      };
+      return {
+        fetchReferencedEntities,
+      };
+    });
+  });
+
+  describe('when in editor mode', () => {
+    const isEditorMode = true;
+
+    it('should returned undefined if in editor mode', async () => {
+      const experienceTypeId = 'experienceTypeId';
+      const id = 'abc123';
+      const localeCode = 'en-US';
+
+      const result = await fetchById({
+        client: mockClient,
+        experienceTypeId,
+        id,
+        localeCode,
+        isEditorMode,
+      });
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe('when not in editor mode', () => {
+    const isEditorMode = false;
+
+    it('should return an experience entry with the given slug', async () => {
+      const experienceTypeId = 'experienceTypeId';
+      const id = 'abc123';
+      const localeCode = 'en-US';
+
+      const result = await fetchById({
+        client: mockClient,
+        experienceTypeId,
+        id,
+        localeCode,
+        isEditorMode,
+      });
+      expect(result?.entityStore?.experienceEntryFields?.slug).toEqual(experienceEntry.fields.slug);
+    });
+  });
+});

--- a/packages/core/src/fetchers/fetchById.ts
+++ b/packages/core/src/fetchers/fetchById.ts
@@ -14,23 +14,32 @@ const handleError = (generalMessage: string, error: unknown) => {
   throw Error(message);
 };
 
+type FetchByIdParams = {
+  /** instantiated client from the Contentful SDK */
+  client: ContentfulClientApi<undefined>;
+  /** id of the content type associated with the experience */
+  experienceTypeId: string;
+  /** id of the experience (defined in entry settings) */
+  id: string;
+  /** locale code to fetch the experience */
+  localeCode: string;
+  /** if the experience is being loaded in the Contentful Studio editor or not. If true, this function is a noop. */
+  isEditorMode?: boolean;
+};
+
 /**
- * Fetch experience entry using slug as the identifier
- * @param {string} experienceTypeId - id of the content type associated with the experience
- * @param {string} slug - slug of the experience (defined in entry settings)
- * @param {string} localeCode - locale code to fetch the experience. Falls back to the currently active locale in the state
+ * Fetches an experience object by its id
+ * @param {FetchByIdParams} options - options to fetch the experience
  */
 export async function fetchById({
   client,
   experienceTypeId,
   id,
   localeCode,
-}: {
-  client: ContentfulClientApi<undefined>;
-  experienceTypeId: string;
-  id: string;
-  localeCode: string;
-}) {
+  isEditorMode,
+}: FetchByIdParams) {
+  //Be a no-op if in editor mode
+  if (isEditorMode) return;
   let experienceEntry: Entry | ExperienceEntry | undefined = undefined;
 
   try {

--- a/packages/core/src/fetchers/fetchBySlug.spec.ts
+++ b/packages/core/src/fetchers/fetchBySlug.spec.ts
@@ -1,0 +1,73 @@
+import { ContentfulClientApi } from 'contentful';
+import { fetchBySlug } from './fetchBySlug';
+import { experienceEntry } from '../test/__fixtures__/experience';
+import { assets, entries } from '../test/__fixtures__/entities';
+import { describe, beforeEach, it, expect, vi } from 'vitest';
+
+const mockClient = {
+  getAssets: vi.fn(),
+  getEntries: vi.fn(),
+  withoutLinkResolution: {
+    getEntries: vi.fn(),
+  },
+} as unknown as ContentfulClientApi<undefined>;
+
+describe('fetchBySlug', () => {
+  beforeEach(() => {
+    vi.mock('./fetchExperienceEntry', () => {
+      const fetchExperienceEntry = async () => {
+        return experienceEntry;
+      };
+      return {
+        fetchExperienceEntry,
+      };
+    });
+
+    vi.mock('./fetchReferencedEntities', () => {
+      const fetchReferencedEntities = async () => {
+        return { entries, assets };
+      };
+      return {
+        fetchReferencedEntities,
+      };
+    });
+  });
+
+  describe('when in editor mode', () => {
+    const isEditorMode = true;
+
+    it('should returned undefined if in editor mode', async () => {
+      const experienceTypeId = 'experienceTypeId';
+      const slug = 'slug';
+      const localeCode = 'en-US';
+
+      const result = await fetchBySlug({
+        client: mockClient,
+        experienceTypeId,
+        slug,
+        localeCode,
+        isEditorMode,
+      });
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe('when not in editor mode', () => {
+    const isEditorMode = false;
+
+    it('should return an experience entry with the given slug', async () => {
+      const experienceTypeId = 'experienceTypeId';
+      const slug = 'slug';
+      const localeCode = 'en-US';
+
+      const result = await fetchBySlug({
+        client: mockClient,
+        experienceTypeId,
+        slug,
+        localeCode,
+        isEditorMode,
+      });
+      expect(result?.entityStore?.experienceEntryFields?.slug).toEqual(experienceEntry.fields.slug);
+    });
+  });
+});

--- a/packages/core/src/fetchers/fetchBySlug.ts
+++ b/packages/core/src/fetchers/fetchBySlug.ts
@@ -14,25 +14,32 @@ const handleError = (generalMessage: string, error: unknown) => {
   throw Error(message);
 };
 
-/**
- * Fetch experience entry using slug as the identifier
- * @param {string} experienceTypeId - id of the content type associated with the experience
- * @param {string} slug - slug of the experience (defined in entry settings)
- * @param {string} localeCode - locale code to fetch the experience. Falls back to the currently active locale in the state
- */
+type FetchBySlugParams = {
+  /** instantiated client from the Contentful SDK */
+  client: ContentfulClientApi<undefined>;
+  /** id of the content type associated with the experience */
+  experienceTypeId: string;
+  /** slug of the experience (defined in entry settings) */
+  slug: string;
+  /** locale code to fetch the experience */
+  localeCode: string;
+  /** if the experience is being loaded in the Contentful Studio editor or not. If true, this function is a noop. */
+  isEditorMode?: boolean;
+};
 
-//  Promise<Experience<EntityStore> | undefined> =>
+/**
+ * Fetches an experience object by its slug
+ * @param {FetchBySlugParams} options - options to fetch the experience
+ */
 export async function fetchBySlug({
   client,
   experienceTypeId,
   slug,
   localeCode,
-}: {
-  client: ContentfulClientApi<undefined>;
-  experienceTypeId: string;
-  slug: string;
-  localeCode: string;
-}) {
+  isEditorMode,
+}: FetchBySlugParams) {
+  //Be a no-op if in editor mode
+  if (isEditorMode) return;
   let experienceEntry: Entry | ExperienceEntry | undefined = undefined;
 
   try {

--- a/packages/experience-builder-sdk/src/index.ts
+++ b/packages/experience-builder-sdk/src/index.ts
@@ -25,6 +25,6 @@ if (typeof window !== 'undefined') {
   window.__EB__.sdkVersion = SDK_VERSION;
 }
 
-export type { ComponentDefinition } from '@contentful/experiences-core/types';
+export type { Experience, ComponentDefinition } from '@contentful/experiences-core/types';
 
 export { detachExperienceStyles } from '@contentful/experiences-core';

--- a/packages/templates/nextjs-marketing-demo/src/getExperience.ts
+++ b/packages/templates/nextjs-marketing-demo/src/getExperience.ts
@@ -24,24 +24,17 @@ export const getExperience = async (
   isPreview = false,
   isEditorMode = false,
 ) => {
-  // While in editor mode, the experience is passed to the ExperienceRoot
-  // component by the editor, so we don't fetch it here
-  if (isEditorMode) {
-    return { experience: undefined, error: undefined };
-  }
-
   const client = getConfig(isPreview);
-  let experience: Awaited<ReturnType<typeof fetchBySlug>> | undefined;
-
   try {
-    experience = await fetchBySlug({
+    const experience = await fetchBySlug({
       client,
       slug,
       experienceTypeId,
       localeCode,
+      isEditorMode,
     });
+    return { experience };
   } catch (error) {
-    return { experience, error: error as Error };
+    return { experience: undefined, error: error as Error };
   }
-  return { experience, error: undefined };
 };

--- a/packages/test-apps/nextjs/next-env.d.ts
+++ b/packages/test-apps/nextjs/next-env.d.ts
@@ -2,4 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/app/building-your-application/configuring/typescript for more information.
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/packages/test-apps/nextjs/src/utils/getExperience.ts
+++ b/packages/test-apps/nextjs/src/utils/getExperience.ts
@@ -24,24 +24,17 @@ export const getExperience = async (
   isPreview = false,
   isEditorMode = false,
 ) => {
-  // While in editor mode, the experience is passed to the ExperienceRoot
-  // component by the editor, so we don't fetch it here
-  if (isEditorMode) {
-    return { experience: undefined, error: undefined };
-  }
-
   const client = getConfig(isPreview);
-  let experience: Awaited<ReturnType<typeof fetchBySlug>> | undefined;
-
   try {
-    experience = await fetchBySlug({
+    const experience = await fetchBySlug({
       client,
       slug,
       experienceTypeId,
       localeCode,
+      isEditorMode,
     });
+    return { experience };
   } catch (error) {
-    return { experience, error: error as Error };
+    return { experience: undefined, error: error as Error };
   }
-  return { experience, error: undefined };
 };


### PR DESCRIPTION
## Purpose

Added an optional param named isEditorMode to the vanilla js fetchers (fetchBySlug and fetchById) to be a noop if it is true. This will help clean up code in customers apps that they would otherwise have to write themselves. Now they just need to pass in if they are in editor mode or not to the function.

Also updated the Next and Astro test apps/examples to use this new method.

## Approach

<!--
Remember when merging:
- Use "Squash and merge" when merging changes into development.
- Use "Create a merge commit" when releasing changes into next and main.

Three important notes on pull requests:
- In general, you should ask yourself whether this code change will improve or worsen the overall code quality. Any new tech debt will probably never be cleaned up.
- Please remember that newly introduced logic should be validated and protected through testing.
- Take a look at PR guides:
  Google's Code Review Guidelines: https://google.github.io/eng-practices/
  Blockly - Writing a Good Pull Request: https://developers.google.com/blockly/guides/contribute/get-started/write_a_good_pr
-->
