### PR TITLE
Validations/binding source type

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -15,6 +15,7 @@ import type {
   PrimitiveValue,
   ExperienceComponentTree,
   ComponentDefinitionPropertyType,
+  BindingSourceTypeEnum,
 } from '@contentful/experiences-validators';
 export type {
   ExperienceDataSource,
@@ -78,6 +79,7 @@ export type ComponentDefinitionVariableValidation<T extends ComponentDefinitionP
   required?: boolean;
   in?: ValidationOption<T>[];
   format?: VariableFormats;
+  bindingSourceType?: BindingSourceTypeEnum;
 };
 
 export interface ComponentDefinitionVariableBase<T extends ComponentDefinitionPropertyType> {

--- a/packages/validators/src/schemas/index.ts
+++ b/packages/validators/src/schemas/index.ts
@@ -1,2 +1,5 @@
-export { ExperienceFieldsCMAShapeSchema as Schema_2023_09_28 } from './v2023_09_28/experience';
+export {
+  BindingSourceTypeEnum,
+  ExperienceFieldsCMAShapeSchema as Schema_2023_09_28,
+} from './v2023_09_28/experience';
 export { ComponentDefinitionSchema } from './componentDefinition';

--- a/packages/validators/src/schemas/v2023_09_28/experience.ts
+++ b/packages/validators/src/schemas/v2023_09_28/experience.ts
@@ -132,6 +132,10 @@ const ComponentTreeNodeSchema: z.ZodType<ComponentTreeNode> = BaseComponentTreeN
   children: z.lazy(() => ComponentTreeNodeSchema.array()),
 });
 
+const BindingSourceTypeEnumSchema = z
+  .array(z.enum(['entry', 'asset', 'manual', 'experience']))
+  .nonempty();
+
 export const ComponentVariableSchema = z.object({
   displayName: z.string().optional(),
   type: DefinitionPropertyTypeSchema,
@@ -140,6 +144,7 @@ export const ComponentVariableSchema = z.object({
   defaultValue: PrimitiveValueSchema.or(ComponentPropertyValueSchema).optional(),
   validations: z
     .object({
+      bindingSourceType: BindingSourceTypeEnumSchema.optional(),
       required: z.boolean().optional(),
       format: z.literal('URL').optional(),
       in: z
@@ -249,3 +254,4 @@ export type BoundValue = z.infer<typeof BoundValueSchema>;
 export type UnboundValue = z.infer<typeof UnboundValueSchema>;
 export type HyperlinkValue = z.infer<typeof HyperlinkValueSchema>;
 export type ComponentValue = z.infer<typeof ComponentValueSchema>;
+export type BindingSourceTypeEnum = z.infer<typeof BindingSourceTypeEnumSchema>;


### PR DESCRIPTION
### Context
There are certain component properties where it doesn't make sense to bind certain types of content. 

1. Binding an image to an Experience doesn't make any sense, nor does manually binding an image.
2. Binding an URL behavior to an asset also doesn't make sense.

## Purpose
Add a new optional validation called `bindingSourceType` to the existing validation object, enabling component properties to be optionally configured to restrict what types of content binding
(entry, manual, asserts, experience).




## Approach
Add a new Zod enum/array to describe the schema of this new validation, export that data structure for re-use in the `core` package.
