### PR TITLE
fix(components): add className to anchor tag when passing url to the Text component [ALT-1522]

### DIFF
--- a/packages/components/src/components/Text/Text.css
+++ b/packages/components/src/components/Text/Text.css
@@ -1,3 +1,7 @@
 .cf-text {
   white-space: pre-line;
 }
+
+.cf-text-link .cf-text {
+  margin: 0;
+}

--- a/packages/components/src/components/Text/Text.cy.tsx
+++ b/packages/components/src/components/Text/Text.cy.tsx
@@ -42,7 +42,7 @@ describe('Text', () => {
   });
 
   it('has a wrapping anchor tag with the class "cf-text-link" when a url is provided', () => {
-    cy.mount(<Text value="My Text" className="custom-class" url="#link" />);
+    cy.mount(<Text value="My Text" url="#link" />);
     cy.get('a').should('have.class', 'cf-text-link');
   });
 

--- a/packages/components/src/components/Text/Text.cy.tsx
+++ b/packages/components/src/components/Text/Text.cy.tsx
@@ -26,7 +26,7 @@ describe('Text', () => {
     cy.mount(
       <Text value="My Text" data-foo="bar">
         Children text
-      </Text>
+      </Text>,
     );
     cy.get('p').should('have.attr', 'data-foo', 'bar');
   });
@@ -39,5 +39,15 @@ describe('Text', () => {
   it('has a default class of "cf-text"', () => {
     cy.mount(<Text value="My Text" />);
     cy.get('p').should('have.class', 'cf-text');
+  });
+
+  it('has a wrapping anchor tag with the class "cf-text-link" when a url is provided', () => {
+    cy.mount(<Text value="My Text" className="custom-class" url="#link" />);
+    cy.get('a').should('have.class', 'cf-text-link');
+  });
+
+  it('when className and url are provided, the className should be added to the anchor tag', () => {
+    cy.mount(<Text value="My Text" className="custom-class" url="#link" />);
+    cy.get('a').should('have.class', 'custom-class');
   });
 });

--- a/packages/components/src/components/Text/Text.tsx
+++ b/packages/components/src/components/Text/Text.tsx
@@ -83,6 +83,20 @@ export const Text: React.FC<TextProps> = ({
   onClick,
   ...props
 }) => {
+  const Tag = as;
+
+  if (url) {
+    return (
+      <a
+        className={combineClasses('cf-text-link', className)}
+        href={url}
+        {...(target ? { target } : {})}
+        {...props}>
+        <Tag className="cf-text">{value ? value : children}</Tag>
+      </a>
+    );
+  }
+
   const handleClick = (event: React.MouseEvent<HTMLElement>) => {
     if (onNavigate && url) {
       event.preventDefault();
@@ -91,9 +105,7 @@ export const Text: React.FC<TextProps> = ({
     onClick && onClick(event);
   };
 
-  const Tag = as;
-
-  const textAsTag = (
+  return (
     <Tag
       className={combineClasses('cf-text', className)}
       onClick={handleClick}
@@ -102,18 +114,5 @@ export const Text: React.FC<TextProps> = ({
       {...props}>
       {value ? value : children}
     </Tag>
-  );
-
-  if (!url) {
-    return textAsTag;
-  }
-
-  return (
-    <a
-      className={combineClasses('cf-text-link', className)}
-      href={url}
-      {...(target ? { target } : {})}>
-      {textAsTag}
-    </a>
   );
 };

--- a/packages/components/src/components/Text/Text.tsx
+++ b/packages/components/src/components/Text/Text.tsx
@@ -109,7 +109,10 @@ export const Text: React.FC<TextProps> = ({
   }
 
   return (
-    <a className="cf-text-link" href={url} {...(target ? { target } : {})}>
+    <a
+      className={combineClasses('cf-text-link', className)}
+      href={url}
+      {...(target ? { target } : {})}>
       {textAsTag}
     </a>
   );


### PR DESCRIPTION
## Purpose

This change fixes an issue with the text alignment when a URL is bound to a built-in Text component.

Editor:
![Screenshot 2025-01-10 at 3 08 06 PM](https://github.com/user-attachments/assets/2f8b4593-a989-4d11-83da-e1fdb3016300)

Delivery:
![Screenshot 2025-01-10 at 3 42 21 PM](https://github.com/user-attachments/assets/c2aea8f2-c52b-4333-b5b3-08b2fb8aa47a)

