### PR TITLE
feat(prebinding): resolve prebindings in delivery mode [LUMOS-544]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2507,6 +2507,7 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {

--- a/packages/experience-builder-sdk/src/core/preview/assemblyUtils.ts
+++ b/packages/experience-builder-sdk/src/core/preview/assemblyUtils.ts
@@ -4,18 +4,24 @@ import type {
   ComponentTreeNode,
   DesignValue,
   ExperienceComponentSettings,
+  PatternProperty,
 } from '@contentful/experiences-core/types';
+import { resolvePrebindingPath, shouldUsePrebinding } from '../../utils/prebindingUtils';
 
 /** While unfolding the assembly definition on the instance, this function will replace all
  * ComponentValue in the definitions tree with the actual value on the instance. */
 export const deserializeAssemblyNode = ({
   node,
   componentInstanceVariables,
-  assemblyVariableDefinitions,
+  componentSettings,
+  patternProperties,
+  entityStore,
 }: {
   node: ComponentTreeNode;
   componentInstanceVariables: ComponentTreeNode['variables'];
-  assemblyVariableDefinitions: ExperienceComponentSettings['variableDefinitions'];
+  componentSettings: ExperienceComponentSettings;
+  patternProperties: Record<string, PatternProperty>;
+  entityStore: EntityStore;
 }): ComponentTreeNode => {
   const variables: Record<string, ComponentPropertyValue> = {};
 
@@ -24,12 +30,34 @@ export const deserializeAssemblyNode = ({
     if (variable.type === 'ComponentValue') {
       const componentValueKey = variable.key;
       const instanceProperty = componentInstanceVariables[componentValueKey];
-      const variableDefinition = assemblyVariableDefinitions?.[componentValueKey];
+      const variableDefinition = componentSettings.variableDefinitions?.[componentValueKey];
       const defaultValue = variableDefinition?.defaultValue;
 
-      // For assembly, we look up the variable in the assembly instance and
-      // replace the ComponentValue with that one.
-      if (instanceProperty?.type === 'UnboundValue') {
+      const usePrebinding = shouldUsePrebinding({
+        componentSettings,
+        componentValueKey,
+        patternProperties,
+        variable: instanceProperty,
+      });
+
+      if (usePrebinding) {
+        const path = resolvePrebindingPath({
+          componentSettings,
+          componentValueKey,
+          entityStore,
+          patternProperties,
+        });
+
+        if (path) {
+          variables[variableName] = {
+            type: 'BoundValue',
+            path,
+          };
+        }
+
+        // For assembly, we look up the variable in the assembly instance and
+        // replace the ComponentValue with that one.
+      } else if (instanceProperty?.type === 'UnboundValue') {
         variables[variableName] = {
           type: 'UnboundValue',
           key: instanceProperty.key,
@@ -65,7 +93,9 @@ export const deserializeAssemblyNode = ({
     deserializeAssemblyNode({
       node: child,
       componentInstanceVariables,
-      assemblyVariableDefinitions,
+      componentSettings,
+      patternProperties,
+      entityStore,
     }),
   );
 
@@ -114,7 +144,9 @@ export const resolveAssembly = ({
       children: componentFields.componentTree.children,
     },
     componentInstanceVariables: node.variables,
-    assemblyVariableDefinitions: componentFields.componentSettings!.variableDefinitions,
+    componentSettings: componentFields.componentSettings!,
+    patternProperties: node.patternProperties || {},
+    entityStore,
   });
 
   entityStore.addAssemblyUnboundValues(componentFields.unboundValues);

--- a/packages/experience-builder-sdk/src/utils/prebindingUtils.spec.ts
+++ b/packages/experience-builder-sdk/src/utils/prebindingUtils.spec.ts
@@ -1,0 +1,263 @@
+import { shouldUsePrebinding, resolvePrebindingPath } from './prebindingUtils';
+import { EntityStore } from '@contentful/experiences-core';
+import {
+  ComponentPropertyValue,
+  ExperienceComponentSettings,
+  PatternProperty,
+} from '@contentful/experiences-validators';
+
+describe('shouldUsePrebinding', () => {
+  it('should return true when all conditions are met', () => {
+    const componentValueKey = 'testKey';
+    const componentSettings = {
+      patternPropertyDefinitions: {
+        testPatternPropertyDefinitionId: {},
+      },
+      variableMappings: {
+        testKey: {
+          patternPropertyDefinitionId: 'testPatternPropertyDefinitionId',
+        },
+      },
+    } as unknown as ExperienceComponentSettings;
+    const patternProperties = {
+      testPatternPropertyDefinitionId: {},
+    } as unknown as Record<string, PatternProperty>;
+    const variable = {
+      type: 'NoValue',
+    } as unknown as ComponentPropertyValue;
+
+    const result = shouldUsePrebinding({
+      componentValueKey,
+      componentSettings,
+      patternProperties,
+      variable,
+    });
+
+    expect(result).toBe(true);
+  });
+
+  it('should return false when patternPropertyDefinition is missing', () => {
+    const componentValueKey = 'testKey';
+    const componentSettings = {
+      patternPropertyDefinitions: {},
+      variableMappings: {
+        testKey: {
+          patternPropertyDefinitionId: 'testPatternPropertyDefinitionId',
+        },
+      },
+    } as unknown as ExperienceComponentSettings;
+    const patternProperties: Record<string, PatternProperty> = {
+      testPatternPropertyDefinitionId: {},
+    } as unknown as Record<string, PatternProperty>;
+    const variable = {
+      type: 'NoValue',
+    } as unknown as ComponentPropertyValue;
+
+    const result = shouldUsePrebinding({
+      componentValueKey,
+      componentSettings,
+      patternProperties,
+      variable,
+    });
+
+    expect(result).toBe(false);
+  });
+
+  it('should return false when patternProperty is missing', () => {
+    const componentValueKey = 'testKey';
+    const componentSettings: ExperienceComponentSettings = {
+      patternPropertyDefinitions: {
+        testPatternPropertyDefinitionId: {},
+      },
+      variableMappings: {
+        testKey: {
+          patternPropertyDefinitionId: 'testPatternPropertyDefinitionId',
+        },
+      },
+    } as unknown as ExperienceComponentSettings;
+    const patternProperties: Record<string, PatternProperty> = {};
+    const variable = {
+      type: 'NoValue',
+    } as unknown as ComponentPropertyValue;
+
+    const result = shouldUsePrebinding({
+      componentValueKey,
+      componentSettings,
+      patternProperties,
+      variable,
+    });
+
+    expect(result).toBe(false);
+  });
+
+  it('should return false when variableMapping is missing', () => {
+    const componentValueKey = 'testKey';
+    const componentSettings = {
+      patternPropertyDefinitions: {
+        testPatternPropertyDefinitionId: {},
+      },
+      variableMappings: {},
+    } as unknown as ExperienceComponentSettings;
+    const patternProperties: Record<string, PatternProperty> = {
+      testPatternPropertyDefinitionId: { path: '/entries/testEntry', type: 'BoundValue' },
+    };
+    const variable = {
+      type: 'NoValue',
+    } as unknown as ComponentPropertyValue;
+
+    const result = shouldUsePrebinding({
+      componentValueKey,
+      componentSettings,
+      patternProperties,
+      variable,
+    });
+
+    expect(result).toBe(false);
+  });
+});
+
+describe('resolvePrebindingPath', () => {
+  it('should return the correct path when all conditions are met', () => {
+    const componentValueKey = 'testKey';
+    const componentSettings = {
+      patternPropertyDefinitions: {},
+      variableDefinitions: {},
+      variableMappings: {
+        testKey: {
+          type: 'ContentTypeMapping',
+          patternPropertyDefinitionId: 'testPatternPropertyDefinitionId',
+          pathsByContentType: {
+            testContentType: { path: '/fields/testField' },
+          },
+        },
+      },
+    } as unknown as ExperienceComponentSettings;
+    const patternProperties: Record<string, PatternProperty> = {
+      testPatternPropertyDefinitionId: { path: '/entries/testEntry', type: 'BoundValue' },
+    };
+    const entityStore = {
+      dataSource: {
+        testEntry: { sys: { type: 'Entry', contentType: { sys: { id: 'testContentType' } } } },
+      },
+      getEntryOrAsset: jest.fn().mockReturnValue({
+        sys: { type: 'Entry', contentType: { sys: { id: 'testContentType' } } },
+      }),
+    } as unknown as EntityStore;
+
+    const result = resolvePrebindingPath({
+      componentValueKey,
+      componentSettings,
+      patternProperties,
+      entityStore,
+    });
+
+    expect(result).toBe('/entries/testEntry/fields/testField');
+  });
+
+  it('should return an empty string when variableMapping is missing', () => {
+    const componentValueKey = 'testKey';
+    const componentSettings: ExperienceComponentSettings = {
+      variableMappings: {},
+    } as unknown as ExperienceComponentSettings;
+    const patternProperties: Record<string, PatternProperty> = {};
+    const entityStore: EntityStore = {
+      dataSource: {},
+      getEntryOrAsset: jest.fn(),
+    } as unknown as EntityStore;
+
+    const result = resolvePrebindingPath({
+      componentValueKey,
+      componentSettings,
+      patternProperties,
+      entityStore,
+    });
+
+    expect(result).toBe('');
+  });
+
+  it('should return an empty string when patternProperties is missing', () => {
+    const componentValueKey = 'testKey';
+    const componentSettings: ExperienceComponentSettings = {
+      variableMappings: {
+        testKey: {
+          patternPropertyDefinitionId: 'testPatternPropertyDefinitionId',
+        },
+      },
+    } as unknown as ExperienceComponentSettings;
+    const patternProperties: Record<string, PatternProperty> = {};
+    const entityStore: EntityStore = {
+      dataSource: {},
+      getEntryOrAsset: jest.fn(),
+    } as unknown as EntityStore;
+
+    const result = resolvePrebindingPath({
+      componentValueKey,
+      componentSettings,
+      patternProperties,
+      entityStore,
+    });
+
+    expect(result).toBe('');
+  });
+
+  it('should return an empty string when entityOrAsset is not an Entry', () => {
+    const componentValueKey = 'testKey';
+    const componentSettings: ExperienceComponentSettings = {
+      variableMappings: {
+        testKey: {
+          patternPropertyDefinitionId: 'testPatternPropertyDefinitionId',
+        },
+      },
+    } as unknown as ExperienceComponentSettings;
+    const patternProperties: Record<string, PatternProperty> = {
+      testPatternPropertyDefinitionId: { path: '/entries/testEntry' },
+    } as unknown as Record<string, PatternProperty>;
+    const entityStore: EntityStore = {
+      dataSource: {
+        testEntry: { sys: { type: 'Asset' } },
+      },
+      getEntryOrAsset: jest.fn().mockReturnValue({ sys: { type: 'Asset' } }),
+    } as unknown as EntityStore;
+
+    const result = resolvePrebindingPath({
+      componentValueKey,
+      componentSettings,
+      patternProperties,
+      entityStore,
+    });
+
+    expect(result).toBe('');
+  });
+
+  it('should return an empty string when fieldPath is missing', () => {
+    const componentValueKey = 'testKey';
+    const componentSettings: ExperienceComponentSettings = {
+      variableMappings: {
+        testKey: {
+          patternPropertyDefinitionId: 'testPatternPropertyDefinitionId',
+          pathsByContentType: {},
+        },
+      },
+    } as unknown as ExperienceComponentSettings;
+    const patternProperties: Record<string, PatternProperty> = {
+      testPatternPropertyDefinitionId: { path: '/entries/testEntry' },
+    } as unknown as Record<string, PatternProperty>;
+    const entityStore: EntityStore = {
+      dataSource: {
+        testEntry: { sys: { type: 'Entry', contentType: { sys: { id: 'testContentType' } } } },
+      },
+      getEntryOrAsset: jest.fn().mockReturnValue({
+        sys: { type: 'Entry', contentType: { sys: { id: 'testContentType' } } },
+      }),
+    } as unknown as EntityStore;
+
+    const result = resolvePrebindingPath({
+      componentValueKey,
+      componentSettings,
+      patternProperties,
+      entityStore,
+    });
+
+    expect(result).toBe('');
+  });
+});

--- a/packages/experience-builder-sdk/src/utils/prebindingUtils.ts
+++ b/packages/experience-builder-sdk/src/utils/prebindingUtils.ts
@@ -1,0 +1,68 @@
+import { EntityStore } from '@contentful/experiences-core';
+import {
+  ComponentPropertyValue,
+  ExperienceComponentSettings,
+  PatternProperty,
+} from '@contentful/experiences-validators';
+import { UnresolvedLink } from 'contentful';
+
+export const shouldUsePrebinding = ({
+  componentValueKey,
+  componentSettings,
+  patternProperties,
+  variable,
+}: {
+  componentValueKey: string;
+  componentSettings: ExperienceComponentSettings;
+  patternProperties: Record<string, PatternProperty>;
+  variable: ComponentPropertyValue;
+}) => {
+  const { patternPropertyDefinitions, variableMappings } = componentSettings;
+
+  const variableMapping = variableMappings?.[componentValueKey];
+
+  const patternPropertyDefinition =
+    patternPropertyDefinitions?.[variableMapping?.patternPropertyDefinitionId || ''];
+  const patternProperty = patternProperties?.[variableMapping?.patternPropertyDefinitionId || ''];
+
+  const isValidForPrebinding =
+    !!patternPropertyDefinition && !!patternProperty && !!variableMapping;
+
+  return isValidForPrebinding && variable?.type === 'NoValue';
+};
+
+export const resolvePrebindingPath = ({
+  componentValueKey,
+  componentSettings,
+  patternProperties,
+  entityStore,
+}: {
+  componentValueKey: string;
+  componentSettings: ExperienceComponentSettings;
+  patternProperties: Record<string, PatternProperty>;
+  entityStore: EntityStore;
+}) => {
+  const variableMapping = componentSettings.variableMappings?.[componentValueKey];
+
+  if (!variableMapping) return '';
+
+  const patternProperty = patternProperties?.[variableMapping.patternPropertyDefinitionId];
+
+  if (!patternProperty) return '';
+
+  const [, uuid] = patternProperty.path.split('/');
+  const binding = entityStore.dataSource[uuid] as UnresolvedLink<'Entry' | 'Asset'>;
+  const entityOrAsset = entityStore.getEntryOrAsset(binding, patternProperty.path);
+
+  if (entityOrAsset?.sys?.type !== 'Entry') {
+    return '';
+  }
+
+  const contentType = entityOrAsset.sys.contentType.sys.id;
+
+  const fieldPath = variableMapping.pathsByContentType[contentType]?.path;
+
+  if (!fieldPath) return '';
+
+  return patternProperty.path + fieldPath;
+};


### PR DESCRIPTION
## Purpose
Resolve variables to use prebinding mappings when appropriate based on this flow chart: https://miro.com/app/board/uXjVLqB2PkE=/?moveToWidget=3458764614096889309&cot=14

Variables combine a variableMapping with the patternProperty on the pattern's reference in the experience tree to derive the full BoundValue path.

This only is for delivery/preview mode. 

