### PR TITLE
feat(prebinding): schema updates and rendering of prebinding mappings in delivery mode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2507,6 +2507,7 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -31,6 +31,7 @@ export type {
   DesignValue,
   UnboundValue,
   BoundValue,
+  NoValue,
   ComponentValue,
   ComponentDefinitionPropertyType as ComponentDefinitionVariableType,
   PatternProperty,

--- a/packages/experience-builder-sdk/src/core/preview/assemblyUtils.ts
+++ b/packages/experience-builder-sdk/src/core/preview/assemblyUtils.ts
@@ -15,13 +15,11 @@ export const deserializeAssemblyNode = ({
   componentInstanceVariables,
   componentSettings,
   patternProperties,
-  entityStore,
 }: {
   node: ComponentTreeNode;
   componentInstanceVariables: ComponentTreeNode['variables'];
   componentSettings: ExperienceComponentSettings;
   patternProperties: Record<string, PatternProperty>;
-  entityStore: EntityStore;
 }): ComponentTreeNode => {
   const variables: Record<string, ComponentPropertyValue> = {};
 
@@ -44,7 +42,6 @@ export const deserializeAssemblyNode = ({
         const path = resolvePrebindingPath({
           componentSettings,
           componentValueKey,
-          entityStore,
           patternProperties,
         });
 
@@ -95,7 +92,6 @@ export const deserializeAssemblyNode = ({
       componentInstanceVariables,
       componentSettings,
       patternProperties,
-      entityStore,
     }),
   );
 
@@ -146,7 +142,6 @@ export const resolveAssembly = ({
     componentInstanceVariables: node.variables,
     componentSettings: componentFields.componentSettings!,
     patternProperties: node.patternProperties || {},
-    entityStore,
   });
 
   entityStore.addAssemblyUnboundValues(componentFields.unboundValues);

--- a/packages/experience-builder-sdk/src/core/preview/assemblyUtils.ts
+++ b/packages/experience-builder-sdk/src/core/preview/assemblyUtils.ts
@@ -4,18 +4,24 @@ import type {
   ComponentTreeNode,
   DesignValue,
   ExperienceComponentSettings,
+  PatternProperty,
 } from '@contentful/experiences-core/types';
+import { resolvePrebindingPath, shouldUsePrebinding } from '../../utils/prebindingUtils';
 
 /** While unfolding the assembly definition on the instance, this function will replace all
  * ComponentValue in the definitions tree with the actual value on the instance. */
 export const deserializeAssemblyNode = ({
   node,
   componentInstanceVariables,
-  assemblyVariableDefinitions,
+  componentSettings,
+  patternProperties,
+  entityStore,
 }: {
   node: ComponentTreeNode;
   componentInstanceVariables: ComponentTreeNode['variables'];
-  assemblyVariableDefinitions: ExperienceComponentSettings['variableDefinitions'];
+  componentSettings: ExperienceComponentSettings;
+  patternProperties: Record<string, PatternProperty>;
+  entityStore: EntityStore;
 }): ComponentTreeNode => {
   const variables: Record<string, ComponentPropertyValue> = {};
 
@@ -24,12 +30,34 @@ export const deserializeAssemblyNode = ({
     if (variable.type === 'ComponentValue') {
       const componentValueKey = variable.key;
       const instanceProperty = componentInstanceVariables[componentValueKey];
-      const variableDefinition = assemblyVariableDefinitions?.[componentValueKey];
+      const variableDefinition = componentSettings.variableDefinitions?.[componentValueKey];
       const defaultValue = variableDefinition?.defaultValue;
 
-      // For assembly, we look up the variable in the assembly instance and
-      // replace the ComponentValue with that one.
-      if (instanceProperty?.type === 'UnboundValue') {
+      const usePrebinding = shouldUsePrebinding({
+        componentSettings,
+        componentValueKey,
+        patternProperties,
+        variable: instanceProperty,
+      });
+
+      if (usePrebinding) {
+        const path = resolvePrebindingPath({
+          componentSettings,
+          componentValueKey,
+          entityStore,
+          patternProperties,
+        });
+
+        if (path) {
+          variables[variableName] = {
+            type: 'BoundValue',
+            path,
+          };
+        }
+
+        // For assembly, we look up the variable in the assembly instance and
+        // replace the ComponentValue with that one.
+      } else if (instanceProperty?.type === 'UnboundValue') {
         variables[variableName] = {
           type: 'UnboundValue',
           key: instanceProperty.key,
@@ -65,7 +93,9 @@ export const deserializeAssemblyNode = ({
     deserializeAssemblyNode({
       node: child,
       componentInstanceVariables,
-      assemblyVariableDefinitions,
+      componentSettings,
+      patternProperties,
+      entityStore,
     }),
   );
 
@@ -114,7 +144,9 @@ export const resolveAssembly = ({
       children: componentFields.componentTree.children,
     },
     componentInstanceVariables: node.variables,
-    assemblyVariableDefinitions: componentFields.componentSettings!.variableDefinitions,
+    componentSettings: componentFields.componentSettings!,
+    patternProperties: node.patternProperties || {},
+    entityStore,
   });
 
   entityStore.addAssemblyUnboundValues(componentFields.unboundValues);

--- a/packages/experience-builder-sdk/src/utils/prebindingUtils.spec.ts
+++ b/packages/experience-builder-sdk/src/utils/prebindingUtils.spec.ts
@@ -1,5 +1,5 @@
 import { shouldUsePrebinding, resolvePrebindingPath } from './prebindingUtils';
-import { EntityStore } from '@contentful/experiences-core';
+
 import {
   ComponentPropertyValue,
   ExperienceComponentSettings,
@@ -99,7 +99,11 @@ describe('shouldUsePrebinding', () => {
       variableMappings: {},
     } as unknown as ExperienceComponentSettings;
     const patternProperties: Record<string, PatternProperty> = {
-      testPatternPropertyDefinitionId: { path: '/entries/testEntry', type: 'BoundValue' },
+      testPatternPropertyDefinitionId: {
+        path: '/entries/testEntry',
+        type: 'BoundValue',
+        contenType: 'testContentType',
+      },
     };
     const variable = {
       type: 'NoValue',
@@ -133,22 +137,17 @@ describe('resolvePrebindingPath', () => {
       },
     } as unknown as ExperienceComponentSettings;
     const patternProperties: Record<string, PatternProperty> = {
-      testPatternPropertyDefinitionId: { path: '/entries/testEntry', type: 'BoundValue' },
-    };
-    const entityStore = {
-      dataSource: {
-        testEntry: { sys: { type: 'Entry', contentType: { sys: { id: 'testContentType' } } } },
+      testPatternPropertyDefinitionId: {
+        path: '/entries/testEntry',
+        type: 'BoundValue',
+        contenType: 'testContentType',
       },
-      getEntryOrAsset: jest.fn().mockReturnValue({
-        sys: { type: 'Entry', contentType: { sys: { id: 'testContentType' } } },
-      }),
-    } as unknown as EntityStore;
+    };
 
     const result = resolvePrebindingPath({
       componentValueKey,
       componentSettings,
       patternProperties,
-      entityStore,
     });
 
     expect(result).toBe('/entries/testEntry/fields/testField');
@@ -160,16 +159,11 @@ describe('resolvePrebindingPath', () => {
       variableMappings: {},
     } as unknown as ExperienceComponentSettings;
     const patternProperties: Record<string, PatternProperty> = {};
-    const entityStore: EntityStore = {
-      dataSource: {},
-      getEntryOrAsset: jest.fn(),
-    } as unknown as EntityStore;
 
     const result = resolvePrebindingPath({
       componentValueKey,
       componentSettings,
       patternProperties,
-      entityStore,
     });
 
     expect(result).toBe('');
@@ -185,16 +179,11 @@ describe('resolvePrebindingPath', () => {
       },
     } as unknown as ExperienceComponentSettings;
     const patternProperties: Record<string, PatternProperty> = {};
-    const entityStore: EntityStore = {
-      dataSource: {},
-      getEntryOrAsset: jest.fn(),
-    } as unknown as EntityStore;
 
     const result = resolvePrebindingPath({
       componentValueKey,
       componentSettings,
       patternProperties,
-      entityStore,
     });
 
     expect(result).toBe('');
@@ -212,18 +201,11 @@ describe('resolvePrebindingPath', () => {
     const patternProperties: Record<string, PatternProperty> = {
       testPatternPropertyDefinitionId: { path: '/entries/testEntry' },
     } as unknown as Record<string, PatternProperty>;
-    const entityStore: EntityStore = {
-      dataSource: {
-        testEntry: { sys: { type: 'Asset' } },
-      },
-      getEntryOrAsset: jest.fn().mockReturnValue({ sys: { type: 'Asset' } }),
-    } as unknown as EntityStore;
 
     const result = resolvePrebindingPath({
       componentValueKey,
       componentSettings,
       patternProperties,
-      entityStore,
     });
 
     expect(result).toBe('');
@@ -242,20 +224,11 @@ describe('resolvePrebindingPath', () => {
     const patternProperties: Record<string, PatternProperty> = {
       testPatternPropertyDefinitionId: { path: '/entries/testEntry' },
     } as unknown as Record<string, PatternProperty>;
-    const entityStore: EntityStore = {
-      dataSource: {
-        testEntry: { sys: { type: 'Entry', contentType: { sys: { id: 'testContentType' } } } },
-      },
-      getEntryOrAsset: jest.fn().mockReturnValue({
-        sys: { type: 'Entry', contentType: { sys: { id: 'testContentType' } } },
-      }),
-    } as unknown as EntityStore;
 
     const result = resolvePrebindingPath({
       componentValueKey,
       componentSettings,
       patternProperties,
-      entityStore,
     });
 
     expect(result).toBe('');

--- a/packages/experience-builder-sdk/src/utils/prebindingUtils.spec.ts
+++ b/packages/experience-builder-sdk/src/utils/prebindingUtils.spec.ts
@@ -1,0 +1,263 @@
+import { shouldUsePrebinding, resolvePrebindingPath } from './prebindingUtils';
+import { EntityStore } from '@contentful/experiences-core';
+import {
+  ComponentPropertyValue,
+  ExperienceComponentSettings,
+  PatternProperty,
+} from '@contentful/experiences-validators';
+
+describe('shouldUsePrebinding', () => {
+  it('should return true when all conditions are met', () => {
+    const componentValueKey = 'testKey';
+    const componentSettings = {
+      patternPropertyDefinitions: {
+        testPatternPropertyDefinitionId: {},
+      },
+      variableMappings: {
+        testKey: {
+          patternPropertyDefinitionId: 'testPatternPropertyDefinitionId',
+        },
+      },
+    } as unknown as ExperienceComponentSettings;
+    const patternProperties = {
+      testPatternPropertyDefinitionId: {},
+    } as unknown as Record<string, PatternProperty>;
+    const variable = {
+      type: 'NoValue',
+    } as unknown as ComponentPropertyValue;
+
+    const result = shouldUsePrebinding({
+      componentValueKey,
+      componentSettings,
+      patternProperties,
+      variable,
+    });
+
+    expect(result).toBe(true);
+  });
+
+  it('should return false when patternPropertyDefinition is missing', () => {
+    const componentValueKey = 'testKey';
+    const componentSettings = {
+      patternPropertyDefinitions: {},
+      variableMappings: {
+        testKey: {
+          patternPropertyDefinitionId: 'testPatternPropertyDefinitionId',
+        },
+      },
+    } as unknown as ExperienceComponentSettings;
+    const patternProperties: Record<string, PatternProperty> = {
+      testPatternPropertyDefinitionId: {},
+    } as unknown as Record<string, PatternProperty>;
+    const variable = {
+      type: 'NoValue',
+    } as unknown as ComponentPropertyValue;
+
+    const result = shouldUsePrebinding({
+      componentValueKey,
+      componentSettings,
+      patternProperties,
+      variable,
+    });
+
+    expect(result).toBe(false);
+  });
+
+  it('should return false when patternProperty is missing', () => {
+    const componentValueKey = 'testKey';
+    const componentSettings: ExperienceComponentSettings = {
+      patternPropertyDefinitions: {
+        testPatternPropertyDefinitionId: {},
+      },
+      variableMappings: {
+        testKey: {
+          patternPropertyDefinitionId: 'testPatternPropertyDefinitionId',
+        },
+      },
+    } as unknown as ExperienceComponentSettings;
+    const patternProperties: Record<string, PatternProperty> = {};
+    const variable = {
+      type: 'NoValue',
+    } as unknown as ComponentPropertyValue;
+
+    const result = shouldUsePrebinding({
+      componentValueKey,
+      componentSettings,
+      patternProperties,
+      variable,
+    });
+
+    expect(result).toBe(false);
+  });
+
+  it('should return false when variableMapping is missing', () => {
+    const componentValueKey = 'testKey';
+    const componentSettings = {
+      patternPropertyDefinitions: {
+        testPatternPropertyDefinitionId: {},
+      },
+      variableMappings: {},
+    } as unknown as ExperienceComponentSettings;
+    const patternProperties: Record<string, PatternProperty> = {
+      testPatternPropertyDefinitionId: { path: '/entries/testEntry', type: 'BoundValue' },
+    };
+    const variable = {
+      type: 'NoValue',
+    } as unknown as ComponentPropertyValue;
+
+    const result = shouldUsePrebinding({
+      componentValueKey,
+      componentSettings,
+      patternProperties,
+      variable,
+    });
+
+    expect(result).toBe(false);
+  });
+});
+
+describe('resolvePrebindingPath', () => {
+  it('should return the correct path when all conditions are met', () => {
+    const componentValueKey = 'testKey';
+    const componentSettings = {
+      patternPropertyDefinitions: {},
+      variableDefinitions: {},
+      variableMappings: {
+        testKey: {
+          type: 'ContentTypeMapping',
+          patternPropertyDefinitionId: 'testPatternPropertyDefinitionId',
+          pathsByContentType: {
+            testContentType: { path: '/fields/testField' },
+          },
+        },
+      },
+    } as unknown as ExperienceComponentSettings;
+    const patternProperties: Record<string, PatternProperty> = {
+      testPatternPropertyDefinitionId: { path: '/entries/testEntry', type: 'BoundValue' },
+    };
+    const entityStore = {
+      dataSource: {
+        testEntry: { sys: { type: 'Entry', contentType: { sys: { id: 'testContentType' } } } },
+      },
+      getEntryOrAsset: jest.fn().mockReturnValue({
+        sys: { type: 'Entry', contentType: { sys: { id: 'testContentType' } } },
+      }),
+    } as unknown as EntityStore;
+
+    const result = resolvePrebindingPath({
+      componentValueKey,
+      componentSettings,
+      patternProperties,
+      entityStore,
+    });
+
+    expect(result).toBe('/entries/testEntry/fields/testField');
+  });
+
+  it('should return an empty string when variableMapping is missing', () => {
+    const componentValueKey = 'testKey';
+    const componentSettings: ExperienceComponentSettings = {
+      variableMappings: {},
+    } as unknown as ExperienceComponentSettings;
+    const patternProperties: Record<string, PatternProperty> = {};
+    const entityStore: EntityStore = {
+      dataSource: {},
+      getEntryOrAsset: jest.fn(),
+    } as unknown as EntityStore;
+
+    const result = resolvePrebindingPath({
+      componentValueKey,
+      componentSettings,
+      patternProperties,
+      entityStore,
+    });
+
+    expect(result).toBe('');
+  });
+
+  it('should return an empty string when patternProperties is missing', () => {
+    const componentValueKey = 'testKey';
+    const componentSettings: ExperienceComponentSettings = {
+      variableMappings: {
+        testKey: {
+          patternPropertyDefinitionId: 'testPatternPropertyDefinitionId',
+        },
+      },
+    } as unknown as ExperienceComponentSettings;
+    const patternProperties: Record<string, PatternProperty> = {};
+    const entityStore: EntityStore = {
+      dataSource: {},
+      getEntryOrAsset: jest.fn(),
+    } as unknown as EntityStore;
+
+    const result = resolvePrebindingPath({
+      componentValueKey,
+      componentSettings,
+      patternProperties,
+      entityStore,
+    });
+
+    expect(result).toBe('');
+  });
+
+  it('should return an empty string when entityOrAsset is not an Entry', () => {
+    const componentValueKey = 'testKey';
+    const componentSettings: ExperienceComponentSettings = {
+      variableMappings: {
+        testKey: {
+          patternPropertyDefinitionId: 'testPatternPropertyDefinitionId',
+        },
+      },
+    } as unknown as ExperienceComponentSettings;
+    const patternProperties: Record<string, PatternProperty> = {
+      testPatternPropertyDefinitionId: { path: '/entries/testEntry' },
+    } as unknown as Record<string, PatternProperty>;
+    const entityStore: EntityStore = {
+      dataSource: {
+        testEntry: { sys: { type: 'Asset' } },
+      },
+      getEntryOrAsset: jest.fn().mockReturnValue({ sys: { type: 'Asset' } }),
+    } as unknown as EntityStore;
+
+    const result = resolvePrebindingPath({
+      componentValueKey,
+      componentSettings,
+      patternProperties,
+      entityStore,
+    });
+
+    expect(result).toBe('');
+  });
+
+  it('should return an empty string when fieldPath is missing', () => {
+    const componentValueKey = 'testKey';
+    const componentSettings: ExperienceComponentSettings = {
+      variableMappings: {
+        testKey: {
+          patternPropertyDefinitionId: 'testPatternPropertyDefinitionId',
+          pathsByContentType: {},
+        },
+      },
+    } as unknown as ExperienceComponentSettings;
+    const patternProperties: Record<string, PatternProperty> = {
+      testPatternPropertyDefinitionId: { path: '/entries/testEntry' },
+    } as unknown as Record<string, PatternProperty>;
+    const entityStore: EntityStore = {
+      dataSource: {
+        testEntry: { sys: { type: 'Entry', contentType: { sys: { id: 'testContentType' } } } },
+      },
+      getEntryOrAsset: jest.fn().mockReturnValue({
+        sys: { type: 'Entry', contentType: { sys: { id: 'testContentType' } } },
+      }),
+    } as unknown as EntityStore;
+
+    const result = resolvePrebindingPath({
+      componentValueKey,
+      componentSettings,
+      patternProperties,
+      entityStore,
+    });
+
+    expect(result).toBe('');
+  });
+});

--- a/packages/experience-builder-sdk/src/utils/prebindingUtils.ts
+++ b/packages/experience-builder-sdk/src/utils/prebindingUtils.ts
@@ -1,0 +1,68 @@
+import { EntityStore } from '@contentful/experiences-core';
+import {
+  ComponentPropertyValue,
+  ExperienceComponentSettings,
+  PatternProperty,
+} from '@contentful/experiences-validators';
+import { UnresolvedLink } from 'contentful';
+
+export const shouldUsePrebinding = ({
+  componentValueKey,
+  componentSettings,
+  patternProperties,
+  variable,
+}: {
+  componentValueKey: string;
+  componentSettings: ExperienceComponentSettings;
+  patternProperties: Record<string, PatternProperty>;
+  variable: ComponentPropertyValue;
+}) => {
+  const { patternPropertyDefinitions, variableMappings } = componentSettings;
+
+  const variableMapping = variableMappings?.[componentValueKey];
+
+  const patternPropertyDefinition =
+    patternPropertyDefinitions?.[variableMapping?.patternPropertyDefinitionId || ''];
+  const patternProperty = patternProperties?.[variableMapping?.patternPropertyDefinitionId || ''];
+
+  const isValidForPrebinding =
+    !!patternPropertyDefinition && !!patternProperty && !!variableMapping;
+
+  return isValidForPrebinding && variable?.type === 'NoValue';
+};
+
+export const resolvePrebindingPath = ({
+  componentValueKey,
+  componentSettings,
+  patternProperties,
+  entityStore,
+}: {
+  componentValueKey: string;
+  componentSettings: ExperienceComponentSettings;
+  patternProperties: Record<string, PatternProperty>;
+  entityStore: EntityStore;
+}) => {
+  const variableMapping = componentSettings.variableMappings?.[componentValueKey];
+
+  if (!variableMapping) return '';
+
+  const patternProperty = patternProperties?.[variableMapping.patternPropertyDefinitionId];
+
+  if (!patternProperty) return '';
+
+  const [, uuid] = patternProperty.path.split('/');
+  const binding = entityStore.dataSource[uuid] as UnresolvedLink<'Entry' | 'Asset'>;
+  const entityOrAsset = entityStore.getEntryOrAsset(binding, patternProperty.path);
+
+  if (entityOrAsset?.sys?.type !== 'Entry') {
+    return '';
+  }
+
+  const contentType = entityOrAsset.sys.contentType.sys.id;
+
+  const fieldPath = variableMapping.pathsByContentType[contentType]?.path;
+
+  if (!fieldPath) return '';
+
+  return patternProperty.path + fieldPath;
+};

--- a/packages/experience-builder-sdk/src/utils/prebindingUtils.ts
+++ b/packages/experience-builder-sdk/src/utils/prebindingUtils.ts
@@ -1,10 +1,8 @@
-import { EntityStore } from '@contentful/experiences-core';
 import {
   ComponentPropertyValue,
   ExperienceComponentSettings,
   PatternProperty,
 } from '@contentful/experiences-validators';
-import { UnresolvedLink } from 'contentful';
 
 export const shouldUsePrebinding = ({
   componentValueKey,
@@ -35,12 +33,10 @@ export const resolvePrebindingPath = ({
   componentValueKey,
   componentSettings,
   patternProperties,
-  entityStore,
 }: {
   componentValueKey: string;
   componentSettings: ExperienceComponentSettings;
   patternProperties: Record<string, PatternProperty>;
-  entityStore: EntityStore;
 }) => {
   const variableMapping = componentSettings.variableMappings?.[componentValueKey];
 
@@ -50,17 +46,9 @@ export const resolvePrebindingPath = ({
 
   if (!patternProperty) return '';
 
-  const [, uuid] = patternProperty.path.split('/');
-  const binding = entityStore.dataSource[uuid] as UnresolvedLink<'Entry' | 'Asset'>;
-  const entityOrAsset = entityStore.getEntryOrAsset(binding, patternProperty.path);
+  const contentType = patternProperty.contenType;
 
-  if (entityOrAsset?.sys?.type !== 'Entry') {
-    return '';
-  }
-
-  const contentType = entityOrAsset.sys.contentType.sys.id;
-
-  const fieldPath = variableMapping.pathsByContentType[contentType]?.path;
+  const fieldPath = variableMapping?.pathsByContentType?.[contentType]?.path;
 
   if (!fieldPath) return '';
 

--- a/packages/validators/src/schemas/v2023_09_28/experience.ts
+++ b/packages/validators/src/schemas/v2023_09_28/experience.ts
@@ -88,7 +88,7 @@ const ComponentValueSchema = z
 
 // TODO: finalize schema structure before release
 // https://contentful.atlassian.net/browse/LUMOS-523
-const EmptyObjectSchema = z.object({ type: z.undefined() });
+const NoValueSchema = z.object({ type: z.literal('NoValue') }).strict();
 
 const ComponentPropertyValueSchema = z.discriminatedUnion('type', [
   DesignValueSchema,
@@ -96,7 +96,7 @@ const ComponentPropertyValueSchema = z.discriminatedUnion('type', [
   UnboundValueSchema,
   HyperlinkValueSchema,
   ComponentValueSchema,
-  EmptyObjectSchema,
+  NoValueSchema,
 ]);
 
 export type ComponentPropertyValue = z.infer<typeof ComponentPropertyValueSchema>;
@@ -114,13 +114,12 @@ const VariableMappingsSchema = z.record(propertyKeySchema, VariableMappingSchema
 // TODO: finalize schema structure before release
 // https://contentful.atlassian.net/browse/LUMOS-523
 const PatternPropertyDefinitionSchema = z.object({
-  defaultValue: z.union([
-    z.object({
+  defaultValue: z
+    .object({
       path: z.string(),
       type: z.literal('BoundValue'),
-    }),
-    z.null(),
-  ]),
+    })
+    .optional(),
   contentTypes: z.record(z.string(), z.any()),
 });
 

--- a/packages/validators/src/schemas/v2023_09_28/experience.ts
+++ b/packages/validators/src/schemas/v2023_09_28/experience.ts
@@ -133,6 +133,7 @@ const PatternPropertyDefinitionsSchema = z.record(
 const PatternPropertySchema = z.object({
   type: z.literal('BoundValue'),
   path: z.string(),
+  contenType: z.string(),
 });
 
 const PatternPropertysSchema = z.record(propertyKeySchema, PatternPropertySchema);
@@ -321,6 +322,7 @@ export type Breakpoint = z.infer<typeof BreakpointSchema>;
 export type PrimitiveValue = z.infer<typeof PrimitiveValueSchema>;
 export type DesignValue = z.infer<typeof DesignValueSchema>;
 export type BoundValue = z.infer<typeof BoundValueSchema>;
+export type NoValue = z.infer<typeof NoValueSchema>;
 export type UnboundValue = z.infer<typeof UnboundValueSchema>;
 export type HyperlinkValue = z.infer<typeof HyperlinkValueSchema>;
 export type ComponentValue = z.infer<typeof ComponentValueSchema>;

--- a/packages/validators/src/types.ts
+++ b/packages/validators/src/types.ts
@@ -10,6 +10,7 @@ export type {
   ComponentPropertyValue,
   ComponentTreeNode,
   PrimitiveValue,
+  NoValue,
   DesignValue,
   UnboundValue,
   BoundValue,


### PR DESCRIPTION
## Purpose
In order to have prevent dependabot from overriding prerelease versions of the SDK that is compatible with prebinding, we need to merge in the latest schema changes of this feature branch so we can release production version of the SDK. 

Otherwise, we see regressions in the content_api and typings in the user_interface when dependabot updates to an incompatible version.
