### PR TITLE
fix(experience-builder-sdk): SSR classNames not being attached to components rendered in SSR [ZEND-5755]

### DIFF
--- a/packages/experience-builder-sdk/src/blocks/preview/CompositionBlock.tsx
+++ b/packages/experience-builder-sdk/src/blocks/preview/CompositionBlock.tsx
@@ -90,6 +90,7 @@ export const CompositionBlock = ({
       };
     }
 
+    // TODO: remove the deep tertiaries for better clarity and maintainability
     const propMap: Record<string, PrimitiveValue> = {
       cfSsrClassName:
         node.id && getPatternChildNodeClassName
@@ -201,6 +202,7 @@ export const CompositionBlock = ({
 
   const { component } = componentRegistration;
 
+  // Retrieves the CSS class name for a given child node ID.
   const _getPatternChildNodeClassName = (childNodeId: string) => {
     if (isAssembly) {
       // @ts-expect-error -- property cfSsrClassName is a map (id to classNames) that is added during rendering in ssrStyles

--- a/packages/experience-builder-sdk/src/blocks/preview/CompositionBlock.tsx
+++ b/packages/experience-builder-sdk/src/blocks/preview/CompositionBlock.tsx
@@ -222,7 +222,9 @@ export const CompositionBlock = ({
           return (
             <CompositionBlock
               getPatternChildNodeClassName={
-                getPatternChildNodeClassName && _getPatternChildNodeClassName
+                isAssembly || getPatternChildNodeClassName
+                  ? _getPatternChildNodeClassName
+                  : undefined
               }
               node={childNode}
               key={index}

--- a/packages/experience-builder-sdk/src/blocks/preview/CompositionBlock.tsx
+++ b/packages/experience-builder-sdk/src/blocks/preview/CompositionBlock.tsx
@@ -91,14 +91,15 @@ export const CompositionBlock = ({
     }
 
     const propMap: Record<string, PrimitiveValue> = {
-      cfSsrClassName: node.id
-        ? getPatternChildNodeClassName?.(node.id)
-        : node.variables.cfSsrClassName
-          ? resolveDesignValue(
-              (node.variables.cfSsrClassName as DesignValue).valuesByBreakpoint,
-              'cfSsrClassName',
-            )
-          : undefined,
+      cfSsrClassName:
+        node.id && getPatternChildNodeClassName
+          ? getPatternChildNodeClassName?.(node.id)
+          : node.variables.cfSsrClassName
+            ? resolveDesignValue(
+                (node.variables.cfSsrClassName as DesignValue).valuesByBreakpoint,
+                'cfSsrClassName',
+              )
+            : undefined,
     };
 
     const props = Object.entries(componentRegistration.definition.variables).reduce(
@@ -220,7 +221,9 @@ export const CompositionBlock = ({
       ? node.children.map((childNode: ComponentTreeNode, index) => {
           return (
             <CompositionBlock
-              getPatternChildNodeClassName={_getPatternChildNodeClassName}
+              getPatternChildNodeClassName={
+                getPatternChildNodeClassName && _getPatternChildNodeClassName
+              }
               node={childNode}
               key={index}
               locale={locale}


### PR DESCRIPTION
## Purpose

Fixed an issue in `CompositionBlock` where `cfSsrClassName` was being set to `undefined` when `getPatternChildNodeClassName` was not defined. Added checks to ensure `getPatternChildNodeClassName` exists before calling it, ensuring SSR class names are applied when rendering components in preview/delivery.

For internal tracking: https://contentful.atlassian.net/browse/ZEND-5755

