### PR TITLE
chore(prebinding): update schema for default entry to include contentType [LUMOS-581]

### DIFF
--- a/packages/validators/src/schemas/v2023_09_28/experience.ts
+++ b/packages/validators/src/schemas/v2023_09_28/experience.ts
@@ -118,6 +118,7 @@ const PatternPropertyDefinitionSchema = z.object({
     .object({
       path: z.string(),
       type: z.literal('BoundValue'),
+      contentType: z.string(),
     })
     .optional(),
   contentTypes: z.record(z.string(), z.any()),


### PR DESCRIPTION
## Purpose
Add `contentType` to the default entry field of a pattern property definition
