### PR TITLE
fix: let visibility display style take precedence when toggled [SPA-2468]

### DIFF
--- a/packages/core/src/utils/styleUtils/styleTransformers.ts
+++ b/packages/core/src/utils/styleUtils/styleTransformers.ts
@@ -9,7 +9,7 @@ import {
 export const transformVisibility = (value?: boolean): CSSProperties => {
   if (value === false) {
     return {
-      display: 'none',
+      display: 'none !important',
     };
   }
   // Don't explicitly set anything when visible to not overwrite values like `grid` or `flex`.


### PR DESCRIPTION
## Purpose

Let visibility display style take precedence when toggled

Following Amr discovery in the video below, some components have inline display which overrides the transform visibility `display: none` 

Bug Video

https://github.com/user-attachments/assets/8ab30fb0-fca9-4c1b-8feb-977944bc0a35

This PR ensures the transform visibility `display: none` takes precedence when the value is false

Fix after PR

https://github.com/user-attachments/assets/67f96e78-cbdf-409d-92e0-aa580c5a0e46




