### PR TITLE
fix: render patterns in preview [SPA-2518]

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -362,7 +362,7 @@ export interface Experience<T extends EntityStore = EntityStore> {
 }
 
 export type ResolveDesignValueType = (
-  valuesByBreakpoint: ValuesByBreakpoint,
+  valuesByBreakpoint: ValuesByBreakpoint | undefined,
   variableName: string,
 ) => PrimitiveValue;
 

--- a/packages/core/src/utils/breakpoints.ts
+++ b/packages/core/src/utils/breakpoints.ts
@@ -96,7 +96,7 @@ export const isValidBreakpointValue = (value: PrimitiveValue) => {
 };
 
 export const getValueForBreakpoint = (
-  valuesByBreakpoint: ValuesByBreakpoint,
+  valuesByBreakpoint: ValuesByBreakpoint | undefined,
   breakpoints: Breakpoint[],
   activeBreakpointIndex: number,
   variableName: string,
@@ -136,5 +136,4 @@ export const getValueForBreakpoint = (
     // Old design properties did not support breakpoints, keep for backward compatibility
     return valuesByBreakpoint;
   }
-  return undefined;
 };

--- a/packages/experience-builder-sdk/src/blocks/preview/CompositionBlock.tsx
+++ b/packages/experience-builder-sdk/src/blocks/preview/CompositionBlock.tsx
@@ -78,29 +78,23 @@ export const CompositionBlock = ({
   }, [isAssembly, node.definitionId]);
 
   const nodeProps = useMemo(() => {
+    // In SSR, we store the className under breakpoints[0] which is resolved here to the actual string
+    const cfSsrClassNameValues = node.variables.cfSsrClassName as DesignValue | undefined;
+    const cfSsrClassName = resolveDesignValue(
+      cfSsrClassNameValues?.valuesByBreakpoint,
+      'cfSsrClassName',
+    );
+
     // Don't enrich the assembly wrapper node with props
     if (!componentRegistration || isAssembly) {
-      return {
-        cfSsrClassName: node.variables.cfSsrClassName
-          ? resolveDesignValue(
-              (node.variables.cfSsrClassName as DesignValue).valuesByBreakpoint,
-              'cfSsrClassName',
-            )
-          : undefined,
-      };
+      return { cfSsrClassName };
     }
 
-    // TODO: remove the deep tertiaries for better clarity and maintainability
     const propMap: Record<string, PrimitiveValue> = {
       cfSsrClassName:
         node.id && getPatternChildNodeClassName
-          ? getPatternChildNodeClassName?.(node.id)
-          : node.variables.cfSsrClassName
-            ? resolveDesignValue(
-                (node.variables.cfSsrClassName as DesignValue).valuesByBreakpoint,
-                'cfSsrClassName',
-              )
-            : undefined,
+          ? getPatternChildNodeClassName(node.id)
+          : cfSsrClassName,
     };
 
     const props = Object.entries(componentRegistration.definition.variables).reduce(
@@ -184,11 +178,13 @@ export const CompositionBlock = ({
 
     return props;
   }, [
+    resolveDesignValue,
+    node.variables,
+    node.id,
+    node.children,
     componentRegistration,
     isAssembly,
-    node.children,
-    node.variables,
-    resolveDesignValue,
+    getPatternChildNodeClassName,
     entityStore,
     hyperlinkPattern,
     locale,
@@ -206,14 +202,9 @@ export const CompositionBlock = ({
   const _getPatternChildNodeClassName = (childNodeId: string) => {
     if (isAssembly) {
       // @ts-expect-error -- property cfSsrClassName is a map (id to classNames) that is added during rendering in ssrStyles
-      const classesForNode = node.variables.cfSsrClassName[childNodeId];
-      if (classesForNode) {
-        return resolveDesignValue(
-          (classesForNode as DesignValue).valuesByBreakpoint,
-          'cfSsrClassName',
-        ) as string;
-      }
-      return;
+      const classesForNode: DesignValue | undefined = node.variables.cfSsrClassName?.[childNodeId];
+      if (!classesForNode) return undefined;
+      return resolveDesignValue(classesForNode.valuesByBreakpoint, 'cfSsrClassName') as string;
     }
     return getPatternChildNodeClassName?.(childNodeId);
   };

--- a/packages/experience-builder-sdk/src/hooks/useBreakpoints.ts
+++ b/packages/experience-builder-sdk/src/hooks/useBreakpoints.ts
@@ -1,9 +1,4 @@
-import type {
-  ValuesByBreakpoint,
-  Breakpoint,
-  PrimitiveValue,
-  ResolveDesignValueType,
-} from '@contentful/experiences-core/types';
+import type { Breakpoint, ResolveDesignValueType } from '@contentful/experiences-core/types';
 import {
   mediaQueryMatcher,
   getFallbackBreakpointIndex,
@@ -55,7 +50,7 @@ export const useBreakpoints = (breakpoints: Breakpoint[]) => {
   );
 
   const resolveDesignValue: ResolveDesignValueType = useCallback(
-    (valuesByBreakpoint: ValuesByBreakpoint, variableName: string): PrimitiveValue => {
+    (valuesByBreakpoint, variableName) => {
       return getValueForBreakpoint(
         valuesByBreakpoint,
         breakpoints,

--- a/packages/visual-editor/src/hooks/useBreakpoints.ts
+++ b/packages/visual-editor/src/hooks/useBreakpoints.ts
@@ -58,7 +58,7 @@ export const useBreakpoints = (breakpoints: Breakpoint[]) => {
   );
 
   const resolveDesignValue: ResolveDesignValueType = useCallback(
-    (valuesByBreakpoint: ValuesByBreakpoint, variableName: string): PrimitiveValue => {
+    (valuesByBreakpoint, variableName) => {
       return getValueForBreakpoint(
         valuesByBreakpoint,
         breakpoints,

--- a/packages/visual-editor/src/hooks/useBreakpoints.ts
+++ b/packages/visual-editor/src/hooks/useBreakpoints.ts
@@ -1,9 +1,4 @@
-import type {
-  ValuesByBreakpoint,
-  Breakpoint,
-  PrimitiveValue,
-  ResolveDesignValueType,
-} from '@contentful/experiences-core/types';
+import type { Breakpoint, ResolveDesignValueType } from '@contentful/experiences-core/types';
 import {
   mediaQueryMatcher,
   getFallbackBreakpointIndex,


### PR DESCRIPTION
## Purpose

As a regression of https://github.com/contentful/experience-builder/pull/874, the application would crash everytime when `cfSsrClassName` was not defined, i.e. when not running in SSR.

![Screenshot 2024-12-19 at 09 12 27](https://github.com/user-attachments/assets/5df21499-9c87-417c-bee5-eaf810cc4113)

## Approach
Simplify the ternary conditions and remove some duplicate conditional checks. As `resolveDesignValue` handles undefined values, I adjusted its types and was able to further reduce our conditional logic in `CompositionBlock`.