### PR TITLE
chore: add thumbnail id to component settings validation [SPA-2572]

### DIFF
--- a/packages/validators/src/schemas/v2023_09_28/experience.ts
+++ b/packages/validators/src/schemas/v2023_09_28/experience.ts
@@ -207,8 +207,34 @@ export const ComponentVariablesSchema = z.record(
   ComponentVariableSchema,
 );
 
+const THUMBNAIL_IDS = [
+  'columns',
+  'columnsPlusRight',
+  'imagesSquare',
+  'subtitles',
+  'rowsPlusBottom',
+  'userRectangle',
+  'textbox',
+  'monitorPlay',
+  'article',
+  'table',
+  'star',
+  'heartStraight',
+  'frameCorners',
+  'rows',
+  'dotsThreeOutline',
+  'listDashes',
+  'checkerBoard',
+  'gridFour',
+  'slideshow',
+  'diamondsFour',
+  'cards',
+  'textColumns',
+] as const;
+
 const ComponentSettingsSchema = z.object({
   variableDefinitions: ComponentVariablesSchema,
+  thumbnailId: z.enum(THUMBNAIL_IDS),
   variableMappings: VariableMappingsSchema.optional(),
   patternPropertyDefinitions: PatternPropertyDefinitionsSchema.optional(),
 });

--- a/packages/validators/src/schemas/v2023_09_28/experience.ts
+++ b/packages/validators/src/schemas/v2023_09_28/experience.ts
@@ -234,7 +234,7 @@ const THUMBNAIL_IDS = [
 
 const ComponentSettingsSchema = z.object({
   variableDefinitions: ComponentVariablesSchema,
-  thumbnailId: z.enum(THUMBNAIL_IDS),
+  thumbnailId: z.enum(THUMBNAIL_IDS).optional(),
   variableMappings: VariableMappingsSchema.optional(),
   patternPropertyDefinitions: PatternPropertyDefinitionsSchema.optional(),
 });


### PR DESCRIPTION
## Purpose

Add validation for thumbnail ids

These are the thumbnails we are providing for now and these could increase in the future

![Screenshot 2025-02-19 at 13 25 18](https://github.com/user-attachments/assets/6881a3a1-a6ff-4232-9e9f-9677ef4c27d2)
