### PR TITLE
feat: add optional id property for component tree nodes

### DIFF
--- a/packages/core/src/utils/styleUtils/ssrStyles.ts
+++ b/packages/core/src/utils/styleUtils/ssrStyles.ts
@@ -328,13 +328,11 @@ export const detachExperienceStyles = (experience: Experience): string | undefin
       // making sure that we respect the order of breakpoints from
       // we can achieve "desktop first" or "mobile first" approach to style over-writes
       if (patternWrapper) {
-        // @ts-expect-error -- temporarily add node ID to pick up the className during rendering in CompositionBlock
         currentNode.id = currentNode.id ?? generateRandomId(15);
         // @ts-expect-error -- valueByBreakpoint is not explicitly defined, but it's already defined in the patternWrapper styles
         patternWrapper.variables.cfSsrClassName = {
           ...(patternWrapper.variables.cfSsrClassName ?? {}),
           type: 'DesignValue',
-          // @ts-expect-error -- id is not defined in ComponentTreeNode type
           [currentNode.id]: {
             valuesByBreakpoint: {
               [breakpointIds[0]]: currentNodeClassNames.join(' '),

--- a/packages/experience-builder-sdk/src/blocks/preview/CompositionBlock.tsx
+++ b/packages/experience-builder-sdk/src/blocks/preview/CompositionBlock.tsx
@@ -91,10 +91,8 @@ export const CompositionBlock = ({
     }
 
     const propMap: Record<string, PrimitiveValue> = {
-      // @ts-expect-error -- node id is being generated in ssrStyles.ts, currently missing ComponentTreeNode type
       cfSsrClassName: node.id
-        ? // @ts-expect-error -- node id is being generated in ssrStyles.ts, currently missing ComponentTreeNode type
-          getPatternChildNodeClassName?.(node.id)
+        ? getPatternChildNodeClassName?.(node.id)
         : node.variables.cfSsrClassName
           ? resolveDesignValue(
               (node.variables.cfSsrClassName as DesignValue).valuesByBreakpoint,

--- a/packages/experience-builder-sdk/src/core/preview/assemblyUtils.ts
+++ b/packages/experience-builder-sdk/src/core/preview/assemblyUtils.ts
@@ -71,7 +71,6 @@ export const deserializeAssemblyNode = ({
 
   return {
     definitionId: node.definitionId,
-    // @ts-expect-error -- required to extract Ssr styles classNames for pattern instances, ComponentTreeNode type is missing id
     id: node.id,
     variables,
     children,
@@ -110,7 +109,6 @@ export const resolveAssembly = ({
   const deserializedNode = deserializeAssemblyNode({
     node: {
       definitionId: node.definitionId,
-      // @ts-expect-error -- required to extract Ssr styles classNames for pattern instances, ComponentTreeNode type is missing id
       id: node.id,
       variables: node.variables,
       children: componentFields.componentTree.children,

--- a/packages/validators/src/schemas/v2023_09_28/experience.ts
+++ b/packages/validators/src/schemas/v2023_09_28/experience.ts
@@ -115,6 +115,7 @@ const UnboundValuesSchema = z.record(
 
 // Use helper schema to define a recursive schema with its type correctly below
 const BaseComponentTreeNodeSchema = z.object({
+  id: uuidKeySchema.optional(),
   definitionId: DefinitionPropertyKeySchema,
   displayName: z.string().optional(),
   slotId: z.string().optional(),

--- a/packages/validators/src/validators/tests/componentTree.spec.ts
+++ b/packages/validators/src/validators/tests/componentTree.spec.ts
@@ -275,6 +275,28 @@ describe('componentTree', () => {
       },
     );
 
+    it.each(['some-uuid', undefined])('succeeds if id is %s', (id) => {
+      const componentTree = experience.fields.componentTree[locale];
+      const child = {
+        id,
+        definitionId: 'test',
+        displayName: 'display-name',
+        variables: {},
+        children: [],
+      };
+
+      const updatedExperience = {
+        ...experience,
+        fields: {
+          ...experience.fields,
+          componentTree: { [locale]: { ...componentTree, children: [child] } },
+        },
+      };
+      const result = validateExperienceFields(updatedExperience, schemaVersion);
+      expect(result.success).toBe(true);
+      expect(result.errors).toBeUndefined();
+    });
+
     it.each(['Test', undefined])('succeeds if displayName is %s', (displayName) => {
       const componentTree = experience.fields.componentTree[locale];
       const child = {


### PR DESCRIPTION
## Purpose

A few upcoming features (e.g. diffing between the component tree for version history) would benefit from a stable UUID-style identifier for tree nodes that's persisted and (relatively) stable throughout the lifetime of that node.

## Approach

* Add a new `id` property to the validator for the component tree node schema, on the current schema version

For now we decided against creating a new schema version to introduce this property. This can come later, once the implementation is stabilized and we introduce code that ensures that old versions of experiences (ie that use the current schema version) can be seamlessly upgraded to the new version correctly.

<!--
Remember when merging:
- Use "Squash and merge" when merging changes into development.
- Use "Create a merge commit" when releasing changes into next and main.

Three important notes on pull requests:
- In general, you should ask yourself whether this code change will improve or worsen the overall code quality. Any new tech debt will probably never be cleaned up.
- Please remember that newly introduced logic should be validated and protected through testing.
- Take a look at PR guides:
  Google's Code Review Guidelines: https://google.github.io/eng-practices/
  Blockly - Writing a Good Pull Request: https://developers.google.com/blockly/guides/contribute/get-started/write_a_good_pr
-->
