### PR TITLE
fix: dont recreate mediaQuery matchers on every render

### DIFF
--- a/packages/experience-builder-sdk/src/hooks/useBreakpoints.ts
+++ b/packages/experience-builder-sdk/src/hooks/useBreakpoints.ts
@@ -17,7 +17,7 @@ import { useCallback, useEffect, useState } from 'react';
  * and then decending by screen width. For mobile-first designs, the order would be ascending
  */
 export const useBreakpoints = (breakpoints: Breakpoint[]) => {
-  const [mediaQueryMatchers, initialMediaQueryMatches] = mediaQueryMatcher(breakpoints);
+  const [, initialMediaQueryMatches] = mediaQueryMatcher(breakpoints);
 
   const [mediaQueryMatches, setMediaQueryMatches] =
     useState<Record<string, boolean>>(initialMediaQueryMatches);
@@ -26,12 +26,14 @@ export const useBreakpoints = (breakpoints: Breakpoint[]) => {
 
   // Register event listeners to update the media query states
   useEffect(() => {
+    const [mediaQueryMatchers] = mediaQueryMatcher(breakpoints);
     const eventListeners = mediaQueryMatchers.map(({ id, signal }) => {
       const onChange = () =>
         setMediaQueryMatches((prev) => ({
           ...prev,
           [id]: signal.matches,
         }));
+
       signal.addEventListener('change', onChange);
       return onChange;
     });
@@ -41,7 +43,7 @@ export const useBreakpoints = (breakpoints: Breakpoint[]) => {
         mediaQueryMatchers[index].signal.removeEventListener('change', eventListener);
       });
     };
-  }, [mediaQueryMatchers]);
+  }, [breakpoints]);
 
   const activeBreakpointIndex = getActiveBreakpointIndex(
     breakpoints,


### PR DESCRIPTION
When switching with dev tools between desktop and mobile emulator, the breakpoint-specific values would not update correctly.

I noticed that we recreate the event listeners for this on every single render cycle. This led to some changes being not handled correctly as the event listener was not ready yet.

We fix this now with a editor-similar approach