### PR TITLE
feat: add buffer space to bottom of canvas [LUMOS-549]

### DIFF
--- a/packages/visual-editor/src/components/RootRenderer/RootRenderer.tsx
+++ b/packages/visual-editor/src/components/RootRenderer/RootRenderer.tsx
@@ -123,7 +123,13 @@ export const RootRenderer: React.FC<RootRendererProperties> = ({ onChange }) => 
       <div data-ctfl-root className={styles.container} ref={containerRef} style={containerStyles}>
         {userIsDragging && <div data-ctfl-zone-id={ROOT_ID} className={styles.hitbox} />}
         <Dropzone zoneId={ROOT_ID} resolveDesignValue={resolveDesignValue} />
-        {userIsDragging && <div data-ctfl-zone-id={ROOT_ID} className={styles.hitboxLower} />}
+        {userIsDragging && (
+          <>
+            <div data-ctfl-zone-id={ROOT_ID} className={styles.hitboxLower} />
+            {/* This adds extra space to the bottom of the canvas when dragging to improve hitbox targeting */}
+            <div data-ctfl-zone-id={ROOT_ID} className={styles.canvasBottomSpacer} />
+          </>
+        )}
       </div>
       <div data-ctfl-hitboxes />
     </DNDProvider>

--- a/packages/visual-editor/src/components/RootRenderer/render.module.css
+++ b/packages/visual-editor/src/components/RootRenderer/render.module.css
@@ -9,11 +9,17 @@
 
 .hitboxLower {
   position: absolute;
-  bottom: -10px;
+  bottom: -20px;
   left: 0;
   width: 100%;
-  height: 10px;
+  height: 20px;
   z-index: 1000000;
+}
+
+.canvasBottomSpacer {
+  position: absolute;
+  width: 100%;
+  height: 50px;
 }
 
 .container {


### PR DESCRIPTION
## Purpose

This change adds a small invisible spacer element to the bottom of the canvas when dragging in a new component.

## Approach

First I experimented with reusing the `<EmptyContainer>` ("Add components to begin" placeholder) as the last element on the canvas, but it had some issues with overlapping dashed outlines and not shifting position when a canvas interaction shows a hitbox that causes other elements to shift positions. I also thought it seemed a little too busy with the extra "Add components" placeholder element.

I tried a simpler approach and added an absolute positioned invisible div at the bottom of the canvas. This spacer element only renders when the user is dragging. Since it's absolute positioned, if the user has static content below the ExperienceRoot (such as a footer) the spacer element wont show. I think that's a good thing since it's not a problem to add content in the bottom of the experience when theres content below the ExperienceRoot such as a footer.

Since this site has no content below the experience root, the last element touches the bottom of the window, and you can see the small spacer appear when I start dragging a component on to the canvas:

https://github.com/user-attachments/assets/c076d6dd-7c3d-490d-a22b-c8dc72361246

Since this site has a footer below the experience root, the spacer element overlaps with the top of the footer, so there is no gap between the last element and the footer:

https://github.com/user-attachments/assets/a3130bf1-14db-475a-b22e-97cb673a6a85


