### PR TITLE
fix: restore wrapContainer option to work again

### DIFF
--- a/packages/experience-builder-sdk/src/utils/withComponentWrapper.spec.tsx
+++ b/packages/experience-builder-sdk/src/utils/withComponentWrapper.spec.tsx
@@ -13,7 +13,24 @@ describe('withComponentWrapper', () => {
   });
 
   describe('when component is wrapped', () => {
-    const WrappedButton = withComponentWrapper(MyButton);
+    const WrappedButton = withComponentWrapper(MyButton, {
+      wrapComponent: true,
+    });
+
+    it('can wrap a component with a custom tag', () => {
+      const WrappedButtonSpan = withComponentWrapper(MyButton, {
+        wrapContainerTag: 'span',
+        wrapComponent: true,
+      });
+
+      const { container } = render(
+        <WrappedButtonSpan className="my-span">Click me</WrappedButtonSpan>,
+      );
+
+      expect(container.firstChild?.nodeName).toEqual('SPAN');
+      expect(container.firstChild).toHaveClass('my-span');
+      expect(container.firstChild).toHaveTextContent('Click me');
+    });
 
     it('classes get added to the correct elements', () => {
       const { container, getByRole } = render(

--- a/packages/experience-builder-sdk/src/utils/withComponentWrapper.tsx
+++ b/packages/experience-builder-sdk/src/utils/withComponentWrapper.tsx
@@ -24,8 +24,6 @@ export function withComponentWrapper<T>(
   Component: React.ElementType,
   options: ComponentRegistration['options'] = {
     wrapComponent: true,
-    wrapContainerTag: 'div',
-    wrapContainer: 'div',
   },
 ) {
   const Wrapped: React.FC<CFProps & T> = ({
@@ -40,8 +38,11 @@ export function withComponentWrapper<T>(
       ToolTipAndPlaceholder,
       ...restOfDragProps
     } = dragProps;
+
+    const Tag = (options.wrapContainer || options.wrapContainerTag || 'div') as string;
+
     const component = options.wrapComponent ? (
-      <div
+      <Tag
         data-component-wrapper
         className={classNames(classes, className, dragClassName)}
         {...restOfDragProps}
@@ -50,7 +51,7 @@ export function withComponentWrapper<T>(
         }}>
         {ToolTipAndPlaceholder}
         <Component className={classNames(classes)} {...(props as T)} />
-      </div>
+      </Tag>
     ) : (
       React.createElement(Component, {
         className: classNames(classes, className),


### PR DESCRIPTION
## Purpose

Adds back in the functionality of specifying a custom wrapping container tag that was accidentally removed in https://github.com/contentful/experience-builder/commit/22ef6775df4a551eb0c7f541f3f8ab14069b2e67#diff-032b7a2eac51d40c7a9354cf29f7e1e654073acfd5af7a0b0dc50267b1d309c2

## Approach

<!--
Remember when merging:
- Use "Squash and merge" when merging changes into development.
- Use "Create a merge commit" when releasing changes into next and main.

Three important notes on pull requests:
- In general, you should ask yourself whether this code change will improve or worsen the overall code quality. Any new tech debt will probably never be cleaned up.
- Please remember that newly introduced logic should be validated and protected through testing.
- Take a look at PR guides:
  Google's Code Review Guidelines: https://google.github.io/eng-practices/
  Blockly - Writing a Good Pull Request: https://developers.google.com/blockly/guides/contribute/get-started/write_a_good_pr
-->
