### PR TITLE
fix: hyperlinks to assets or entries should resolve in a rich text variable [ALT-1493]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44166,7 +44166,7 @@
       "license": "MIT",
       "dependencies": {
         "@contentful/experiences-validators": "file:../validators",
-        "@contentful/rich-text-types": "^16.3.0"
+        "@contentful/rich-text-types": "^17.0.0"
       },
       "devDependencies": {
         "@rollup/plugin-commonjs": "^25.0.7",
@@ -44190,6 +44190,17 @@
         "contentful": ">=10.6.0"
       }
     },
+    "packages/core/node_modules/@contentful/rich-text-types": {
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/@contentful/rich-text-types/-/rich-text-types-17.0.0.tgz",
+      "integrity": "sha512-x50t6sILzFHBdFpAo0foJRnH8fHWyidheWhAv3uwt9aOnNqTh893gxyoc3Q0RVEZxXfHpTi+O9gmakHcdlRdTA==",
+      "dependencies": {
+        "is-plain-obj": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "packages/core/node_modules/contentful": {
       "version": "10.15.1",
       "resolved": "https://registry.npmjs.org/contentful/-/contentful-10.15.1.tgz",
@@ -44206,6 +44217,26 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "packages/core/node_modules/contentful/node_modules/@contentful/rich-text-types": {
+      "version": "16.8.5",
+      "resolved": "https://registry.npmjs.org/@contentful/rich-text-types/-/rich-text-types-16.8.5.tgz",
+      "integrity": "sha512-q18RJuJCOuYveGiCIjE5xLCQc5lZ3L2Qgxrlg/H2YEobDFqdtmklazRi1XwEWaK3tMg6yVXBzKKkQfLB4qW14A==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "packages/core/node_modules/is-plain-obj": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-3.0.0.tgz",
+      "integrity": "sha512-gwsOE28k+23GP1B6vFl1oVh/WOzmawBrKwo5Ev6wMKzPkaXaCDIQKzLnvsA42DRlbVTWorkgTKIviAKCWkfUwA==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "packages/core/node_modules/type-fest": {
@@ -44318,7 +44349,7 @@
         "@contentful/experiences-core": "file:../core",
         "@contentful/experiences-validators": "file:../validators",
         "@contentful/experiences-visual-editor-react": "file:../visual-editor",
-        "@contentful/rich-text-types": "^16.2.1",
+        "@contentful/rich-text-types": "^17.0.0",
         "classnames": "^2.3.2",
         "csstype": "^3.1.2",
         "immer": "^10.0.3",
@@ -44372,6 +44403,17 @@
         "react-dom": ">=16.0.0"
       }
     },
+    "packages/experience-builder-sdk/node_modules/@contentful/rich-text-types": {
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/@contentful/rich-text-types/-/rich-text-types-17.0.0.tgz",
+      "integrity": "sha512-x50t6sILzFHBdFpAo0foJRnH8fHWyidheWhAv3uwt9aOnNqTh893gxyoc3Q0RVEZxXfHpTi+O9gmakHcdlRdTA==",
+      "dependencies": {
+        "is-plain-obj": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "packages/experience-builder-sdk/node_modules/contentful": {
       "version": "10.15.1",
       "resolved": "https://registry.npmjs.org/contentful/-/contentful-10.15.1.tgz",
@@ -44388,6 +44430,26 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "packages/experience-builder-sdk/node_modules/contentful/node_modules/@contentful/rich-text-types": {
+      "version": "16.8.5",
+      "resolved": "https://registry.npmjs.org/@contentful/rich-text-types/-/rich-text-types-16.8.5.tgz",
+      "integrity": "sha512-q18RJuJCOuYveGiCIjE5xLCQc5lZ3L2Qgxrlg/H2YEobDFqdtmklazRi1XwEWaK3tMg6yVXBzKKkQfLB4qW14A==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "packages/experience-builder-sdk/node_modules/is-plain-obj": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-3.0.0.tgz",
+      "integrity": "sha512-gwsOE28k+23GP1B6vFl1oVh/WOzmawBrKwo5Ev6wMKzPkaXaCDIQKzLnvsA42DRlbVTWorkgTKIviAKCWkfUwA==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "packages/experience-builder-sdk/node_modules/type-fest": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -70,7 +70,7 @@
   },
   "dependencies": {
     "@contentful/experiences-validators": "file:../validators",
-    "@contentful/rich-text-types": "^16.3.0"
+    "@contentful/rich-text-types": "^17.0.0"
   },
   "peerDependencies": {
     "contentful": ">=10.6.0"

--- a/packages/core/src/test/__fixtures__/entities.ts
+++ b/packages/core/src/test/__fixtures__/entities.ts
@@ -10,6 +10,7 @@ export const entityIds = {
   ENTRY_WITH_ANOTHER_EMBEDDED_ENTRY: 'entryWithAnotherEmbeddedEntry',
   ENTRY_WITH_EMBEDDED_ENTRY_IN_RICH_TEXT: 'entryWithEmbeddedEntryInRichText',
   ENTRY_WITH_EMBEDDED_ASSET_IN_RICH_TEXT: 'entryWithEmbeddedAssetInRichText',
+  ENTRY_WITH_DEEPLY_EMBEDDED_ENTITIES_IN_RICH_TEXT: 'entryWithDeeplyEmbeddedEntitiesInRichText',
   ASSET1: 'asset1',
 };
 
@@ -341,6 +342,131 @@ export const entryWithEmbeddedAssetInRichText: Entry = {
             },
           },
           content: [],
+        },
+      ],
+    },
+  },
+  metadata: {
+    tags: [],
+  },
+};
+
+export const entryWithDeeplyEmbeddedEntitiesInRichText: Entry = {
+  sys: {
+    id: entityIds.ENTRY_WITH_DEEPLY_EMBEDDED_ENTITIES_IN_RICH_TEXT,
+    type: 'Entry',
+    contentType: {
+      sys: {
+        id: 'bar',
+        type: 'Link',
+        linkType: 'ContentType',
+      },
+    },
+    createdAt: '2020-01-01T00:00:00.000Z',
+    updatedAt: '2020-01-01T00:00:00.000Z',
+    revision: 10,
+    space: {
+      sys: {
+        type: 'Link',
+        linkType: 'Space',
+        id: 'cfexampleapi',
+      },
+    },
+    environment: {
+      sys: {
+        id: 'master',
+        type: 'Link',
+        linkType: 'Environment',
+      },
+    },
+    locale: 'en-US',
+  },
+  fields: {
+    body: {
+      nodeType: 'document',
+      data: {},
+      content: [
+        {
+          nodeType: 'unordered-list',
+          data: {},
+          content: [
+            {
+              nodeType: 'list-item',
+              data: {},
+              content: [
+                {
+                  nodeType: 'embedded-asset-block',
+                  data: {
+                    target: {
+                      sys: {
+                        type: 'Link',
+                        id: entityIds.ASSET1,
+                        linkType: 'Asset',
+                      },
+                    },
+                  },
+                  content: [],
+                },
+              ],
+            },
+            {
+              nodeType: 'list-item',
+              data: {},
+              content: [
+                {
+                  nodeType: 'embedded-entry-block',
+                  data: {
+                    target: {
+                      sys: {
+                        type: 'Link',
+                        id: entityIds.ENTRY1,
+                        linkType: 'Entry',
+                      },
+                    },
+                  },
+                  content: [],
+                },
+              ],
+            },
+            {
+              nodeType: 'list-item',
+              data: {},
+              content: [
+                {
+                  nodeType: 'asset-hyperlink',
+                  data: {
+                    target: {
+                      sys: {
+                        id: entityIds.ASSET1,
+                        type: 'Link',
+                        linkType: 'Asset',
+                      },
+                    },
+                  },
+                  content: [],
+                },
+              ],
+            },
+            {
+              nodeType: 'list-item',
+              data: {},
+              content: [
+                {
+                  nodeType: 'entry-hyperlink',
+                  data: {
+                    target: {
+                      sys: {
+                        id: entityIds.ENTRY2,
+                        type: 'Link',
+                        linkType: 'Entry',
+                      },
+                    },
+                  },
+                  content: [],
+                },
+              ],
+            },
+          ],
         },
       ],
     },

--- a/packages/core/src/utils/transformers/transformBoundContentValue.spec.ts
+++ b/packages/core/src/utils/transformers/transformBoundContentValue.spec.ts
@@ -10,6 +10,7 @@ import {
   entryWithEmbeddedEntry,
   entryWithAnotherEmbeddedEntry,
   entryWithEmbeddedEntries,
+  entryWithDeeplyEmbeddedEntitiesInRichText,
 } from '@/test/__fixtures__/entities';
 import {
   BoundValue,
@@ -28,6 +29,7 @@ const entityStore = new EditorModeEntityStore({
     entryWithAnotherEmbeddedEntry,
     entryWithEmbeddedEntryInRichText,
     entryWithEmbeddedAssetInRichText,
+    entryWithDeeplyEmbeddedEntitiesInRichText,
     ...assets,
   ],
   locale: 'en-US',
@@ -260,6 +262,93 @@ describe('transformBoundContentValue', () => {
             ],
             data: {},
             nodeType: 'paragraph',
+          },
+        ],
+        data: {},
+        nodeType: 'document',
+      });
+    });
+
+    it('when rich text has a deeply embedded entry in the document node tree, it should transform the rich text and resolve the entry', () => {
+      const variableName = 'richText';
+      const resolveDesignValue = vitest.fn();
+      const binding: UnresolvedLink<'Entry'> = {
+        sys: {
+          type: 'Link',
+          linkType: 'Entry',
+          id: entityIds.ENTRY_WITH_DEEPLY_EMBEDDED_ENTITIES_IN_RICH_TEXT,
+        },
+      };
+
+      const path = (variables.body as BoundValue).path;
+      const result = transformBoundContentValue(
+        variables,
+        entityStore,
+        binding,
+        resolveDesignValue,
+        variableName,
+        componentDefinition.variables.description,
+        path,
+      );
+      expect(result).toEqual({
+        content: [
+          {
+            nodeType: 'unordered-list',
+            data: {},
+            content: [
+              {
+                nodeType: 'list-item',
+                data: {},
+                content: [
+                  {
+                    nodeType: 'embedded-asset-block',
+                    data: {
+                      target: assets.find((asset) => asset.sys.id === entityIds.ASSET1)!,
+                    },
+                    content: [],
+                  },
+                ],
+              },
+              {
+                nodeType: 'list-item',
+                data: {},
+                content: [
+                  {
+                    nodeType: 'embedded-entry-block',
+                    data: {
+                      target: entries.find((entry) => entry.sys.id === entityIds.ENTRY1)!,
+                    },
+                    content: [],
+                  },
+                ],
+              },
+              {
+                nodeType: 'list-item',
+                data: {},
+                content: [
+                  {
+                    nodeType: 'asset-hyperlink',
+                    data: {
+                      target: assets.find((entry) => entry.sys.id === entityIds.ASSET1)!,
+                    },
+                    content: [],
+                  },
+                ],
+              },
+              {
+                nodeType: 'list-item',
+                data: {},
+                content: [
+                  {
+                    nodeType: 'entry-hyperlink',
+                    data: {
+                      target: entries.find((entry) => entry.sys.id === entityIds.ENTRY2)!,
+                    },
+                    content: [],
+                  },
+                ],
+              },
+            ],
           },
         ],
         data: {},

--- a/packages/experience-builder-sdk/package.json
+++ b/packages/experience-builder-sdk/package.json
@@ -45,7 +45,7 @@
     "@contentful/experiences-core": "file:../core",
     "@contentful/experiences-validators": "file:../validators",
     "@contentful/experiences-visual-editor-react": "file:../visual-editor",
-    "@contentful/rich-text-types": "^16.2.1",
+    "@contentful/rich-text-types": "^17.0.0",
     "classnames": "^2.3.2",
     "csstype": "^3.1.2",
     "immer": "^10.0.3",

--- a/packages/test-apps/nextjs/src/components/KitchenSink.tsx
+++ b/packages/test-apps/nextjs/src/components/KitchenSink.tsx
@@ -68,7 +68,7 @@ const KitchenSink: React.FC<KitchenSinkProps> = ({
         <div>
           <h3>Rich Text</h3>
           <h4>type: {typeof richText}</h4>
-          <div>{JSON.stringify(richText, null, 2)}</div>
+          <pre>{JSON.stringify(richText, null, 2)}</pre>
           <div>
             <RichText value={richText} />
           </div>

--- a/packages/test-apps/react-vite/src/components/KitchenSink.tsx
+++ b/packages/test-apps/react-vite/src/components/KitchenSink.tsx
@@ -68,7 +68,7 @@ const KitchenSink: React.FC<KitchenSinkProps> = ({
         <div>
           <h3>Rich Text</h3>
           <h4>type: {typeof richText}</h4>
-          <div>{JSON.stringify(richText, null, 2)}</div>
+          <pre>{JSON.stringify(richText, null, 2)}</pre>
           <div>
             <RichText value={richText} />
           </div>


### PR DESCRIPTION
## Purpose

[ALT-1493] - when hyperlink to an asset or entry in a rich text field and binding it to a rich text variable in studio, the entities where not being resolved.

## Approach

<!--
Remember when merging:
- Use "Squash and merge" when merging changes into development.
- Use "Create a merge commit" when releasing changes into next and main.

Three important notes on pull requests:
- In general, you should ask yourself whether this code change will improve or worsen the overall code quality. Any new tech debt will probably never be cleaned up.
- Please remember that newly introduced logic should be validated and protected through testing.
- Take a look at PR guides:
  Google's Code Review Guidelines: https://google.github.io/eng-practices/
  Blockly - Writing a Good Pull Request: https://developers.google.com/blockly/guides/contribute/get-started/write_a_good_pr
-->


[ALT-1493]: https://contentful.atlassian.net/browse/ALT-1493?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ