### PR TITLE
fix: update dep for rich-text-renderer for react v19 compat []

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3677,18 +3677,40 @@
       }
     },
     "node_modules/@contentful/rich-text-react-renderer": {
-      "version": "15.22.11",
-      "resolved": "https://registry.npmjs.org/@contentful/rich-text-react-renderer/-/rich-text-react-renderer-15.22.11.tgz",
-      "integrity": "sha512-IDDdiFSab+C3G2HZRbFegTFuagl8dZpJHgWevoS9ODbatgC9GU6LcLz2hz7KKazsxuBJzgxnFsPd2v5+EtTHrg==",
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/@contentful/rich-text-react-renderer/-/rich-text-react-renderer-16.0.1.tgz",
+      "integrity": "sha512-7wZZBMgwbq5Udp2KebKCJoh9K+EPGlgRkudhXSp+OxtAIdBC6JUz3Oi9kXXKYKLeSg7iTBpkO1dd0/xFjHHKbg==",
       "dependencies": {
-        "@contentful/rich-text-types": "^16.8.5"
+        "@contentful/rich-text-types": "^17.0.0"
       },
       "engines": {
         "node": ">=6.0.0"
       },
       "peerDependencies": {
-        "react": "^16.8.6 || ^17.0.0 || ^18.0.0",
-        "react-dom": "^16.8.6 || ^17.0.0 || ^18.0.0"
+        "react": "^16.8.6 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.6 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@contentful/rich-text-react-renderer/node_modules/@contentful/rich-text-types": {
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/@contentful/rich-text-types/-/rich-text-types-17.0.0.tgz",
+      "integrity": "sha512-x50t6sILzFHBdFpAo0foJRnH8fHWyidheWhAv3uwt9aOnNqTh893gxyoc3Q0RVEZxXfHpTi+O9gmakHcdlRdTA==",
+      "dependencies": {
+        "is-plain-obj": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@contentful/rich-text-react-renderer/node_modules/is-plain-obj": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-3.0.0.tgz",
+      "integrity": "sha512-gwsOE28k+23GP1B6vFl1oVh/WOzmawBrKwo5Ev6wMKzPkaXaCDIQKzLnvsA42DRlbVTWorkgTKIviAKCWkfUwA==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@contentful/rich-text-types": {
@@ -44054,7 +44076,7 @@
       "license": "MIT",
       "dependencies": {
         "@contentful/experiences-core": "file:../core",
-        "@contentful/rich-text-react-renderer": "^15.17.2",
+        "@contentful/rich-text-react-renderer": "^16.0.1",
         "postcss-import": "^16.0.1",
         "style-inject": "^0.3.0"
       },

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -79,7 +79,7 @@
   },
   "dependencies": {
     "@contentful/experiences-core": "file:../core",
-    "@contentful/rich-text-react-renderer": "^15.17.2",
+    "@contentful/rich-text-react-renderer": "^16.0.1",
     "postcss-import": "^16.0.1",
     "style-inject": "^0.3.0"
   }


### PR DESCRIPTION
## Purpose

v15 of the rich-text-react-renderer did not allow react 19 to be installed as a peer dep, so trying to install studio in a react 19 project had peer dep issues. The RTR package was updated to fix this, so this PR updates to the latest version of RTR

## Approach

<!--
Remember when merging:
- Use "Squash and merge" when merging changes into development.
- Use "Create a merge commit" when releasing changes into next and main.

Three important notes on pull requests:
- In general, you should ask yourself whether this code change will improve or worsen the overall code quality. Any new tech debt will probably never be cleaned up.
- Please remember that newly introduced logic should be validated and protected through testing.
- Take a look at PR guides:
  Google's Code Review Guidelines: https://google.github.io/eng-practices/
  Blockly - Writing a Good Pull Request: https://developers.google.com/blockly/guides/contribute/get-started/write_a_good_pr
-->
