### PR TITLE
feat: add more strict id schema for component tree node

### DIFF
--- a/packages/validators/src/schemas/v2023_09_28/experience.ts
+++ b/packages/validators/src/schemas/v2023_09_28/experience.ts
@@ -113,9 +113,13 @@ const UnboundValuesSchema = z.record(
   }),
 );
 
+export const ComponentTreeNodeIdSchema = z
+  .string()
+  .regex(/^[a-zA-Z0-9]{1,8}$/, { message: 'Does not match /^[a-zA-Z0-9]{1,8}$/' });
+
 // Use helper schema to define a recursive schema with its type correctly below
 const BaseComponentTreeNodeSchema = z.object({
-  id: uuidKeySchema.optional(),
+  id: ComponentTreeNodeIdSchema.optional(),
   definitionId: DefinitionPropertyKeySchema,
   displayName: z.string().optional(),
   slotId: z.string().optional(),

--- a/packages/validators/src/validators/tests/componentTree.spec.ts
+++ b/packages/validators/src/validators/tests/componentTree.spec.ts
@@ -275,7 +275,7 @@ describe('componentTree', () => {
       },
     );
 
-    it.each(['some-uuid', undefined])('succeeds if id is %s', (id) => {
+    it.each(['someuuid', undefined])('succeeds if id is %s', (id) => {
       const componentTree = experience.fields.componentTree[locale];
       const child = {
         id,


### PR DESCRIPTION
Enforces a stricter schema for the `id` property of component tree node.

## Purpose

In https://github.com/contentful/user_interface/pull/24351 we introduced a change to persist component tree node ids in experiences and patterns. As part of that change -- mostly to ensure payloads were manageable in size -- we introduced a shorter key length and more constrained alphabet.

This PR aligns the experience schema with that change.

## Approach

* Introduce a new schema for the id instead of modifing the existing uuid schema. That schema is used elsewhere -- and additionally the new schema is not really a uuid.
* Export the schema so that it can be referenced directly elsewhere (this allows us to remove some hard coding in tests in the web app)

## Learnings

There was a small learning related to the parallel tree representations we store and manage on the web app and in the visual editor of the SDK. Specifically, we learned that the ids _generated_ by the visual editor tree are not used on the web app tree -- which likewise means our tree updating is probably not as efficient as it could be (this has zero practical consequence however).

The main concern was that the ids generated in visual editor do not conform to the id schema introduced here -- so if there were ever a need to align those ids, the generateId function used to generate node ids [here](https://github.com/contentful/experience-builder/blob/a894b2014a2857a60cef5af87f304f1396fbf815/packages/visual-editor/src/utils/createTreeNode.ts#L14) would need to be updated.

<!--
Remember when merging:
- Use "Squash and merge" when merging changes into development.
- Use "Create a merge commit" when releasing changes into next and main.

Three important notes on pull requests:
- In general, you should ask yourself whether this code change will improve or worsen the overall code quality. Any new tech debt will probably never be cleaned up.
- Please remember that newly introduced logic should be validated and protected through testing.
- Take a look at PR guides:
  Google's Code Review Guidelines: https://google.github.io/eng-practices/
  Blockly - Writing a Good Pull Request: https://developers.google.com/blockly/guides/contribute/get-started/write_a_good_pr
-->
