### PR TITLE
fix(visual-editor): handle circular pattern dependencies in the tree [SPA-2511]

### DIFF
--- a/packages/visual-editor/src/components/DraggableBlock/DropzoneClone.tsx
+++ b/packages/visual-editor/src/components/DraggableBlock/DropzoneClone.tsx
@@ -18,6 +18,7 @@ type DropzoneProps = {
   WrapperComponent?: ElementType | string;
   renderDropzone: RenderDropzoneFunction;
   dragProps?: DragWrapperProps;
+  wrappingPatternIds: Set<string>;
 };
 
 export function DropzoneClone({
@@ -27,6 +28,7 @@ export function DropzoneClone({
   WrapperComponent = 'div',
   renderDropzone,
   dragProps,
+  wrappingPatternIds,
   ...rest
 }: DropzoneProps) {
   const tree = useTreeStore((state) => state.tree);
@@ -72,6 +74,7 @@ export function DropzoneClone({
               node={item}
               resolveDesignValue={resolveDesignValue}
               renderDropzone={renderDropzone}
+              wrappingPatternIds={wrappingPatternIds}
             />
           );
         })}

--- a/packages/visual-editor/src/components/DraggableBlock/EditorBlock.tsx
+++ b/packages/visual-editor/src/components/DraggableBlock/EditorBlock.tsx
@@ -41,6 +41,7 @@ type EditorBlockProps = {
   resolveDesignValue: ResolveDesignValueType;
   renderDropzone: RenderDropzoneFunction;
   zoneId: string;
+  wrappingPatternIds: Set<string>;
 };
 
 export const EditorBlock: React.FC<EditorBlockProps> = ({
@@ -51,6 +52,7 @@ export const EditorBlock: React.FC<EditorBlockProps> = ({
   zoneId,
   userIsDragging,
   placeholder,
+  wrappingPatternIds,
 }) => {
   const { slotId } = parseZoneId(zoneId);
   const ref = useRef<HTMLElement | null>(null);
@@ -69,6 +71,7 @@ export const EditorBlock: React.FC<EditorBlockProps> = ({
     resolveDesignValue,
     renderDropzone,
     userIsDragging,
+    wrappingPatternIds,
   });
   const { isSingleColumn, isWrapped } = useSingleColumn(node, resolveDesignValue);
   const setDomRect = useDraggedItemStore((state) => state.setDomRect);

--- a/packages/visual-editor/src/components/DraggableBlock/EditorBlockClone.tsx
+++ b/packages/visual-editor/src/components/DraggableBlock/EditorBlockClone.tsx
@@ -29,6 +29,7 @@ type EditorBlockCloneProps = {
   provided?: DraggableProvided;
   snapshot?: DraggableStateSnapshot;
   renderDropzone: RenderDropzoneFunction;
+  wrappingPatternIds: Set<string>;
 };
 
 export const EditorBlockClone: React.FC<EditorBlockCloneProps> = ({
@@ -37,6 +38,7 @@ export const EditorBlockClone: React.FC<EditorBlockCloneProps> = ({
   snapshot,
   provided,
   renderDropzone,
+  wrappingPatternIds,
 }) => {
   const userIsDragging = useDraggedItemStore((state) => state.isDraggingOnCanvas);
 
@@ -45,6 +47,7 @@ export const EditorBlockClone: React.FC<EditorBlockCloneProps> = ({
     resolveDesignValue,
     renderDropzone,
     userIsDragging,
+    wrappingPatternIds,
   });
 
   const isAssemblyBlock = node.type === ASSEMBLY_BLOCK_NODE_TYPE;

--- a/packages/visual-editor/src/components/DraggableHelpers/CircularDependencyErrorPlaceholder.tsx
+++ b/packages/visual-editor/src/components/DraggableHelpers/CircularDependencyErrorPlaceholder.tsx
@@ -1,0 +1,41 @@
+import { useEntityStore } from '@/store/entityStore';
+import React, { forwardRef, HTMLAttributes } from 'react';
+
+type CircularDependencyErrorPlaceholderProperties = HTMLAttributes<HTMLDivElement> & {
+  wrappingPatternIds: Set<string>;
+};
+
+export const CircularDependencyErrorPlaceholder = forwardRef<
+  HTMLDivElement,
+  CircularDependencyErrorPlaceholderProperties
+>(({ wrappingPatternIds, ...props }, ref) => {
+  const entityStore = useEntityStore((state) => state.entityStore);
+
+  return (
+    <div
+      {...props}
+      // Pass through ref to avoid DND errors being logged
+      ref={ref}
+      data-cf-node-error="circular-pattern-dependency"
+      style={{
+        border: '1px solid red',
+        background: 'rgba(255, 0, 0, 0.1)',
+        padding: '1rem 1rem 0 1rem',
+        width: '100%',
+        height: '100%',
+      }}>
+      Circular usage of patterns detected:
+      <ul>
+        {Array.from(wrappingPatternIds).map((patternId) => {
+          const entryLink = { sys: { type: 'Link', linkType: 'Entry', id: patternId } } as const;
+          const entry = entityStore.getEntityFromLink(entryLink);
+          const entryTitle = entry?.fields?.title;
+          const text = entryTitle ? `${entryTitle} (${patternId})` : patternId;
+          return <li key={patternId}>{text}</li>;
+        })}
+      </ul>
+    </div>
+  );
+});
+
+CircularDependencyErrorPlaceholder.displayName = 'CircularDependencyErrorPlaceholder';

--- a/packages/visual-editor/src/hooks/useComponent.spec.ts
+++ b/packages/visual-editor/src/hooks/useComponent.spec.ts
@@ -69,6 +69,7 @@ describe('useComponent', () => {
           resolveDesignValue,
           renderDropzone,
           userIsDragging,
+          wrappingPatternIds: new Set(),
         }),
       );
 

--- a/packages/visual-editor/src/utils/getTreeDiff.ts
+++ b/packages/visual-editor/src/utils/getTreeDiff.ts
@@ -2,7 +2,7 @@ import { ExperienceTreeNode, ExperienceTree } from '@contentful/experiences-core
 
 import { getItem } from './getItem';
 import { isEqual } from 'lodash-es';
-import { ROOT_ID, TreeAction } from '@/types/constants';
+import { TreeAction } from '@/types/constants';
 import { TreeDiff } from '@/types/treeActions';
 
 interface MissingNodeActionParams {
@@ -101,13 +101,12 @@ function compareNodes({
   const nodeRemoved = currentNodeCount > updatedNodeCount;
   const nodeAdded = currentNodeCount < updatedNodeCount;
   const parentNodeId = updatedNode.data.id;
-  const isRoot = currentNode.data.id === ROOT_ID;
 
   /**
    * The data of the current node has changed, we need to update
    * this node to reflect the data change. (design, content, unbound values)
    */
-  if (!isRoot && !isEqual(currentNode.data, updatedNode.data)) {
+  if (!isEqual(currentNode.data, updatedNode.data)) {
     differences.push({
       type: TreeAction.UPDATE_NODE,
       nodeId: currentNode.data.id,


### PR DESCRIPTION
## Purpose
When accidentally causing a loop in the chain of pattern dependencies, the SDK would crash and the browser tab becomes not responsible.

## Approach
To address this, we want to render a similar error as we do for missing component definitions. To detect a loop during the render cycle, we pass through a list of `wrappingPatternIds` that gets extended when "diving into" a pattern node.

To detect the loop as early as possible (and not pollute the canvas with multiple instances of a single pattern), we have to know the ID of the opened experience ID. When finding the same ID again deeper inside the tree, we stop immediately the rendering cycle and render the error message. To know the global experience ID, we leverage the `blockId` of the root node. So far, it was the same as the root node id. Using this for the entry ID sounds more reasonable to me and saves us from adding another attribute or message to the communication layer.

Note: This handles only the editor case. For preview/ delivery, there will be a separate PR

![Screenshot 2025-01-22 at 17 29 17](https://github.com/user-attachments/assets/0dade721-bd46-4418-b343-ec06d0350fee)
