### PR TITLE
fix: revert type for validation option values [ALT-690]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2507,7 +2507,6 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -39701,10 +39700,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/studio-experiences-react-app": {
-      "resolved": "packages/create-contentful-studio-experiences/studio-experiences-react-app",
-      "link": true
-    },
     "node_modules/style-inject": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/style-inject/-/style-inject-0.3.0.tgz",
@@ -44055,7 +44050,7 @@
     },
     "packages/components": {
       "name": "@contentful/experiences-components-react",
-      "version": "1.24.0",
+      "version": "1.25.0",
       "license": "MIT",
       "dependencies": {
         "@contentful/experiences-core": "file:../core",
@@ -44145,7 +44140,7 @@
     },
     "packages/core": {
       "name": "@contentful/experiences-core",
-      "version": "1.24.0",
+      "version": "1.25.0",
       "license": "MIT",
       "dependencies": {
         "@contentful/experiences-validators": "file:../validators",
@@ -44204,7 +44199,7 @@
       }
     },
     "packages/create-contentful-studio-experiences": {
-      "version": "1.24.0",
+      "version": "1.25.0",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^0.7.0",
@@ -44266,6 +44261,7 @@
     },
     "packages/create-contentful-studio-experiences/studio-experiences-react-app": {
       "version": "0.0.0",
+      "extraneous": true,
       "dependencies": {
         "@contentful/experiences-sdk-react": "^1.9.0",
         "react": "^18.3.1",
@@ -44293,7 +44289,7 @@
     },
     "packages/experience-builder-sdk": {
       "name": "@contentful/experiences-sdk-react",
-      "version": "1.24.0",
+      "version": "1.25.0",
       "license": "MIT",
       "dependencies": {
         "@contentful/experiences-components-react": "file:../components",
@@ -45248,7 +45244,7 @@
     },
     "packages/validators": {
       "name": "@contentful/experiences-validators",
-      "version": "1.24.0",
+      "version": "1.25.0",
       "dependencies": {
         "zod": "^3.22.4"
       },
@@ -45261,7 +45257,7 @@
     },
     "packages/visual-editor": {
       "name": "@contentful/experiences-visual-editor-react",
-      "version": "1.24.0",
+      "version": "1.25.0",
       "dependencies": {
         "@contentful/experiences-components-react": "file:../components",
         "@contentful/experiences-core": "file:../core",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2507,6 +2507,7 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -39700,6 +39701,10 @@
         "node": ">=4"
       }
     },
+    "node_modules/studio-experiences-react-app": {
+      "resolved": "packages/create-contentful-studio-experiences/studio-experiences-react-app",
+      "link": true
+    },
     "node_modules/style-inject": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/style-inject/-/style-inject-0.3.0.tgz",
@@ -44261,7 +44266,6 @@
     },
     "packages/create-contentful-studio-experiences/studio-experiences-react-app": {
       "version": "0.0.0",
-      "extraneous": true,
       "dependencies": {
         "@contentful/experiences-sdk-react": "^1.9.0",
         "react": "^18.3.1",

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -70,7 +70,7 @@ export interface Link<T extends string> {
 export type VariableFormats = 'URL'; // | alphaNum | base64 | email | ipAddress
 
 export type ValidationOption<T extends ComponentDefinitionPropertyType> = {
-  value: ComponentDefinitionVariableTypeMap[T];
+  value: T extends 'Text' ? string : T extends 'Number' ? number : never;
   displayName?: string;
 };
 


### PR DESCRIPTION
## Purpose

Reverting changes to the value type in `ValidationOption` (the validation rules of component definition variables)

I tried to make this type smarter and infer the right type based on the variable type, but it's actually not a good idea to do this because the validation rules are only expected for certain variable types as simple string or number values in the UI side, so it's best to leave this type as it was before.

Eventually we could expand the support for validations on other variable types and that would be a better time to revise this type.