### PR TITLE
feat: add an optional category field to componentSettings (#1027)

### DIFF
--- a/packages/validators/src/schemas/v2023_09_28/experience.ts
+++ b/packages/validators/src/schemas/v2023_09_28/experience.ts
@@ -237,6 +237,7 @@ const THUMBNAIL_IDS = [
 const ComponentSettingsSchema = z.object({
   variableDefinitions: ComponentVariablesSchema,
   thumbnailId: z.enum(THUMBNAIL_IDS).optional(),
+  category: z.string().max(50, 'Category must contain at most 50 characters').optional(),
   variableMappings: VariableMappingsSchema.optional(),
   patternPropertyDefinitions: PatternPropertyDefinitionsSchema.optional(),
 });
@@ -312,6 +313,8 @@ export const ExperienceFieldsCMAShapeSchema = z.object({
   usedComponents: localeWrapper(UsedComponentsSchema).optional(),
   componentSettings: localeWrapper(ComponentSettingsSchema).optional(),
 });
+
+export { THUMBNAIL_IDS as PATTERN_THUMBNAIL_IDS };
 
 export type ExperienceFields = z.infer<typeof ExperienceFieldsCMAShapeSchema>;
 export type ExperienceDataSource = z.infer<typeof DataSourceSchema>;

--- a/packages/validators/src/validators/tests/componentSettings.spec.ts
+++ b/packages/validators/src/validators/tests/componentSettings.spec.ts
@@ -1,6 +1,7 @@
 import { validateExperienceFields } from '../validateExperienceFields';
 import { experience, experiencePattern } from '../../test/__fixtures__/v2023_09_28';
 import { describe, it, expect } from 'vitest';
+import { PATTERN_THUMBNAIL_IDS } from '../../schemas/latest';
 
 const schemaVersion = '2023-09-28' as const;
 const locale = 'en-US';
@@ -96,5 +97,81 @@ describe('componentSettings', () => {
 
     expect(result.success).toBe(true);
     expect(result.errors).toBeUndefined();
+  });
+
+  it('allows to have an optional thumbnailId field', () => {
+    PATTERN_THUMBNAIL_IDS.forEach((thumbnailId) => {
+      const pattern = {
+        ...experiencePattern,
+        fields: {
+          ...experiencePattern.fields,
+          componentSettings: {
+            [locale]: {
+              variableDefinitions: {},
+              thumbnailId: thumbnailId,
+            },
+          },
+        },
+      };
+      const result = validateExperienceFields(pattern, schemaVersion);
+      expect(result.success).toBe(true);
+      expect(result.errors).toBeUndefined();
+    });
+  });
+
+  it('errors if the thumbnailId contains an unsupported value', () => {
+    const pattern = {
+      ...experiencePattern,
+      fields: {
+        ...experiencePattern.fields,
+        componentSettings: {
+          [locale]: {
+            variableDefinitions: {},
+            thumbnailId: 'poop',
+          },
+        },
+      },
+    };
+    const result = validateExperienceFields(pattern, schemaVersion);
+    expect(result.success).toBe(false);
+    expect(result.errors).toBeDefined();
+    expect(result.errors?.[0].details.startsWith('Invalid enum value.')).toBe(true);
+  });
+
+  it('allows to have an optional category field', () => {
+    const pattern = {
+      ...experiencePattern,
+      fields: {
+        ...experiencePattern.fields,
+        componentSettings: {
+          [locale]: {
+            variableDefinitions: {},
+            category: 'My fancy category',
+          },
+        },
+      },
+    };
+    const result = validateExperienceFields(pattern, schemaVersion);
+    expect(result.success).toBe(true);
+    expect(result.errors).toBeUndefined();
+  });
+
+  it('errors if the category is more than 50 characters length', () => {
+    const pattern = {
+      ...experiencePattern,
+      fields: {
+        ...experiencePattern.fields,
+        componentSettings: {
+          [locale]: {
+            variableDefinitions: {},
+            category: 'a'.repeat(51),
+          },
+        },
+      },
+    };
+    const result = validateExperienceFields(pattern, schemaVersion);
+    expect(result.success).toBe(false);
+    expect(result.errors).toBeDefined();
+    expect(result.errors?.[0].details).toBe('Category must contain at most 50 characters');
   });
 });


### PR DESCRIPTION
Add the optional category property that can be stored in `componentSettings` field of pattern entries. This should allow users to group them better in the sidebar.

## Purpose

## Approach

<!--
Remember when merging:
- Use "Squash and merge" when merging changes into development.
- Use "Create a merge commit" when releasing changes into next and main.

Three important notes on pull requests:
- In general, you should ask yourself whether this code change will improve or worsen the overall code quality. Any new tech debt will probably never be cleaned up.
- Please remember that newly introduced logic should be validated and protected through testing.
- Take a look at PR guides:
  Google's Code Review Guidelines: https://google.github.io/eng-practices/
  Blockly - Writing a Good Pull Request: https://developers.google.com/blockly/guides/contribute/get-started/write_a_good_pr
-->
