### PR TITLE
chore(prebinding): add contentType to patternPropertySchema

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -31,6 +31,7 @@ export type {
   DesignValue,
   UnboundValue,
   BoundValue,
+  NoValue,
   ComponentValue,
   ComponentDefinitionPropertyType as ComponentDefinitionVariableType,
   PatternProperty,

--- a/packages/experience-builder-sdk/src/core/preview/assemblyUtils.ts
+++ b/packages/experience-builder-sdk/src/core/preview/assemblyUtils.ts
@@ -15,13 +15,11 @@ export const deserializeAssemblyNode = ({
   componentInstanceVariables,
   componentSettings,
   patternProperties,
-  entityStore,
 }: {
   node: ComponentTreeNode;
   componentInstanceVariables: ComponentTreeNode['variables'];
   componentSettings: ExperienceComponentSettings;
   patternProperties: Record<string, PatternProperty>;
-  entityStore: EntityStore;
 }): ComponentTreeNode => {
   const variables: Record<string, ComponentPropertyValue> = {};
 
@@ -44,7 +42,6 @@ export const deserializeAssemblyNode = ({
         const path = resolvePrebindingPath({
           componentSettings,
           componentValueKey,
-          entityStore,
           patternProperties,
         });
 
@@ -95,7 +92,6 @@ export const deserializeAssemblyNode = ({
       componentInstanceVariables,
       componentSettings,
       patternProperties,
-      entityStore,
     }),
   );
 
@@ -146,7 +142,6 @@ export const resolveAssembly = ({
     componentInstanceVariables: node.variables,
     componentSettings: componentFields.componentSettings!,
     patternProperties: node.patternProperties || {},
-    entityStore,
   });
 
   entityStore.addAssemblyUnboundValues(componentFields.unboundValues);

--- a/packages/experience-builder-sdk/src/utils/prebindingUtils.spec.ts
+++ b/packages/experience-builder-sdk/src/utils/prebindingUtils.spec.ts
@@ -1,5 +1,5 @@
 import { shouldUsePrebinding, resolvePrebindingPath } from './prebindingUtils';
-import { EntityStore } from '@contentful/experiences-core';
+
 import {
   ComponentPropertyValue,
   ExperienceComponentSettings,
@@ -143,20 +143,11 @@ describe('resolvePrebindingPath', () => {
         contenType: 'testContentType',
       },
     };
-    const entityStore = {
-      dataSource: {
-        testEntry: { sys: { type: 'Entry', contentType: { sys: { id: 'testContentType' } } } },
-      },
-      getEntryOrAsset: jest.fn().mockReturnValue({
-        sys: { type: 'Entry', contentType: { sys: { id: 'testContentType' } } },
-      }),
-    } as unknown as EntityStore;
 
     const result = resolvePrebindingPath({
       componentValueKey,
       componentSettings,
       patternProperties,
-      entityStore,
     });
 
     expect(result).toBe('/entries/testEntry/fields/testField');
@@ -168,16 +159,11 @@ describe('resolvePrebindingPath', () => {
       variableMappings: {},
     } as unknown as ExperienceComponentSettings;
     const patternProperties: Record<string, PatternProperty> = {};
-    const entityStore: EntityStore = {
-      dataSource: {},
-      getEntryOrAsset: jest.fn(),
-    } as unknown as EntityStore;
 
     const result = resolvePrebindingPath({
       componentValueKey,
       componentSettings,
       patternProperties,
-      entityStore,
     });
 
     expect(result).toBe('');
@@ -193,16 +179,11 @@ describe('resolvePrebindingPath', () => {
       },
     } as unknown as ExperienceComponentSettings;
     const patternProperties: Record<string, PatternProperty> = {};
-    const entityStore: EntityStore = {
-      dataSource: {},
-      getEntryOrAsset: jest.fn(),
-    } as unknown as EntityStore;
 
     const result = resolvePrebindingPath({
       componentValueKey,
       componentSettings,
       patternProperties,
-      entityStore,
     });
 
     expect(result).toBe('');
@@ -220,18 +201,11 @@ describe('resolvePrebindingPath', () => {
     const patternProperties: Record<string, PatternProperty> = {
       testPatternPropertyDefinitionId: { path: '/entries/testEntry' },
     } as unknown as Record<string, PatternProperty>;
-    const entityStore: EntityStore = {
-      dataSource: {
-        testEntry: { sys: { type: 'Asset' } },
-      },
-      getEntryOrAsset: jest.fn().mockReturnValue({ sys: { type: 'Asset' } }),
-    } as unknown as EntityStore;
 
     const result = resolvePrebindingPath({
       componentValueKey,
       componentSettings,
       patternProperties,
-      entityStore,
     });
 
     expect(result).toBe('');
@@ -250,20 +224,11 @@ describe('resolvePrebindingPath', () => {
     const patternProperties: Record<string, PatternProperty> = {
       testPatternPropertyDefinitionId: { path: '/entries/testEntry' },
     } as unknown as Record<string, PatternProperty>;
-    const entityStore: EntityStore = {
-      dataSource: {
-        testEntry: { sys: { type: 'Entry', contentType: { sys: { id: 'testContentType' } } } },
-      },
-      getEntryOrAsset: jest.fn().mockReturnValue({
-        sys: { type: 'Entry', contentType: { sys: { id: 'testContentType' } } },
-      }),
-    } as unknown as EntityStore;
 
     const result = resolvePrebindingPath({
       componentValueKey,
       componentSettings,
       patternProperties,
-      entityStore,
     });
 
     expect(result).toBe('');

--- a/packages/experience-builder-sdk/src/utils/prebindingUtils.spec.ts
+++ b/packages/experience-builder-sdk/src/utils/prebindingUtils.spec.ts
@@ -99,7 +99,11 @@ describe('shouldUsePrebinding', () => {
       variableMappings: {},
     } as unknown as ExperienceComponentSettings;
     const patternProperties: Record<string, PatternProperty> = {
-      testPatternPropertyDefinitionId: { path: '/entries/testEntry', type: 'BoundValue' },
+      testPatternPropertyDefinitionId: {
+        path: '/entries/testEntry',
+        type: 'BoundValue',
+        contenType: 'testContentType',
+      },
     };
     const variable = {
       type: 'NoValue',
@@ -133,7 +137,11 @@ describe('resolvePrebindingPath', () => {
       },
     } as unknown as ExperienceComponentSettings;
     const patternProperties: Record<string, PatternProperty> = {
-      testPatternPropertyDefinitionId: { path: '/entries/testEntry', type: 'BoundValue' },
+      testPatternPropertyDefinitionId: {
+        path: '/entries/testEntry',
+        type: 'BoundValue',
+        contenType: 'testContentType',
+      },
     };
     const entityStore = {
       dataSource: {

--- a/packages/experience-builder-sdk/src/utils/prebindingUtils.ts
+++ b/packages/experience-builder-sdk/src/utils/prebindingUtils.ts
@@ -1,10 +1,8 @@
-import { EntityStore } from '@contentful/experiences-core';
 import {
   ComponentPropertyValue,
   ExperienceComponentSettings,
   PatternProperty,
 } from '@contentful/experiences-validators';
-import { UnresolvedLink } from 'contentful';
 
 export const shouldUsePrebinding = ({
   componentValueKey,
@@ -35,12 +33,10 @@ export const resolvePrebindingPath = ({
   componentValueKey,
   componentSettings,
   patternProperties,
-  entityStore,
 }: {
   componentValueKey: string;
   componentSettings: ExperienceComponentSettings;
   patternProperties: Record<string, PatternProperty>;
-  entityStore: EntityStore;
 }) => {
   const variableMapping = componentSettings.variableMappings?.[componentValueKey];
 
@@ -50,15 +46,7 @@ export const resolvePrebindingPath = ({
 
   if (!patternProperty) return '';
 
-  const [, uuid] = patternProperty.path.split('/');
-  const binding = entityStore.dataSource[uuid] as UnresolvedLink<'Entry' | 'Asset'>;
-  const entityOrAsset = entityStore.getEntryOrAsset(binding, patternProperty.path);
-
-  if (entityOrAsset?.sys?.type !== 'Entry') {
-    return '';
-  }
-
-  const contentType = entityOrAsset.sys.contentType.sys.id;
+  const contentType = patternProperty.contenType;
 
   const fieldPath = variableMapping.pathsByContentType[contentType]?.path;
 

--- a/packages/experience-builder-sdk/src/utils/prebindingUtils.ts
+++ b/packages/experience-builder-sdk/src/utils/prebindingUtils.ts
@@ -48,7 +48,7 @@ export const resolvePrebindingPath = ({
 
   const contentType = patternProperty.contenType;
 
-  const fieldPath = variableMapping.pathsByContentType[contentType]?.path;
+  const fieldPath = variableMapping?.pathsByContentType?.[contentType]?.path;
 
   if (!fieldPath) return '';
 

--- a/packages/validators/src/schemas/v2023_09_28/experience.ts
+++ b/packages/validators/src/schemas/v2023_09_28/experience.ts
@@ -133,6 +133,7 @@ const PatternPropertyDefinitionsSchema = z.record(
 const PatternPropertySchema = z.object({
   type: z.literal('BoundValue'),
   path: z.string(),
+  contenType: z.string(),
 });
 
 const PatternPropertysSchema = z.record(propertyKeySchema, PatternPropertySchema);
@@ -321,6 +322,7 @@ export type Breakpoint = z.infer<typeof BreakpointSchema>;
 export type PrimitiveValue = z.infer<typeof PrimitiveValueSchema>;
 export type DesignValue = z.infer<typeof DesignValueSchema>;
 export type BoundValue = z.infer<typeof BoundValueSchema>;
+export type NoValue = z.infer<typeof NoValueSchema>;
 export type UnboundValue = z.infer<typeof UnboundValueSchema>;
 export type HyperlinkValue = z.infer<typeof HyperlinkValueSchema>;
 export type ComponentValue = z.infer<typeof ComponentValueSchema>;

--- a/packages/validators/src/types.ts
+++ b/packages/validators/src/types.ts
@@ -10,6 +10,7 @@ export type {
   ComponentPropertyValue,
   ComponentTreeNode,
   PrimitiveValue,
+  NoValue,
   DesignValue,
   UnboundValue,
   BoundValue,


### PR DESCRIPTION
## Purpose
Allow us to more easily derive the contentType for prebinding by including it in the schema stored on the entry instead of trying to derive at runtime with the fetched entity.

Ticket: https://contentful.atlassian.net/browse/LUMOS-561
