### PR TITLE
[LUMOS-507] feat(content binding redesign - sensible defaults): add bindingSourceType validations to built in components

### DIFF
--- a/packages/components/src/components/Button/index.ts
+++ b/packages/components/src/components/Button/index.ts
@@ -85,10 +85,16 @@ export const ButtonComponentDefinition: ComponentDefinition = {
       displayName: 'Text',
       type: 'Text',
       defaultValue: 'Button',
+      validations: {
+        bindingSourceType: ['entry', 'manual'],
+      },
     },
     url: {
       displayName: 'URL',
       type: 'Hyperlink',
+      validations: {
+        bindingSourceType: ['entry', 'experience', 'manual'],
+      },
     },
     target: {
       displayName: 'URL behavior',

--- a/packages/components/src/components/Heading/index.ts
+++ b/packages/components/src/components/Heading/index.ts
@@ -65,6 +65,9 @@ export const HeadingComponentDefinition: ComponentDefinition = {
       type: 'Text',
       description: 'The text to display in the heading.',
       defaultValue: 'Heading',
+      validations: {
+        bindingSourceType: ['entry', 'manual'],
+      },
     },
     type: {
       displayName: 'HTML tag',

--- a/packages/components/src/components/Image/index.ts
+++ b/packages/components/src/components/Image/index.ts
@@ -19,6 +19,9 @@ export const ImageComponentDefinition: ComponentDefinition = {
       displayName: 'Alt text',
       type: 'Text',
       description: 'Alternative text for the image',
+      validations: {
+        bindingSourceType: ['entry', 'manual', 'asset'],
+      },
     },
   },
 };

--- a/packages/components/src/components/RichText/index.ts
+++ b/packages/components/src/components/RichText/index.ts
@@ -59,6 +59,9 @@ export const RichTextComponentDefinition: ComponentDefinition = {
       displayName: 'Text',
       description: 'The text to display.',
       type: 'RichText',
+      validations: {
+        bindingSourceType: ['entry', 'manual'],
+      },
       defaultValue: {
         nodeType: 'document',
         data: {},

--- a/packages/components/src/components/Text/index.ts
+++ b/packages/components/src/components/Text/index.ts
@@ -45,6 +45,9 @@ export const TextComponentDefinition: ComponentDefinition = {
       description: 'The text to display. If not provided, children will be used instead.',
       type: 'Text',
       defaultValue: 'Text',
+      validations: {
+        bindingSourceType: ['manual', 'entry'],
+      },
     },
     as: {
       displayName: 'HTML tag',
@@ -69,6 +72,9 @@ export const TextComponentDefinition: ComponentDefinition = {
       displayName: 'URL',
       type: 'Text',
       defaultValue: '',
+      validations: {
+        bindingSourceType: ['entry', 'experience', 'manual'],
+      },
     },
     target: {
       displayName: 'URL behavior',

--- a/packages/core/src/definitions/styles.ts
+++ b/packages/core/src/definitions/styles.ts
@@ -139,6 +139,7 @@ export const builtInStyles: Partial<DesignVariableMap> = {
     defaultValue: '',
     validations: {
       format: 'URL',
+      bindingSourceType: ['entry', 'experience', 'manual'],
     },
     description: 'hyperlink for section or container',
   },
@@ -185,6 +186,9 @@ export const optionalBuiltInStyles: Partial<DesignVariableMap> = {
     displayName: 'Image',
     type: 'Media',
     description: 'Image to display',
+    validations: {
+      bindingSourceType: ['entry', 'asset', 'manual'],
+    },
   },
   cfImageOptions: {
     displayName: 'Image options',
@@ -207,6 +211,9 @@ export const optionalBuiltInStyles: Partial<DesignVariableMap> = {
     displayName: 'Background image',
     type: 'Media',
     description: 'Background image for component',
+    validations: {
+      bindingSourceType: ['entry', 'asset', 'manual'],
+    },
   },
   cfBackgroundImageOptions: {
     displayName: 'Background image options',


### PR DESCRIPTION
### Figma
https://www.figma.com/design/pjrHiK6yw0eIWwtQ4Zzvnn/Studio-Content-Binding?node-id=878-109152&t=PPoR63zgphoihGfy-1

## Purpose
As titled


### Screenshots
## 1. Section
a. **URL** is restricted to `Entry`, `Experience`, `Manual`
<img width="930" alt="Screenshot 2025-01-23 at 3 36 42 PM" src="https://github.com/user-attachments/assets/82708e87-9101-4e27-b9bf-4ea6af54597f" />
b. Background image is restricted to `Asset`, `Entry`, `Manual`
<img width="926" alt="Screenshot 2025-01-23 at 3 38 28 PM" src="https://github.com/user-attachments/assets/74c538c3-7faa-4ffd-8736-22e969dadf75" />

## 2. Container 
a. **URL** is restricted to `Entry`, `Experience`, `Manual`
<img width="926" alt="Screenshot 2025-01-23 at 3 41 24 PM" src="https://github.com/user-attachments/assets/b096a273-7c4b-4c0c-84d7-7e5753d74786" />
b. Background image is restricted to `Asset`, `Entry`, `Manual`
<img width="924" alt="Screenshot 2025-01-23 at 3 41 46 PM" src="https://github.com/user-attachments/assets/bf51b17f-ac7b-4d3f-9a38-bcd76c8b59c2" />

## 3. Columns
a. Background image is restricted to `Asset`, `Entry`, `Manual`
<img width="926" alt="Screenshot 2025-01-23 at 3 43 31 PM" src="https://github.com/user-attachments/assets/02b63bcb-c4c8-449a-a895-3ea51a731352" />

## 4. Column (singular)
a. Background image is restricted to `Asset`, `Entry`, `Manual`
<img width="922" alt="Screenshot 2025-01-23 at 3 44 57 PM" src="https://github.com/user-attachments/assets/400ec78c-5310-42a8-8114-3044ae53df6a" />

## 5. Button
a. **Label** is restricted to restricted to `Entry` and `Manual`
<img width="479" alt="Screenshot 2025-01-23 at 3 47 16 PM" src="https://github.com/user-attachments/assets/105fb58e-7362-451a-876a-9f84679552c3" />

b. **URL** is restricted to `Entry`, `Experience`, `Manual`
<img width="482" alt="Screenshot 2025-01-23 at 3 47 52 PM" src="https://github.com/user-attachments/assets/be51c829-7703-4edf-9564-d89c71c98764" />

## 6. Text
a. Text is restricted to `Entry` and `Manual`
<img width="926" alt="Screenshot 2025-01-23 at 3 50 41 PM" src="https://github.com/user-attachments/assets/8cec2e63-ce6c-45d7-a404-11415d5d99bc" />
b. URL is restricted to `Entry`, `Experience`, `Manual`
<img width="872" alt="Screenshot 2025-01-23 at 3 58 56 PM" src="https://github.com/user-attachments/assets/c7e0d293-e426-4778-9c22-d7658640214e" />


## 7. Image
a. Alt Text is restricted `Asset`, `Entry` and `Manual`
<img width="697" alt="Screenshot 2025-01-23 at 3 52 45 PM" src="https://github.com/user-attachments/assets/4c4ea261-8079-4dcc-b8f2-9a722153999a" />

b. Image is restricted to `Asset`, `Entry` and `Manual`
<img width="716" alt="Screenshot 2025-01-23 at 3 52 57 PM" src="https://github.com/user-attachments/assets/19f01f37-c08d-4b38-84f6-5db1ea8491f9" />

## 8. Rich Text
a. Text is restricted to `Entry` and `Manual`
<img width="745" alt="Screenshot 2025-01-23 at 3 54 00 PM" src="https://github.com/user-attachments/assets/027e1d94-1ae2-42da-83f1-9587e8763d30" />

## 9. Heading
### a. Text is restricted to `Entry` and `Manual`
<img width="874" alt="Screenshot 2025-01-23 at 3 57 37 PM" src="https://github.com/user-attachments/assets/9f553426-8d0f-4d00-838a-228407ddcc11" />



