### PR TITLE
fix(experience-builder-sdk): remove race condition in mode detection when reloading the canvas on save [SPA-2511]

### DIFF
--- a/packages/experience-builder-sdk/src/hooks/useFetchByBase.ts
+++ b/packages/experience-builder-sdk/src/hooks/useFetchByBase.ts
@@ -32,6 +32,17 @@ export const useFetchByBase = (
     })();
   }, [fetchMethod, mode]);
 
+  // When a save event caused a canvas reload, the `receivedModeMessage` might time out and set the
+  // mode temporarily to NONE. If it's set to a valid mode afterward, we ignore the fetch result.
+  if (mode === StudioCanvasMode.EDITOR || mode === StudioCanvasMode.READ_ONLY) {
+    return {
+      error: undefined,
+      experience: undefined,
+      isLoading: false,
+      mode,
+    };
+  }
+
   return {
     error,
     experience,

--- a/packages/visual-editor/src/components/RootRenderer/RootRenderer.tsx
+++ b/packages/visual-editor/src/components/RootRenderer/RootRenderer.tsx
@@ -14,11 +14,11 @@ import { OUTGOING_EVENTS } from '@contentful/experiences-core/constants';
 import { useEditorStore } from '@/store/editor';
 import { Dropzone } from '@components/DraggableBlock/Dropzone';
 
-interface Props {
+interface RootRendererProperties {
   onChange?: (data: ExperienceTree) => void;
 }
 
-export const RootRenderer: React.FC<Props> = ({ onChange }) => {
+export const RootRenderer: React.FC<RootRendererProperties> = ({ onChange }) => {
   useEditorSubscriber();
 
   const dragItem = useDraggedItemStore((state) => state.componentId);


### PR DESCRIPTION
## Purpose

I often run into this error after hitting "save" on the editor:
![Screenshot 2025-01-22 at 10 46 26](https://github.com/user-attachments/assets/33ab1823-ba72-430a-89b9-35bb17b0592b)

## Approach

 I discovered that the detected canvas mode would not switch to `editor` in time (we wait only 100ms). This triggered the query to CPN which eventually ends in an error. As a fix, we're handling a "too late" event for requesting editor mode. In that case, we ignore the result of the API query and just do business as usual.

@ethan-ozelius-contentful we might want to revisit the current timeout of 100ms. As this could change multiple times back and forth via trial & error, I decided to implement a graceful handling of the race condition.