### PR TITLE
[LUMOS-578] fix(text-component): add asset and experience to binding-source-type validation

### DIFF
--- a/packages/components/src/components/Heading/index.ts
+++ b/packages/components/src/components/Heading/index.ts
@@ -65,9 +65,6 @@ export const HeadingComponentDefinition: ComponentDefinition = {
       type: 'Text',
       description: 'The text to display in the heading.',
       defaultValue: 'Heading',
-      validations: {
-        bindingSourceType: ['entry', 'manual'],
-      },
     },
     type: {
       displayName: 'HTML tag',


### PR DESCRIPTION
LUMOS-578

## Purpose
Remove the `bindingSourceType` validation from the Text component.  Now Text can be bound to any binding source type: `entry`, `asset`, `experience`, `manual`.

### Previous
![image](https://github.com/user-attachments/assets/cb5e74ad-e601-4e11-83ae-b8b8a76d53e9)



### Fixed
<img width="428" alt="Screenshot 2025-02-25 at 10 01 53 AM" src="https://github.com/user-attachments/assets/c82d8d22-c460-4175-963b-eb1464ad9928" />

