### PR TITLE
fix: update active breakpoint correctly

### DIFF
--- a/packages/core/src/utils/breakpoints.spec.ts
+++ b/packages/core/src/utils/breakpoints.spec.ts
@@ -28,6 +28,7 @@ describe('getValueForBreakpoint for css values', () => {
         valuesByBreakpoint,
         breakpoints,
         desktopIndex,
+        desktopIndex,
         variableName,
       );
       expect(value).toEqual(desktopValue);
@@ -40,6 +41,7 @@ describe('getValueForBreakpoint for css values', () => {
         valuesByBreakpoint,
         breakpoints,
         tabletIndex,
+        desktopIndex,
         variableName,
       );
       expect(value).toEqual(tabletValue);
@@ -49,6 +51,7 @@ describe('getValueForBreakpoint for css values', () => {
         valuesByBreakpointWithoutTabletAndMobile,
         breakpoints,
         tabletIndex,
+        desktopIndex,
         variableName,
       );
       expect(value).toEqual(desktopValue);
@@ -61,6 +64,7 @@ describe('getValueForBreakpoint for css values', () => {
         valuesByBreakpoint,
         breakpoints,
         mobileIndex,
+        desktopIndex,
         variableName,
       );
       expect(value).toEqual(mobileValue);
@@ -70,6 +74,7 @@ describe('getValueForBreakpoint for css values', () => {
         valuesByBreakpointWithoutMobile,
         breakpoints,
         mobileIndex,
+        desktopIndex,
         variableName,
       );
       expect(value).toEqual(tabletValue);
@@ -79,6 +84,7 @@ describe('getValueForBreakpoint for css values', () => {
         valuesByBreakpointWithoutTabletAndMobile,
         breakpoints,
         mobileIndex,
+        desktopIndex,
         variableName,
       );
       expect(value).toEqual(desktopValue);
@@ -91,6 +97,7 @@ describe('getValueForBreakpoint for css values', () => {
         valuesByBreakpointWithoutTabletAndMobile,
         breakpoints,
         3,
+        desktopIndex,
         variableName,
       );
       expect(value).toEqual(desktopValue);
@@ -135,6 +142,7 @@ describe('getValueForBreakpoint for design tokens', () => {
         valuesByBreakpoint,
         breakpoints,
         desktopIndex,
+        desktopIndex,
         variableName,
       );
       expect(value).toEqual(desktopResolvedValue);
@@ -143,6 +151,7 @@ describe('getValueForBreakpoint for design tokens', () => {
       const value = getValueForBreakpoint(
         valuesByBreakpoint,
         breakpoints,
+        desktopIndex,
         desktopIndex,
         variableName,
         false,
@@ -157,6 +166,7 @@ describe('getValueForBreakpoint for design tokens', () => {
         valuesByBreakpoint,
         breakpoints,
         tabletIndex,
+        desktopIndex,
         variableName,
       );
       expect(value).toEqual(tabletResolvedValue);
@@ -166,6 +176,7 @@ describe('getValueForBreakpoint for design tokens', () => {
         valuesByBreakpointWithoutTabletAndMobile,
         breakpoints,
         tabletIndex,
+        desktopIndex,
         variableName,
       );
       expect(value).toEqual(desktopResolvedValue);
@@ -176,6 +187,7 @@ describe('getValueForBreakpoint for design tokens', () => {
         valuesByBreakpoint,
         breakpoints,
         tabletIndex,
+        desktopIndex,
         variableName,
         false,
       );
@@ -186,6 +198,7 @@ describe('getValueForBreakpoint for design tokens', () => {
         valuesByBreakpointWithoutTabletAndMobile,
         breakpoints,
         tabletIndex,
+        desktopIndex,
         variableName,
         false,
       );
@@ -199,6 +212,7 @@ describe('getValueForBreakpoint for design tokens', () => {
         valuesByBreakpoint,
         breakpoints,
         mobileIndex,
+        desktopIndex,
         variableName,
       );
       expect(value).toEqual(mobileResolvedValue);
@@ -208,6 +222,7 @@ describe('getValueForBreakpoint for design tokens', () => {
         valuesByBreakpointWithoutMobile,
         breakpoints,
         mobileIndex,
+        desktopIndex,
         variableName,
       );
       expect(value).toEqual(tabletResolvedValue);
@@ -217,6 +232,7 @@ describe('getValueForBreakpoint for design tokens', () => {
         valuesByBreakpointWithoutTabletAndMobile,
         breakpoints,
         mobileIndex,
+        desktopIndex,
         variableName,
       );
       expect(value).toEqual(desktopResolvedValue);
@@ -227,6 +243,7 @@ describe('getValueForBreakpoint for design tokens', () => {
         valuesByBreakpoint,
         breakpoints,
         mobileIndex,
+        desktopIndex,
         variableName,
         false,
       );
@@ -237,6 +254,7 @@ describe('getValueForBreakpoint for design tokens', () => {
         valuesByBreakpointWithoutMobile,
         breakpoints,
         mobileIndex,
+        desktopIndex,
         variableName,
         false,
       );
@@ -247,6 +265,7 @@ describe('getValueForBreakpoint for design tokens', () => {
         valuesByBreakpointWithoutTabletAndMobile,
         breakpoints,
         mobileIndex,
+        desktopIndex,
         variableName,
         false,
       );
@@ -260,6 +279,7 @@ describe('getValueForBreakpoint for design tokens', () => {
         valuesByBreakpointWithoutTabletAndMobile,
         breakpoints,
         3,
+        desktopIndex,
         variableName,
       );
       expect(value).toEqual(desktopResolvedValue);
@@ -269,6 +289,7 @@ describe('getValueForBreakpoint for design tokens', () => {
         valuesByBreakpointWithoutTabletAndMobile,
         breakpoints,
         3,
+        desktopIndex,
         variableName,
         false,
       );

--- a/packages/core/src/utils/breakpoints.ts
+++ b/packages/core/src/utils/breakpoints.ts
@@ -99,6 +99,7 @@ export const getValueForBreakpoint = (
   valuesByBreakpoint: ValuesByBreakpoint | undefined,
   breakpoints: Breakpoint[],
   activeBreakpointIndex: number,
+  fallbackBreakpointIndex: number,
   variableName: string,
   resolveDesignTokens = true,
 ) => {
@@ -123,8 +124,7 @@ export const getValueForBreakpoint = (
         return valuesByBreakpoint[breakpointId];
       }
     }
-    // If no breakpoint matched, we search and apply the fallback breakpoint
-    const fallbackBreakpointIndex = getFallbackBreakpointIndex(breakpoints);
+
     const fallbackBreakpointId = breakpoints[fallbackBreakpointIndex]?.id;
     if (isValidBreakpointValue(valuesByBreakpoint[fallbackBreakpointId])) {
       if (resolveDesignTokens) {

--- a/packages/experience-builder-sdk/src/hooks/useBreakpoints.spec.ts
+++ b/packages/experience-builder-sdk/src/hooks/useBreakpoints.spec.ts
@@ -30,7 +30,7 @@ describe('useBreakpoints', () => {
         [breakpoints[1].id]: 'blue',
         [breakpoints[2].id]: 'green',
       };
-      const value = getValueForBreakpoint(valuesByBreakpoint, breakpoints, 1, 'cfColor');
+      const value = getValueForBreakpoint(valuesByBreakpoint, breakpoints, 1, 0, 'cfColor');
       expect(value).toBe('blue');
     });
 
@@ -40,7 +40,7 @@ describe('useBreakpoints', () => {
         [breakpoints[1].id]: 'blue',
         [breakpoints[2].id]: 'green',
       };
-      const value = getValueForBreakpoint(valuesByBreakpoint, breakpoints, -1, 'cfColor');
+      const value = getValueForBreakpoint(valuesByBreakpoint, breakpoints, -1, 0, 'cfColor');
       expect(value).toBe('red');
     });
 
@@ -51,7 +51,7 @@ describe('useBreakpoints', () => {
       };
       // We ask for the mobile value but it's not defined.
       // Thus, we expect to get the tablet value.
-      const value = getValueForBreakpoint(valuesByBreakpoint, breakpoints, 2, 'cfColor');
+      const value = getValueForBreakpoint(valuesByBreakpoint, breakpoints, 2, 0, 'cfColor');
       expect(value).toBe('blue');
     });
   });

--- a/packages/experience-builder-sdk/src/hooks/useBreakpoints.ts
+++ b/packages/experience-builder-sdk/src/hooks/useBreakpoints.ts
@@ -17,23 +17,21 @@ import { useCallback, useEffect, useState } from 'react';
  * and then decending by screen width. For mobile-first designs, the order would be ascending
  */
 export const useBreakpoints = (breakpoints: Breakpoint[]) => {
-  const [, initialMediaQueryMatches] = mediaQueryMatcher(breakpoints);
-  console.log('~initialMediaQueryMatches', initialMediaQueryMatches);
-
-  const [mediaQueryMatches, setMediaQueryMatches] =
-    useState<Record<string, boolean>>(initialMediaQueryMatches);
+  const [mediaQueryMatches, setMediaQueryMatches] = useState<Record<string, boolean>>({});
 
   // Register event listeners to update the media query states
   useEffect(() => {
     const [mediaQueryMatchers] = mediaQueryMatcher(breakpoints);
+    console.log('~mediaQueryMatchers', mediaQueryMatchers);
+
+    setMediaQueryMatches(mediaQueryMatches);
+
     const eventListeners = mediaQueryMatchers.map(({ id, signal }) => {
-      const onChange = () => {
-        console.log('~onBreakpointChange', id, signal.matches);
+      const onChange = () =>
         setMediaQueryMatches((prev) => ({
           ...prev,
           [id]: signal.matches,
         }));
-      };
 
       signal.addEventListener('change', onChange);
       return onChange;
@@ -62,6 +60,7 @@ export const useBreakpoints = (breakpoints: Breakpoint[]) => {
         console.log('~mediaQueryMatches', mediaQueryMatches);
         console.log('~activeBreakpointIndex', activeBreakpointIndex);
       }
+
       return getValueForBreakpoint(
         valuesByBreakpoint,
         breakpoints,

--- a/packages/experience-builder-sdk/src/hooks/useBreakpoints.ts
+++ b/packages/experience-builder-sdk/src/hooks/useBreakpoints.ts
@@ -21,10 +21,11 @@ export const useBreakpoints = (breakpoints: Breakpoint[]) => {
 
   // Register event listeners to update the media query states
   useEffect(() => {
-    const [mediaQueryMatchers] = mediaQueryMatcher(breakpoints);
+    const [mediaQueryMatchers, initialMediaQueryMatches] = mediaQueryMatcher(breakpoints);
     console.log('~mediaQueryMatchers', mediaQueryMatchers);
 
-    setMediaQueryMatches(mediaQueryMatches);
+    setMediaQueryMatches(initialMediaQueryMatches);
+    console.log('~mediaQueryMatches', initialMediaQueryMatches);
 
     const eventListeners = mediaQueryMatchers.map(({ id, signal }) => {
       const onChange = () =>

--- a/packages/experience-builder-sdk/src/hooks/useBreakpoints.ts
+++ b/packages/experience-builder-sdk/src/hooks/useBreakpoints.ts
@@ -22,10 +22,8 @@ export const useBreakpoints = (breakpoints: Breakpoint[]) => {
   // Register event listeners to update the media query states
   useEffect(() => {
     const [mediaQueryMatchers, initialMediaQueryMatches] = mediaQueryMatcher(breakpoints);
-    console.log('~mediaQueryMatchers', mediaQueryMatchers);
 
     setMediaQueryMatches(initialMediaQueryMatches);
-    console.log('~mediaQueryMatches', initialMediaQueryMatches);
 
     const eventListeners = mediaQueryMatchers.map(({ id, signal }) => {
       const onChange = () =>
@@ -54,13 +52,6 @@ export const useBreakpoints = (breakpoints: Breakpoint[]) => {
         mediaQueryMatches,
         fallbackBreakpointIndex,
       );
-      if (variableName === 'hide') {
-        console.log('~valuesByBreakpoint', valuesByBreakpoint);
-        console.log('~breakpoints', breakpoints);
-        console.log('~fallbackBreakpointIndex', fallbackBreakpointIndex);
-        console.log('~mediaQueryMatches', mediaQueryMatches);
-        console.log('~activeBreakpointIndex', activeBreakpointIndex);
-      }
 
       return getValueForBreakpoint(
         valuesByBreakpoint,

--- a/packages/experience-builder-sdk/src/hooks/useBreakpoints.ts
+++ b/packages/experience-builder-sdk/src/hooks/useBreakpoints.ts
@@ -22,8 +22,6 @@ export const useBreakpoints = (breakpoints: Breakpoint[]) => {
   const [mediaQueryMatches, setMediaQueryMatches] =
     useState<Record<string, boolean>>(initialMediaQueryMatches);
 
-  const fallbackBreakpointIndex = getFallbackBreakpointIndex(breakpoints);
-
   // Register event listeners to update the media query states
   useEffect(() => {
     const [mediaQueryMatchers] = mediaQueryMatcher(breakpoints);
@@ -45,22 +43,24 @@ export const useBreakpoints = (breakpoints: Breakpoint[]) => {
     };
   }, [breakpoints]);
 
-  const activeBreakpointIndex = getActiveBreakpointIndex(
-    breakpoints,
-    mediaQueryMatches,
-    fallbackBreakpointIndex,
-  );
-
   const resolveDesignValue: ResolveDesignValueType = useCallback(
     (valuesByBreakpoint, variableName) => {
+      const fallbackBreakpointIndex = getFallbackBreakpointIndex(breakpoints);
+
+      const activeBreakpointIndex = getActiveBreakpointIndex(
+        breakpoints,
+        mediaQueryMatches,
+        fallbackBreakpointIndex,
+      );
       return getValueForBreakpoint(
         valuesByBreakpoint,
         breakpoints,
         activeBreakpointIndex,
+        fallbackBreakpointIndex,
         variableName,
       );
     },
-    [activeBreakpointIndex, breakpoints],
+    [mediaQueryMatches, breakpoints],
   );
 
   return { resolveDesignValue };

--- a/packages/experience-builder-sdk/src/hooks/useBreakpoints.ts
+++ b/packages/experience-builder-sdk/src/hooks/useBreakpoints.ts
@@ -18,6 +18,7 @@ import { useCallback, useEffect, useState } from 'react';
  */
 export const useBreakpoints = (breakpoints: Breakpoint[]) => {
   const [, initialMediaQueryMatches] = mediaQueryMatcher(breakpoints);
+  console.log('~initialMediaQueryMatches', initialMediaQueryMatches);
 
   const [mediaQueryMatches, setMediaQueryMatches] =
     useState<Record<string, boolean>>(initialMediaQueryMatches);
@@ -26,11 +27,13 @@ export const useBreakpoints = (breakpoints: Breakpoint[]) => {
   useEffect(() => {
     const [mediaQueryMatchers] = mediaQueryMatcher(breakpoints);
     const eventListeners = mediaQueryMatchers.map(({ id, signal }) => {
-      const onChange = () =>
+      const onChange = () => {
+        console.log('~onBreakpointChange', id, signal.matches);
         setMediaQueryMatches((prev) => ({
           ...prev,
           [id]: signal.matches,
         }));
+      };
 
       signal.addEventListener('change', onChange);
       return onChange;
@@ -52,6 +55,13 @@ export const useBreakpoints = (breakpoints: Breakpoint[]) => {
         mediaQueryMatches,
         fallbackBreakpointIndex,
       );
+      if (variableName === 'hide') {
+        console.log('~valuesByBreakpoint', valuesByBreakpoint);
+        console.log('~breakpoints', breakpoints);
+        console.log('~fallbackBreakpointIndex', fallbackBreakpointIndex);
+        console.log('~mediaQueryMatches', mediaQueryMatches);
+        console.log('~activeBreakpointIndex', activeBreakpointIndex);
+      }
       return getValueForBreakpoint(
         valuesByBreakpoint,
         breakpoints,

--- a/packages/visual-editor/src/hooks/useBreakpoints.spec.ts
+++ b/packages/visual-editor/src/hooks/useBreakpoints.spec.ts
@@ -13,7 +13,7 @@ describe('useBreakpoints', () => {
         [tablet.id]: 'blue',
         [mobile.id]: 'green',
       };
-      const value = getValueForBreakpoint(valuesByBreakpoint, breakpoints, 1, 'cfColor');
+      const value = getValueForBreakpoint(valuesByBreakpoint, breakpoints, 1, 0, 'cfColor');
       expect(value).toBe('blue');
     });
 
@@ -23,7 +23,7 @@ describe('useBreakpoints', () => {
         [tablet.id]: 'blue',
         [mobile.id]: 'green',
       };
-      const value = getValueForBreakpoint(valuesByBreakpoint, breakpoints, -1, 'cfColor');
+      const value = getValueForBreakpoint(valuesByBreakpoint, breakpoints, -1, 0, 'cfColor');
       expect(value).toBe('red');
     });
 
@@ -34,7 +34,7 @@ describe('useBreakpoints', () => {
       };
       // We ask for the mobile value but it's not defined.
       // Thus, we expect to get the tablet value.
-      const value = getValueForBreakpoint(valuesByBreakpoint, breakpoints, 2, 'cfColor');
+      const value = getValueForBreakpoint(valuesByBreakpoint, breakpoints, 2, 0, 'cfColor');
       expect(value).toBe('blue');
     });
   });

--- a/packages/visual-editor/src/hooks/useBreakpoints.ts
+++ b/packages/visual-editor/src/hooks/useBreakpoints.ts
@@ -19,8 +19,6 @@ import { useCallback, useEffect, useState } from 'react';
 export const useBreakpoints = (breakpoints: Breakpoint[]) => {
   const [mediaQueryMatches, setMediaQueryMatches] = useState<Record<string, boolean>>({});
 
-  const fallbackBreakpointIndex = getFallbackBreakpointIndex(breakpoints);
-
   // Register event listeners to update the media query states
   useEffect(() => {
     const [mediaQueryMatchers, initialMediaQueryMatches] = mediaQueryMatcher(breakpoints);
@@ -46,22 +44,25 @@ export const useBreakpoints = (breakpoints: Breakpoint[]) => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [breakpoints]);
 
-  const activeBreakpointIndex = getActiveBreakpointIndex(
-    breakpoints,
-    mediaQueryMatches,
-    fallbackBreakpointIndex,
-  );
-
   const resolveDesignValue: ResolveDesignValueType = useCallback(
     (valuesByBreakpoint, variableName) => {
+      const fallbackBreakpointIndex = getFallbackBreakpointIndex(breakpoints);
+
+      const activeBreakpointIndex = getActiveBreakpointIndex(
+        breakpoints,
+        mediaQueryMatches,
+        fallbackBreakpointIndex,
+      );
+
       return getValueForBreakpoint(
         valuesByBreakpoint,
         breakpoints,
         activeBreakpointIndex,
+        fallbackBreakpointIndex,
         variableName,
       );
     },
-    [activeBreakpointIndex, breakpoints],
+    [mediaQueryMatches, breakpoints],
   );
 
   return { resolveDesignValue };

--- a/packages/visual-editor/src/hooks/useComponent.spec.ts
+++ b/packages/visual-editor/src/hooks/useComponent.spec.ts
@@ -50,7 +50,13 @@ describe('useComponent', () => {
   const breakpoints = createBreakpoints();
   const desktopIndex = 0;
   const resolveDesignValue = vi.fn((valuesByBreakpoint, variableName) =>
-    getValueForBreakpoint(valuesByBreakpoint, breakpoints, desktopIndex, variableName),
+    getValueForBreakpoint(
+      valuesByBreakpoint,
+      breakpoints,
+      desktopIndex,
+      desktopIndex,
+      variableName,
+    ),
   );
   const userIsDragging = false;
   const renderDropzone = vi.fn();

--- a/packages/visual-editor/src/hooks/useComponentProps.spec.ts
+++ b/packages/visual-editor/src/hooks/useComponentProps.spec.ts
@@ -15,7 +15,7 @@ const breakpoints = createBreakpoints();
 const desktopIndex = 0;
 const desktop = breakpoints[desktopIndex];
 const resolveDesignValue = vi.fn((valuesByBreakpoint, variableName) =>
-  getValueForBreakpoint(valuesByBreakpoint, breakpoints, desktopIndex, variableName),
+  getValueForBreakpoint(valuesByBreakpoint, breakpoints, desktopIndex, desktopIndex, variableName),
 );
 const renderDropzone = vi.fn();
 const areEntitiesFetched = true;


### PR DESCRIPTION
## Purpose

Makes sure that active breakpoint is updated correctly when breakpoints as eventually updated.

## Approach

**Fix 1**
The root of the problem was that initial state is only used on the first render (see also this [SO question](https://stackoverflow.com/questions/58818727/react-usestate-not-setting-initial-value)), but in the first render we'll always pass in `breakpoints: []` which leads to `mediaQueryMatches` being empty. On the next render when breakpoints have been fetched this line doesn't actually update the `mediaQueryMatches`:
```
 const [mediaQueryMatches, setMediaQueryMatches] =
    useState<Record<string, boolean>>(initialMediaQueryMatches);
```
We need to instead update the `mediaQueryMatches` inside the useEffect [here](https://github.com/contentful/experience-builder/pull/995/files#diff-c71237ef291dccb20a3d2be94092a02b56c8169fc3f7214e9855fac0a5f3d504R26) (`breakpoints` is a dependency for the useEffect)

There are two almost identical useBreakpoints hook one in `visual-editor` and one in the `experience-builder-sdk`. It was the `experience-builder-sdk` that had the issue. `visual-editor` hook already had the above fix.

**Fix 2**
Fallback and active breakpoints were also moved into the resolveDesignValue callback to make sure they always have the updated values, as they also depend on the `mediaQueryMatches`. After fix 1 this fix might not be necessary but I'd suggest we keep it as this version has been tested by the customer.

A screenshot from the customer's experience with this fix and some extra logging inside the `resolveDesignValue` callback:
<img width="615" alt="Screenshot 2025-02-18 at 11 29 47" src="https://github.com/user-attachments/assets/5f5ba023-8b03-464e-8f8d-a98f169d2875" />

I don't have a screenshot from before but essentially **activeBreakpointIndex was always 0** and **mediaQueryMatches where empty**. 


