### PR TITLE
fix(core-fetchers): remove duplicate entry IDs from API query [SPA-2559]

### DIFF
--- a/packages/core/src/fetchers/fetchReferencedEntities.ts
+++ b/packages/core/src/fetchers/fetchReferencedEntities.ts
@@ -37,24 +37,24 @@ export const fetchReferencedEntities = async ({
     experienceEntry as ExperienceEntry,
   );
 
-  const entryIds: string[] = [];
-  const assetIds: string[] = [];
+  const entryIds = new Set<string>();
+  const assetIds = new Set<string>();
 
   for (const dataBinding of Object.values((experienceEntry as ExperienceEntry).fields.dataSource)) {
     if (!('sys' in dataBinding)) {
       continue;
     }
     if (dataBinding.sys.linkType === 'Entry') {
-      entryIds.push(dataBinding.sys.id);
+      entryIds.add(dataBinding.sys.id);
     }
     if (dataBinding.sys.linkType === 'Asset') {
-      assetIds.push(dataBinding.sys.id);
+      assetIds.add(dataBinding.sys.id);
     }
   }
 
   const [entriesResponse, assetsResponse] = await Promise.all([
-    fetchAllEntries({ client, ids: entryIds, locale }),
-    fetchAllAssets({ client, ids: assetIds, locale }),
+    fetchAllEntries({ client, ids: [...entryIds], locale }),
+    fetchAllAssets({ client, ids: [...assetIds], locale }),
   ]);
 
   const { autoFetchedReferentAssets, autoFetchedReferentEntries } =


### PR DESCRIPTION
## Purpose

When fetching entries and assets based on the `dataSource`, we're not properly handling the case of entries or assets being used multiple times. While this is quite common, we're currently not storing experiences in such an "efficient" way to only have one data source for all its occurrences. So for the time being, we have to accept that there are duplicates.

## Approach
To not create extremely long query strings, a set is used instead of a plain list to collect all IDs before fetching the entities.

Example where an ID is used twice for the `sys.id[in]` filter:
![Screenshot 2025-01-28 at 10 33 47](https://github.com/user-attachments/assets/ca05f714-5452-4a29-84f8-eb6aa4901fdf)
