### PR TITLE
feat: only provide isInExpEditorMode if activated in options [SPA-2607]

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -121,10 +121,12 @@ export type ComponentRegistration = {
   component: React.ElementType;
   definition: ComponentDefinition;
   options?: {
+    /**
+     * If true, the component receives the optional boolean property `isInExpEditorMode` to
+     * render different content between editor and delivery mode.
+     */
+    enableCustomEditorView?: boolean;
     wrapComponent?: boolean;
-    /** @deprecated use wrapContainer instead */
-    wrapContainerTag?: keyof JSX.IntrinsicElements;
-    wrapContainer?: keyof JSX.IntrinsicElements | React.ReactElement;
     wrapContainerWidth?: React.CSSProperties['width'];
   };
 };

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -127,6 +127,9 @@ export type ComponentRegistration = {
      */
     enableCustomEditorView?: boolean;
     wrapComponent?: boolean;
+    /** @deprecated use wrapContainer instead */
+    wrapContainerTag?: keyof JSX.IntrinsicElements;
+    wrapContainer?: keyof JSX.IntrinsicElements | React.ReactElement;
     wrapContainerWidth?: React.CSSProperties['width'];
   };
 };

--- a/packages/experience-builder-sdk/src/utils/withComponentWrapper.tsx
+++ b/packages/experience-builder-sdk/src/utils/withComponentWrapper.tsx
@@ -17,13 +17,15 @@ interface CFProps extends React.HtmlHTMLAttributes<HTMLElement> {
  * Sets up a component to be consumed by Experience Builder. This function can be used to wrap a component with a container component, or to pass props to the component directly.
  * @param Component Component to be used by Experience Builder.
  * @param options Options for the `withComponentWrapper` function.
- * @default { wrapComponent: true }
+ * @default { wrapComponent: true, wrapContainerTag: 'div' }
  * @returns A component that can be passed to `defineComponents`.
  */
 export function withComponentWrapper<T>(
   Component: React.ElementType,
   options: ComponentRegistration['options'] = {
     wrapComponent: true,
+    wrapContainerTag: 'div',
+    wrapContainer: 'div',
   },
 ) {
   const Wrapped: React.FC<CFProps & T> = ({

--- a/packages/experience-builder-sdk/src/utils/withComponentWrapper.tsx
+++ b/packages/experience-builder-sdk/src/utils/withComponentWrapper.tsx
@@ -17,15 +17,13 @@ interface CFProps extends React.HtmlHTMLAttributes<HTMLElement> {
  * Sets up a component to be consumed by Experience Builder. This function can be used to wrap a component with a container component, or to pass props to the component directly.
  * @param Component Component to be used by Experience Builder.
  * @param options Options for the `withComponentWrapper` function.
- * @default { wrapComponent: true, wrapContainerTag: 'div' }
+ * @default { wrapComponent: true }
  * @returns A component that can be passed to `defineComponents`.
  */
 export function withComponentWrapper<T>(
   Component: React.ElementType,
   options: ComponentRegistration['options'] = {
     wrapComponent: true,
-    wrapContainerTag: 'div',
-    wrapContainer: 'div',
   },
 ) {
   const Wrapped: React.FC<CFProps & T> = ({

--- a/packages/visual-editor/src/hooks/useComponentProps.spec.ts
+++ b/packages/visual-editor/src/hooks/useComponentProps.spec.ts
@@ -324,7 +324,23 @@ describe('useComponentProps', () => {
       },
     );
 
-    it('should return isInExpEditorMode as true for custom components', () => {
+    it('should return isInExpEditorMode as true for custom components when flag is enabled', () => {
+      const { result } = renderHook(() =>
+        useComponentProps({
+          node,
+          areEntitiesFetched,
+          resolveDesignValue,
+          renderDropzone,
+          definition,
+          userIsDragging,
+          options: { wrapComponent: false, enableCustomEditorView: true },
+        }),
+      );
+
+      expect(result.current.componentProps.isInExpEditorMode).toBe(true);
+    });
+
+    it('should not return isInExpEditorMode when the flag is not enabled', () => {
       const { result } = renderHook(() =>
         useComponentProps({
           node,
@@ -337,7 +353,7 @@ describe('useComponentProps', () => {
         }),
       );
 
-      expect(result.current.componentProps.isInExpEditorMode).toBe(true);
+      expect(result.current.componentProps.isInExpEditorMode).toBeUndefined();
     });
 
     it('should return unbound values in componentProps for structural components', () => {

--- a/packages/visual-editor/src/hooks/useComponentProps.ts
+++ b/packages/visual-editor/src/hooks/useComponentProps.ts
@@ -314,7 +314,9 @@ export const useComponentProps = ({
 
   const customComponentProps: ResolvedComponentProps = {
     ...sharedProps,
-    isInExpEditorMode: true,
+    // Allows custom components to render differently in the editor. This needs to be activated
+    // through options as the component has to be aware of this prop to not cause any React warnings.
+    ...(options?.enableCustomEditorView ? { isInExpEditorMode: true } : {}),
     ...sanitizeNodeProps(props),
   };
 


### PR DESCRIPTION
## Purpose
We added the prop `isInExpEditorMode` as some customers want to render different content in editor mode than in delivery.
However, this will cause a React warning for every (non-structural) component.

<img width="1457" alt="Feb 20 2025 Sprint 2 Screenshot" src="https://github.com/user-attachments/assets/31e0e794-6127-44d6-9d7f-092febae6d92" />

## Approach
To still allow this level of customization without disrupting simple use cases, we only provide it if activated through the registration options.

I noticed that we still have two options that have no effect anymore on the SDK. I removed those (`wrapContainerTag` and `wrapContainer`)