### PR TITLE
chore(components): remove type and as field from built-in components [LUMOS-460, LUMOS-461]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39727,10 +39727,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/studio-experiences-react-app": {
-      "resolved": "packages/create-contentful-studio-experiences/studio-experiences-react-app",
-      "link": true
-    },
     "node_modules/style-inject": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/style-inject/-/style-inject-0.3.0.tgz",
@@ -44292,6 +44288,7 @@
     },
     "packages/create-contentful-studio-experiences/studio-experiences-react-app": {
       "version": "0.0.0",
+      "extraneous": true,
       "dependencies": {
         "@contentful/experiences-sdk-react": "^1.9.0",
         "react": "^18.3.1",

--- a/packages/components/src/components/Heading/index.ts
+++ b/packages/components/src/components/Heading/index.ts
@@ -66,22 +66,5 @@ export const HeadingComponentDefinition: ComponentDefinition = {
       description: 'The text to display in the heading.',
       defaultValue: 'Heading',
     },
-    type: {
-      displayName: 'Type',
-      type: 'Text',
-      defaultValue: 'h1',
-      description:
-        'Determines the HTML tag of the heading. Value can be h1, h2, h3, h4, h5, or h6.',
-      validations: {
-        in: [
-          { value: 'h1', displayName: 'H1' },
-          { value: 'h2', displayName: 'H2' },
-          { value: 'h3', displayName: 'H3' },
-          { value: 'h4', displayName: 'H4' },
-          { value: 'h5', displayName: 'H5' },
-          { value: 'h6', displayName: 'H6' },
-        ],
-      },
-    },
   },
 };

--- a/packages/components/src/components/Text/index.ts
+++ b/packages/components/src/components/Text/index.ts
@@ -46,24 +46,6 @@ export const TextComponentDefinition: ComponentDefinition = {
       type: 'Text',
       defaultValue: 'Text',
     },
-    as: {
-      displayName: 'As',
-      description: 'Renders the text in a specific HTML tag.',
-      type: 'Text',
-      defaultValue: 'p',
-      validations: {
-        in: [
-          { value: 'p', displayName: 'p' },
-          { value: 'span', displayName: 'span' },
-          { value: 'div', displayName: 'div' },
-          { value: 'label', displayName: 'label' },
-          { value: 'caption', displayName: 'caption' },
-          { value: 'small', displayName: 'small' },
-          { value: 'strong', displayName: 'strong' },
-          { value: 'em', displayName: 'em' },
-        ],
-      },
-    },
     url: {
       displayName: 'URL',
       type: 'Text',


### PR DESCRIPTION
## Purpose
As part of our content binding redesign, we are cleaning up the naming conventions and fields used for built-in components. This PR is for removing the AS field from the Text component and the Type field from the Heading component.

Tickets:
- https://contentful.atlassian.net/browse/LUMOS-460
- https://contentful.atlassian.net/browse/LUMOS-461