### PR TITLE
chore: rename and move variables to design tab for text and heading [LUMOS-482]

### DIFF
--- a/packages/components/src/components/Heading/index.ts
+++ b/packages/components/src/components/Heading/index.ts
@@ -67,9 +67,10 @@ export const HeadingComponentDefinition: ComponentDefinition = {
       defaultValue: 'Heading',
     },
     type: {
-      displayName: 'Type',
+      displayName: 'HTML tag',
       type: 'Text',
       defaultValue: 'h1',
+      group: 'style',
       description:
         'Determines the HTML tag of the heading. Value can be h1, h2, h3, h4, h5, or h6.',
       validations: {

--- a/packages/components/src/components/Text/index.ts
+++ b/packages/components/src/components/Text/index.ts
@@ -47,10 +47,11 @@ export const TextComponentDefinition: ComponentDefinition = {
       defaultValue: 'Text',
     },
     as: {
-      displayName: 'As',
+      displayName: 'HTML tag',
       description: 'Renders the text in a specific HTML tag.',
       type: 'Text',
       defaultValue: 'p',
+      group: 'style',
       validations: {
         in: [
           { value: 'p', displayName: 'p' },


### PR DESCRIPTION
## Purpose
The `as` variable for the Text built-in component and the `type` variable for the Heading built-in component should be moved to the design tab and have the display name changed to `HTML tag`

Ticket: https://contentful.atlassian.net/browse/LUMOS-482

NOTE:
This has been tested and it does not break existing experiences that have content bound to these variables. Even though the variable is moved from the content to the design tab, previously set values (whether a bound entry, asset, or manual text) are persisted. When the value is changed from the design tab, it still works as expected.

Text component
<img width="313" alt="Screenshot 2025-01-08 at 11 05 25 AM" src="https://github.com/user-attachments/assets/015935b8-c71c-4482-8b19-6b336b35237f" />

Heading component
<img width="311" alt="Screenshot 2025-01-08 at 11 05 35 AM" src="https://github.com/user-attachments/assets/17174189-5a54-4a40-9458-f5ac18946267" />
