### PR TITLE
fix(core): export new type for ComponentDefinitionVariableTypeMap [ALT-690]

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -33,7 +33,7 @@ export type {
   ComponentDefinitionPropertyType as ComponentDefinitionVariableType,
 } from '@contentful/experiences-validators';
 
-type ComponentDefinitionVariableTypeMap = {
+export type ComponentDefinitionVariableTypeMap = {
   Array: unknown[];
   Boolean: boolean;
   Date: string;


### PR DESCRIPTION
## Purpose

Exporting `ComponentDefinitionVariableTypeMap` (a new type that was recently added in #850) so that we can have it available to use in the UI as well.