### PR TITLE
chore: update validators for pre-binding functionality [LUMOS-543]

### DIFF
--- a/packages/validators/src/schemas/v2023_09_28/experience.ts
+++ b/packages/validators/src/schemas/v2023_09_28/experience.ts
@@ -109,10 +109,13 @@ const VariableMappingsSchema = z.record(propertyKeySchema, VariableMappingSchema
 // TODO: finalized schema structure before release
 // https://contentful.atlassian.net/browse/LUMOS-523
 const PatternPropertyDefinitionSchema = z.object({
-  defaultValue: z.object({
-    path: z.string(),
-    type: z.literal('BoundValue'),
-  }),
+  defaultValue: z.union([
+    z.object({
+      path: z.string(),
+      type: z.literal('BoundValue'),
+    }),
+    z.null(),
+  ]),
   contentTypes: z.record(z.string(), z.any()),
 });
 
@@ -157,7 +160,7 @@ const BaseComponentTreeNodeSchema = z.object({
   definitionId: DefinitionPropertyKeySchema,
   displayName: z.string().optional(),
   slotId: z.string().optional(),
-  variables: z.record(propertyKeySchema, ComponentPropertyValueSchema),
+  variables: z.record(propertyKeySchema, ComponentPropertyValueSchema.optional()),
   patternProperties: PatternPropertysSchema.optional(),
 });
 export type ComponentTreeNode = z.infer<typeof BaseComponentTreeNodeSchema> & {

--- a/packages/validators/src/schemas/v2023_09_28/experience.ts
+++ b/packages/validators/src/schemas/v2023_09_28/experience.ts
@@ -86,12 +86,15 @@ const ComponentValueSchema = z
   })
   .strict();
 
+const EmptyObjectSchema = z.object({ type: z.undefined() });
+
 const ComponentPropertyValueSchema = z.discriminatedUnion('type', [
   DesignValueSchema,
   BoundValueSchema,
   UnboundValueSchema,
   HyperlinkValueSchema,
   ComponentValueSchema,
+  EmptyObjectSchema,
 ]);
 
 export type ComponentPropertyValue = z.infer<typeof ComponentPropertyValueSchema>;
@@ -160,7 +163,7 @@ const BaseComponentTreeNodeSchema = z.object({
   definitionId: DefinitionPropertyKeySchema,
   displayName: z.string().optional(),
   slotId: z.string().optional(),
-  variables: z.record(propertyKeySchema, ComponentPropertyValueSchema.optional()),
+  variables: z.record(propertyKeySchema, ComponentPropertyValueSchema),
   patternProperties: PatternPropertysSchema.optional(),
 });
 export type ComponentTreeNode = z.infer<typeof BaseComponentTreeNodeSchema> & {

--- a/packages/validators/src/schemas/v2023_09_28/experience.ts
+++ b/packages/validators/src/schemas/v2023_09_28/experience.ts
@@ -86,6 +86,8 @@ const ComponentValueSchema = z
   })
   .strict();
 
+// TODO: finalize schema structure before release
+// https://contentful.atlassian.net/browse/LUMOS-523
 const EmptyObjectSchema = z.object({ type: z.undefined() });
 
 const ComponentPropertyValueSchema = z.discriminatedUnion('type', [
@@ -99,7 +101,7 @@ const ComponentPropertyValueSchema = z.discriminatedUnion('type', [
 
 export type ComponentPropertyValue = z.infer<typeof ComponentPropertyValueSchema>;
 
-// TODO: finalized schema structure before release
+// TODO: finalize schema structure before release
 // https://contentful.atlassian.net/browse/LUMOS-523
 const VariableMappingSchema = z.object({
   patternPropertyDefinitionId: propertyKeySchema,
@@ -109,7 +111,7 @@ const VariableMappingSchema = z.object({
 
 const VariableMappingsSchema = z.record(propertyKeySchema, VariableMappingSchema);
 
-// TODO: finalized schema structure before release
+// TODO: finalize schema structure before release
 // https://contentful.atlassian.net/browse/LUMOS-523
 const PatternPropertyDefinitionSchema = z.object({
   defaultValue: z.union([
@@ -127,7 +129,7 @@ const PatternPropertyDefinitionsSchema = z.record(
   PatternPropertyDefinitionSchema,
 );
 
-// TODO: finalized schema structure before release
+// TODO: finalize schema structure before release
 // https://contentful.atlassian.net/browse/LUMOS-523
 const PatternPropertySchema = z.object({
   type: z.literal('BoundValue'),


### PR DESCRIPTION
## Purpose
Additional changes to the validators package so that we can build the initial rendering logic for pre-bound patterns on experiences.

Ticket: https://contentful.atlassian.net/browse/LUMOS-543