### PR TITLE
fix(core-fetchers): remove circular self references [SPA-2557]

### DIFF
--- a/packages/core/src/fetchers/fetchById.ts
+++ b/packages/core/src/fetchers/fetchById.ts
@@ -3,7 +3,10 @@ import { fetchExperienceEntry } from './fetchExperienceEntry';
 import { fetchReferencedEntities } from './fetchReferencedEntities';
 import { ExperienceEntry } from '@/types';
 import { ContentfulClientApi, Entry } from 'contentful';
-import { removeCircularPatternReferences } from './shared/circularityCheckers';
+import {
+  removeCircularPatternReferences,
+  removeSelfReferencingDataSource,
+} from './shared/circularityCheckers';
 
 const errorMessagesWhileFetching = {
   experience: 'Failed to fetch experience',
@@ -58,6 +61,7 @@ export async function fetchById({
     }
 
     removeCircularPatternReferences(experienceEntry as ExperienceEntry);
+    removeSelfReferencingDataSource(experienceEntry as ExperienceEntry);
 
     try {
       const { entries, assets } = await fetchReferencedEntities({

--- a/packages/core/src/fetchers/fetchBySlug.ts
+++ b/packages/core/src/fetchers/fetchBySlug.ts
@@ -3,7 +3,10 @@ import { fetchExperienceEntry } from './fetchExperienceEntry';
 import { fetchReferencedEntities } from './fetchReferencedEntities';
 import { ExperienceEntry } from '@/types';
 import { ContentfulClientApi, Entry } from 'contentful';
-import { removeCircularPatternReferences } from './shared/circularityCheckers';
+import {
+  removeCircularPatternReferences,
+  removeSelfReferencingDataSource,
+} from './shared/circularityCheckers';
 
 const errorMessagesWhileFetching = {
   experience: 'Failed to fetch experience',
@@ -58,6 +61,7 @@ export async function fetchBySlug({
     }
 
     removeCircularPatternReferences(experienceEntry as ExperienceEntry);
+    removeSelfReferencingDataSource(experienceEntry as ExperienceEntry);
 
     try {
       const { entries, assets } = await fetchReferencedEntities({


### PR DESCRIPTION
## Purpose
When creating a hyperlink that points to the experience entry itself, this breaks SSR applications preview/ delivery mode.

![Screenshot 2025-01-28 at 11 11 53](https://github.com/user-attachments/assets/75f4aefd-f9a5-4c0b-890f-4a3d12ca24d4)


## Approach
Similar to the circularity check for `usedComponents`, circular references are replaced by a plain link.