### PR TITLE
fix: dont send pattern definitions to the editor [SPA-2588]

### DIFF
--- a/packages/experience-builder-sdk/src/core/componentRegistry.ts
+++ b/packages/experience-builder-sdk/src/core/componentRegistry.ts
@@ -192,9 +192,11 @@ export const optionalBuiltInComponents = [
 
 export const sendRegisteredComponentsMessage = () => {
   // Send the definitions (without components) via the connection message to the experience builder
-  const registeredDefinitions = Array.from(componentRegistry.values()).map(
-    ({ definition }) => definition,
-  );
+  const registeredDefinitions = Array.from(componentRegistry.values())
+    .map(({ definition }) => definition)
+    // Pattern definitions are empty placeholder within the SDK without variables
+    // We don't send those to the editor as they would overwrite the actual correct definitions.
+    .filter((definition) => definition.category !== ASSEMBLY_DEFAULT_CATEGORY);
 
   sendMessage(OUTGOING_EVENTS.RegisteredComponents, {
     definitions: registeredDefinitions,


### PR DESCRIPTION
A customer was losing all their content when saving an experience with a pattern in it. This is due to the fact the SDK defines an empty definition without variables and sends it to the editor. When saving the experience this placeholder definition will make all the content vanish from the tree.