### PR TITLE
feat(components): rename builtin component content fields [LUMOS-459]

### DIFF
--- a/packages/components/src/components/Button/index.ts
+++ b/packages/components/src/components/Button/index.ts
@@ -82,7 +82,7 @@ export const ButtonComponentDefinition: ComponentDefinition = {
       defaultValue: 'center',
     },
     label: {
-      displayName: 'Label',
+      displayName: 'Text',
       type: 'Text',
       defaultValue: 'Button',
     },
@@ -91,7 +91,7 @@ export const ButtonComponentDefinition: ComponentDefinition = {
       type: 'Hyperlink',
     },
     target: {
-      displayName: 'Target',
+      displayName: 'URL behavior',
       type: 'Text',
       defaultValue: '',
     },

--- a/packages/components/src/components/RichText/index.ts
+++ b/packages/components/src/components/RichText/index.ts
@@ -56,7 +56,7 @@ export const RichTextComponentDefinition: ComponentDefinition = {
       defaultValue: 'fit-content',
     },
     value: {
-      displayName: 'Value',
+      displayName: 'Text',
       description: 'The text to display.',
       type: 'RichText',
       defaultValue: {

--- a/packages/components/src/components/Text/index.ts
+++ b/packages/components/src/components/Text/index.ts
@@ -41,7 +41,7 @@ export const TextComponentDefinition: ComponentDefinition = {
       defaultValue: 'fit-content',
     },
     value: {
-      displayName: 'Value',
+      displayName: 'Text',
       description: 'The text to display. If not provided, children will be used instead.',
       type: 'Text',
       defaultValue: 'Text',
@@ -70,7 +70,7 @@ export const TextComponentDefinition: ComponentDefinition = {
       defaultValue: '',
     },
     target: {
-      displayName: 'Target',
+      displayName: 'URL behavior',
       type: 'Text',
       defaultValue: '',
     },

--- a/packages/core/src/definitions/styles.ts
+++ b/packages/core/src/definitions/styles.ts
@@ -134,7 +134,7 @@ export const builtInStyles: Partial<DesignVariableMap> = {
     defaultValue: '0px',
   },
   cfHyperlink: {
-    displayName: 'Hyperlink',
+    displayName: 'URL',
     type: 'Hyperlink',
     defaultValue: '',
     validations: {
@@ -143,7 +143,7 @@ export const builtInStyles: Partial<DesignVariableMap> = {
     description: 'hyperlink for section or container',
   },
   cfOpenInNewTab: {
-    displayName: 'Hyperlink behaviour',
+    displayName: 'URL behaviour',
     type: 'Boolean',
     defaultValue: false,
     description: 'Open in new tab',


### PR DESCRIPTION
## Purpose
Rename specific built-in component fields. This is only changing the displayName field so no breaking changes.

Ticket: https://contentful.atlassian.net/browse/LUMOS-459