### PR TITLE
fix: handle case where single column is not wrapped in columns component

### DIFF
--- a/packages/visual-editor/src/hooks/useSingleColumn.ts
+++ b/packages/visual-editor/src/hooks/useSingleColumn.ts
@@ -22,7 +22,7 @@ export default function useSingleColumn(
 
     const parentNode = getItem({ id: node.parentId }, tree);
 
-    if (!parentNode) {
+    if (!parentNode || parentNode.data.blockId !== CONTENTFUL_COMPONENTS.columns.id) {
       return { isWrapped, wrapColumnsCount };
     }
 


### PR DESCRIPTION
## Purpose

Handle case where single column is not wrapped inside a `Columns` component.

## Approach

An error is thrown when a `Column` component is not wrapped inside a `Columns` component. This shouldn't normally happen but a customer has run into this scenario and the editor is crashing in this case:

<img width="243" alt="Screenshot 2025-02-19 at 11 10 36" src="https://github.com/user-attachments/assets/0fc4a0b9-72c9-4d97-a874-ca058659306d" />

Column tree node:
<img width="351" alt="Screenshot 2025-02-19 at 11 11 23" src="https://github.com/user-attachments/assets/71d3505a-dbde-42d8-a88a-82d218a68e7c" />

Parent tree node (it's a `contentful-section` instead of `contentful-columns`): 
<img width="322" alt="Screenshot 2025-02-19 at 11 11 02" src="https://github.com/user-attachments/assets/45048774-d607-4cd3-8620-77f49866eef2" />


<!--
Remember when merging:
- Use "Squash and merge" when merging changes into development.
- Use "Create a merge commit" when releasing changes into next and main.

Three important notes on pull requests:
- In general, you should ask yourself whether this code change will improve or worsen the overall code quality. Any new tech debt will probably never be cleaned up.
- Please remember that newly introduced logic should be validated and protected through testing.
- Take a look at PR guides:
  Google's Code Review Guidelines: https://google.github.io/eng-practices/
  Blockly - Writing a Good Pull Request: https://developers.google.com/blockly/guides/contribute/get-started/write_a_good_pr
-->
