### PR TITLE
[LUMOS-578] fix(text-component): add asset and experience to binding-source-type validation

### DIFF
--- a/packages/components/src/components/Text/index.ts
+++ b/packages/components/src/components/Text/index.ts
@@ -45,9 +45,6 @@ export const TextComponentDefinition: ComponentDefinition = {
       description: 'The text to display. If not provided, children will be used instead.',
       type: 'Text',
       defaultValue: 'Text',
-      validations: {
-        bindingSourceType: ['manual', 'entry'],
-      },
     },
     as: {
       displayName: 'HTML tag',


### PR DESCRIPTION
LUMOS-578

## Purpose
Remove the `bindingSourceType` validation from the Text component.  Now Text can be bound to any binding source type: `entry`, `asset`, `experience`, `manual`.

### Previous
![image](https://github.com/user-attachments/assets/cb5e74ad-e601-4e11-83ae-b8b8a76d53e9)



### Fixed
<img width="428" alt="Screenshot 2025-02-25 at 10 01 53 AM" src="https://github.com/user-attachments/assets/c82d8d22-c460-4175-963b-eb1464ad9928" />

