### PR TITLE
chore(pre-binding): update validators for prebinding fields [LUMOS-495]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2507,6 +2507,7 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -16,6 +16,7 @@ import type {
   ExperienceComponentTree,
   ComponentDefinitionPropertyType,
   BindingSourceTypeEnum,
+  PatternProperty,
 } from '@contentful/experiences-validators';
 export type {
   ExperienceDataSource,
@@ -32,6 +33,9 @@ export type {
   BoundValue,
   ComponentValue,
   ComponentDefinitionPropertyType as ComponentDefinitionVariableType,
+  PatternProperty,
+  PatternPropertyDefinition,
+  VariableMapping,
 } from '@contentful/experiences-validators';
 
 export type ComponentDefinitionVariableTypeMap = {
@@ -171,6 +175,7 @@ export type ExperienceTreeNode = {
     dataSource: ExperienceDataSource;
     unboundValues: ExperienceUnboundValues;
     breakpoints: Breakpoint[];
+    patternProperties?: Record<string, PatternProperty>;
     pattern?: {
       id: string;
       nodeId: string;

--- a/packages/validators/src/schemas/index.ts
+++ b/packages/validators/src/schemas/index.ts
@@ -1,5 +1,8 @@
 export {
   BindingSourceTypeEnum,
+  PatternProperty,
+  PatternPropertyDefinition,
+  VariableMapping,
   ExperienceFieldsCMAShapeSchema as Schema_2023_09_28,
 } from './v2023_09_28/experience';
 export { ComponentDefinitionSchema } from './componentDefinition';

--- a/packages/validators/src/schemas/v2023_09_28/experience.ts
+++ b/packages/validators/src/schemas/v2023_09_28/experience.ts
@@ -96,6 +96,40 @@ const ComponentPropertyValueSchema = z.discriminatedUnion('type', [
 
 export type ComponentPropertyValue = z.infer<typeof ComponentPropertyValueSchema>;
 
+// TODO: finalized schema structure before release
+// https://contentful.atlassian.net/browse/LUMOS-523
+const VariableMappingSchema = z.object({
+  patternPropertyDefinitionId: propertyKeySchema,
+  type: z.literal('ContentTypeMapping'),
+  pathsByContentType: z.record(z.string(), z.object({ path: z.string() })),
+});
+
+const VariableMappingsSchema = z.record(propertyKeySchema, VariableMappingSchema);
+
+// TODO: finalized schema structure before release
+// https://contentful.atlassian.net/browse/LUMOS-523
+const PatternPropertyDefinitionSchema = z.object({
+  defaultValue: z.object({
+    path: z.string(),
+    type: z.literal('BoundValue'),
+  }),
+  contentTypes: z.record(z.string(), z.any()),
+});
+
+const PatternPropertyDefinitionsSchema = z.record(
+  propertyKeySchema,
+  PatternPropertyDefinitionSchema,
+);
+
+// TODO: finalized schema structure before release
+// https://contentful.atlassian.net/browse/LUMOS-523
+const PatternPropertySchema = z.object({
+  type: z.literal('BoundValue'),
+  path: z.string(),
+});
+
+const PatternPropertysSchema = z.record(propertyKeySchema, PatternPropertySchema);
+
 export const BreakpointSchema = z
   .object({
     id: propertyKeySchema,
@@ -124,6 +158,7 @@ const BaseComponentTreeNodeSchema = z.object({
   displayName: z.string().optional(),
   slotId: z.string().optional(),
   variables: z.record(propertyKeySchema, ComponentPropertyValueSchema),
+  patternProperties: PatternPropertysSchema.optional(),
 });
 export type ComponentTreeNode = z.infer<typeof BaseComponentTreeNodeSchema> & {
   children: ComponentTreeNode[];
@@ -166,6 +201,8 @@ export const ComponentVariablesSchema = z.record(
 
 const ComponentSettingsSchema = z.object({
   variableDefinitions: ComponentVariablesSchema,
+  variableMappings: VariableMappingsSchema.optional(),
+  patternPropertyDefinitions: PatternPropertyDefinitionsSchema.optional(),
 });
 
 const UsedComponentsSchema = z.array(
@@ -255,3 +292,6 @@ export type UnboundValue = z.infer<typeof UnboundValueSchema>;
 export type HyperlinkValue = z.infer<typeof HyperlinkValueSchema>;
 export type ComponentValue = z.infer<typeof ComponentValueSchema>;
 export type BindingSourceTypeEnum = z.infer<typeof BindingSourceTypeEnumSchema>;
+export type PatternPropertyDefinition = z.infer<typeof PatternPropertyDefinitionSchema>;
+export type PatternProperty = z.infer<typeof PatternPropertySchema>;
+export type VariableMapping = z.infer<typeof VariableMappingSchema>;


### PR DESCRIPTION
## Purpose
Update the validator's package so that we can begin saving prebinding data to both patterns and experiences.

Ticket: https://contentful.atlassian.net/browse/LUMOS-495

NOTE: this is just to get us started, an additional ticket exists to finalize the field names in the validators package once they have been set. https://contentful.atlassian.net/browse/LUMOS-523


