### PR TITLE
chore(circleci): remove nextjs deployment to Vercel []

### DIFF
--- a/.github/workflows/vercel.yaml
+++ b/.github/workflows/vercel.yaml
@@ -65,7 +65,7 @@ jobs:
             vercel build --token=${{ secrets.VERCEL_TOKEN }}
             vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }}
           fi
-      # FIXME: The Vercel project doesn't exist anymore
+      # FIXME: These Vercel projects doesn't exist anymore
       # - name: 'Deploy nextjs-marketing-demo site to Vercel'
       #   env:
       #     VERCEL_PROJECT_ID: prj_CQ1K4Pbkx5SQq2Fi9c4ZPHloOv79
@@ -80,17 +80,17 @@ jobs:
       #       vercel build --token=${{ secrets.VERCEL_TOKEN }}
       #       vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }}
       #     fi
-      - name: 'Deploy react vite template site to Vercel'
-        env:
-          VERCEL_PROJECT_ID: prj_HoAvIbgvZ3gYJDLCAaNsHIpBvI0k
-          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
-        run: |
-          if [ ${{ github.ref_name }} = main ] || [ ${{ inputs.publish-web-apps-to-prod }} = true ]; then
-            vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
-            vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
-            vercel deploy --prod --prebuilt --token=${{ secrets.VERCEL_TOKEN }}
-          else
-            vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
-            vercel build --token=${{ secrets.VERCEL_TOKEN }}
-            vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }}
-          fi
+      # - name: 'Deploy react vite template site to Vercel'
+      #   env:
+      #     VERCEL_PROJECT_ID: prj_HoAvIbgvZ3gYJDLCAaNsHIpBvI0k
+      #     VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+      #   run: |
+      #     if [ ${{ github.ref_name }} = main ] || [ ${{ inputs.publish-web-apps-to-prod }} = true ]; then
+      #       vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
+      #       vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
+      #       vercel deploy --prod --prebuilt --token=${{ secrets.VERCEL_TOKEN }}
+      #     else
+      #       vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
+      #       vercel build --token=${{ secrets.VERCEL_TOKEN }}
+      #       vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }}
+      #     fi

--- a/.github/workflows/vercel.yaml
+++ b/.github/workflows/vercel.yaml
@@ -64,21 +64,22 @@ jobs:
             vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
             vercel build --token=${{ secrets.VERCEL_TOKEN }}
             vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }}
-          fi          
-      - name: 'Deploy nextjs-marketing-demo site to Vercel'
-        env:
-          VERCEL_PROJECT_ID: prj_CQ1K4Pbkx5SQq2Fi9c4ZPHloOv79
-          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
-        run: |
-          if [ ${{ github.ref_name }} = main ] || [ ${{ inputs.publish-web-apps-to-prod }} = true ]; then
-            vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
-            vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
-            vercel deploy --prod --prebuilt --token=${{ secrets.VERCEL_TOKEN }}
-          else
-            vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
-            vercel build --token=${{ secrets.VERCEL_TOKEN }}
-            vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }}
-          fi          
+          fi
+      # FIXME: The Vercel project doesn't exist anymore
+      # - name: 'Deploy nextjs-marketing-demo site to Vercel'
+      #   env:
+      #     VERCEL_PROJECT_ID: prj_CQ1K4Pbkx5SQq2Fi9c4ZPHloOv79
+      #     VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+      #   run: |
+      #     if [ ${{ github.ref_name }} = main ] || [ ${{ inputs.publish-web-apps-to-prod }} = true ]; then
+      #       vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
+      #       vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
+      #       vercel deploy --prod --prebuilt --token=${{ secrets.VERCEL_TOKEN }}
+      #     else
+      #       vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
+      #       vercel build --token=${{ secrets.VERCEL_TOKEN }}
+      #       vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }}
+      #     fi
       - name: 'Deploy react vite template site to Vercel'
         env:
           VERCEL_PROJECT_ID: prj_HoAvIbgvZ3gYJDLCAaNsHIpBvI0k
@@ -92,5 +93,4 @@ jobs:
             vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
             vercel build --token=${{ secrets.VERCEL_TOKEN }}
             vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }}
-          fi          
-     
+          fi


### PR DESCRIPTION
The job for deploying the nextjs marketing & react-vite demo started failing today on all branches and is not available any more on Vercel.
To unblock the pipeline, drop the job from the config.