### PR TITLE
fix(divider): remove the CSS overlay of divider component in delivery  [SPA-2596]

### DIFF
--- a/packages/components/src/components/Divider/ContentfulDivider.css
+++ b/packages/components/src/components/Divider/ContentfulDivider.css
@@ -9,7 +9,9 @@
   border: none;
 }
 
-.cf-divider::before {
+/* For the editor mode add this 10px tolerance to make it easier picking up the divider component.
+ * Using the DND zone as precondition makes sure that we don't render this pseudo element in delivery. */
+[data-ctfl-zone-id='root'] .cf-divider::before {
   content: "";
   position: absolute;
   top: -5px;


### PR DESCRIPTION
## Purpose

The pseudo element covers many other neighbouring components in delivery. This is why we disable it when the DND context doesn't exist (i.e. delivery mode).