### PR TITLE
fix: types export from core package [SPA-2612]

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -21,7 +21,8 @@
   ],
   "exports": {
     ".": "./dist/index.js",
-    "./constants": "./dist/constants.js"
+    "./constants": "./dist/constants.js",
+    "./types": "./dist/types.d.ts"
   },
   "publishConfig": {
     "registry": "https://npm.pkg.github.com/"

--- a/packages/experience-builder-sdk/src/index.ts
+++ b/packages/experience-builder-sdk/src/index.ts
@@ -26,6 +26,10 @@ if (typeof window !== 'undefined') {
   window.__EB__.sdkVersion = SDK_VERSION;
 }
 
-export type { Experience, ComponentDefinition } from '@contentful/experiences-core/types';
+export type {
+  Experience,
+  ComponentDefinition,
+  ComponentRegistration,
+} from '@contentful/experiences-core/types';
 
 export { detachExperienceStyles } from '@contentful/experiences-core';

--- a/packages/templates/nextjs-marketing-demo/src/components/ButtonComponentRegistration.tsx
+++ b/packages/templates/nextjs-marketing-demo/src/components/ButtonComponentRegistration.tsx
@@ -1,12 +1,13 @@
 import { Button } from 'antd';
 import Icon from './Icon';
+import { ComponentRegistration } from '@contentful/experiences-sdk-react';
 
 type ButtonComponentProps = Omit<React.ComponentProps<typeof Button>, 'children' | 'icon'> & {
   text: string;
   icon?: React.ComponentProps<typeof Icon>['icon'];
 };
 
-export const ButtonComponentRegistration = {
+export const ButtonComponentRegistration: ComponentRegistration = {
   component: (props: ButtonComponentProps) => {
     const { color, icon, variant, text, ...rest } = props;
     return (

--- a/packages/templates/nextjs-marketing-demo/src/components/CardComponentRegistration.tsx
+++ b/packages/templates/nextjs-marketing-demo/src/components/CardComponentRegistration.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Card } from 'antd';
+import { ComponentRegistration } from '@contentful/experiences-sdk-react';
 
 type CardComponentProps = {
   coverSlot: React.ReactNode;
@@ -8,7 +9,7 @@ type CardComponentProps = {
   size: 'default' | 'small';
 };
 
-export const CardComponentRegistration = {
+export const CardComponentRegistration: ComponentRegistration = {
   component: ({ coverSlot, title, description, size }: CardComponentProps) => {
     return (
       <Card size={size} cover={coverSlot}>

--- a/packages/templates/nextjs-marketing-demo/src/components/RatingStarsComponentRegistration.tsx
+++ b/packages/templates/nextjs-marketing-demo/src/components/RatingStarsComponentRegistration.tsx
@@ -1,6 +1,7 @@
+import { ComponentRegistration } from '@contentful/experiences-sdk-react';
 import { Rate } from 'antd';
 
-export const RatingStarsComponentRegistration = {
+export const RatingStarsComponentRegistration: ComponentRegistration = {
   component: Rate,
   definition: {
     id: 'custom-rating',


### PR DESCRIPTION
## Purpose

Ensure that types are properly exported so that they are provide hints/autosuggestion when writing component registrations.

Additionally export `ComponentRegistration` type as it seems to be more useful than `ComponentDefinition` when defining components.

## Approach

I noticed that when hovering over an import of `'@contentful/experiences-core/constants'` or `'@contentful/experiences-core'` in the `experiences-sdk-react` built version, visual studio was able to resolve and follow the path of those files unlike the `'@contentful/experiences-core/types'`

https://github.com/user-attachments/assets/b1b152ae-1bbb-4456-9b28-702071b49e78

This seemed to be the reason it couldn't resolve types for `ComponentDefinition` and `ComponentRegistration`.

After adding `./types` in the `exports` of the core package the problem was resolved. Now we get autocomplete suggestions and proper type-checking when defining components.

https://github.com/user-attachments/assets/a64801fd-a736-4b65-87bc-321f6741fbbf

