### PR TITLE
feat: add support for debug logger [SPA-2589]

### DIFF
--- a/packages/core/src/utils/debug.ts
+++ b/packages/core/src/utils/debug.ts
@@ -1,0 +1,66 @@
+const CF_DEBUG_KEY = 'cf_debug';
+
+class Debugger {
+  private static instance: Debugger | null = null;
+  private enabled: boolean;
+
+  constructor() {
+    // Default to checking localStorage for the debug mode on initialization if in browser
+    if (typeof localStorage === 'undefined') {
+      this.enabled = false;
+      return;
+    }
+
+    this.enabled = localStorage.getItem(CF_DEBUG_KEY) === 'true';
+  }
+
+  public static getInstance(): Debugger {
+    if (this.instance === null) {
+      this.instance = new Debugger();
+    }
+    return this.instance;
+  }
+
+  public getEnabled() {
+    return this.enabled;
+  }
+
+  public setEnabled(enabled: boolean) {
+    this.enabled = enabled;
+
+    if (typeof localStorage === 'undefined') {
+      return;
+    }
+    if (enabled) {
+      localStorage.setItem(CF_DEBUG_KEY, 'true');
+    } else {
+      localStorage.removeItem(CF_DEBUG_KEY);
+    }
+  }
+
+  // Log method for different levels (error, warn, log)
+  private logger(level: 'error' | 'log' | 'warn'): typeof console.log {
+    return (...args) => {
+      if (this.enabled) {
+        console[level]('[cf-experiences-sdk]', ...args);
+      }
+    };
+  }
+
+  // Public methods for logging
+  public error = this.logger('error');
+  public warn = this.logger('warn');
+  public log = this.logger('log');
+}
+
+export const debug = Debugger.getInstance();
+
+export const enableDebug = () => {
+  debug.setEnabled(true);
+  console.log('Debug mode enabled');
+};
+
+export const disableDebug = () => {
+  debug.setEnabled(false);
+  console.log('Debug mode disabled');
+};

--- a/packages/core/src/utils/debugLogger.spec.ts
+++ b/packages/core/src/utils/debugLogger.spec.ts
@@ -1,0 +1,46 @@
+import { debug, DebugLogger } from './debugLogger';
+import { describe, it, expect, vi } from 'vitest';
+
+describe('debugLogger', () => {
+  it('should not log anything if debug is not enabled', () => {
+    const consoleLogSpy = vi.spyOn(console, 'log');
+    debug.log('test');
+    expect(consoleLogSpy).not.toHaveBeenCalled();
+  });
+
+  it('should log if debug is enabled', () => {
+    const consoleLogSpy = vi.spyOn(console, 'log');
+    debug.setEnabled(true);
+    debug.log('test');
+    expect(consoleLogSpy).toHaveBeenCalledWith('[cf-experiences-sdk]', 'test');
+  });
+
+  it('should set cf_debug in localStorage when getting enabled', () => {
+    const localStorageSpy = vi.spyOn(localStorage, 'setItem');
+    debug.setEnabled(true);
+    expect(localStorageSpy).toHaveBeenCalledWith('cf_debug', 'true');
+  });
+
+  it('should remove cf_debug in localStorage when getting disabled', () => {
+    const localStorageSpy = vi.spyOn(localStorage, 'removeItem');
+    debug.setEnabled(false);
+    expect(localStorageSpy).toHaveBeenCalledWith('cf_debug');
+  });
+
+  it('should get initialised to the localStorage value if localStorage present', () => {
+    vi.spyOn(localStorage, 'getItem').mockReturnValue('true');
+    const debug2 = new DebugLogger();
+    expect(debug2.getEnabled()).toBe(true);
+  });
+
+  describe('when localStorage is not available', () => {
+    beforeEach(() => {
+      Object.assign(window, { localStorage: undefined });
+    });
+
+    it('should still enable to logger', () => {
+      debug.setEnabled(true);
+      expect(debug.getEnabled()).toBe(true);
+    });
+  });
+});

--- a/packages/core/src/utils/debugLogger.ts
+++ b/packages/core/src/utils/debugLogger.ts
@@ -39,7 +39,7 @@ export class DebugLogger {
   }
 
   // Log method for different levels (error, warn, log)
-  private logger(level: 'error' | 'log' | 'warn'): typeof console.log {
+  private logger(level: 'error' | 'log' | 'warn' | 'debug'): typeof console.log {
     return (...args) => {
       if (this.enabled) {
         console[level]('[cf-experiences-sdk]', ...args);
@@ -51,6 +51,7 @@ export class DebugLogger {
   public error = this.logger('error');
   public warn = this.logger('warn');
   public log = this.logger('log');
+  public debug = this.logger('debug');
 }
 
 export const debug = DebugLogger.getInstance();

--- a/packages/core/src/utils/debugLogger.ts
+++ b/packages/core/src/utils/debugLogger.ts
@@ -1,22 +1,22 @@
 const CF_DEBUG_KEY = 'cf_debug';
 
-class Debugger {
-  private static instance: Debugger | null = null;
+export class DebugLogger {
+  private static instance: DebugLogger | null = null;
   private enabled: boolean;
 
   constructor() {
-    // Default to checking localStorage for the debug mode on initialization if in browser
     if (typeof localStorage === 'undefined') {
       this.enabled = false;
       return;
     }
 
+    // Default to checking localStorage for the debug mode on initialization if in browser
     this.enabled = localStorage.getItem(CF_DEBUG_KEY) === 'true';
   }
 
-  public static getInstance(): Debugger {
+  public static getInstance(): DebugLogger {
     if (this.instance === null) {
-      this.instance = new Debugger();
+      this.instance = new DebugLogger();
     }
     return this.instance;
   }
@@ -53,7 +53,7 @@ class Debugger {
   public log = this.logger('log');
 }
 
-export const debug = Debugger.getInstance();
+export const debug = DebugLogger.getInstance();
 
 export const enableDebug = () => {
   debug.setEnabled(true);

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -11,4 +11,4 @@ export * from './isLink';
 export * from './pathSchema';
 export * from './resolveHyperlinkPattern';
 export * from './sanitizeNodeProps';
-export * from './debug';
+export * from './debugLogger';

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -11,3 +11,4 @@ export * from './isLink';
 export * from './pathSchema';
 export * from './resolveHyperlinkPattern';
 export * from './sanitizeNodeProps';
+export * from './debug';

--- a/packages/experience-builder-sdk/src/ExperienceRoot.tsx
+++ b/packages/experience-builder-sdk/src/ExperienceRoot.tsx
@@ -17,6 +17,11 @@ type ExperienceRootProps = {
   experience?: Experience<EntityStore> | string | null;
   locale: string;
   visualEditorMode?: VisualEditorMode;
+  /** Enables extra logging in the SDK to support troubleshooting.
+   *  This option is not recommended for production enviroments as it
+   *  will result in too many unnecessary logs being produced during runtime.
+   *  Default: false
+   */
   debug?: boolean;
 };
 

--- a/packages/experience-builder-sdk/src/ExperienceRoot.tsx
+++ b/packages/experience-builder-sdk/src/ExperienceRoot.tsx
@@ -4,6 +4,7 @@ import {
   VisualEditorMode,
   createExperience,
   validateExperienceBuilderConfig,
+  debug as cfDebug,
 } from '@contentful/experiences-core';
 import { EntityStore } from '@contentful/experiences-core';
 import type { Experience } from '@contentful/experiences-core/types';
@@ -16,14 +17,20 @@ type ExperienceRootProps = {
   experience?: Experience<EntityStore> | string | null;
   locale: string;
   visualEditorMode?: VisualEditorMode;
+  debug?: boolean;
 };
 
 export const ExperienceRoot = ({
   locale,
   experience,
   visualEditorMode = VisualEditorMode.LazyLoad,
+  debug,
 }: ExperienceRootProps) => {
   const mode = useDetectCanvasMode();
+
+  if (typeof debug === 'boolean') {
+    cfDebug.setEnabled(debug);
+  }
 
   //If experience is passed in as a JSON string, recreate it to an experience object
   const experienceObject =

--- a/packages/experience-builder-sdk/src/index.ts
+++ b/packages/experience-builder-sdk/src/index.ts
@@ -1,3 +1,4 @@
+import { enableDebug, disableDebug } from '@contentful/experiences-core';
 import { SDK_VERSION } from './sdkVersion';
 export { SDK_VERSION as version };
 
@@ -24,6 +25,8 @@ if (typeof window !== 'undefined') {
     window.__EB__ = {};
   }
   window.__EB__.sdkVersion = SDK_VERSION;
+  window.__EB__.enableDebug = enableDebug;
+  window.__EB__.disableDebug = disableDebug;
 }
 
 export type {

--- a/packages/experience-builder-sdk/src/utils/parseComponentProps.ts
+++ b/packages/experience-builder-sdk/src/utils/parseComponentProps.ts
@@ -1,4 +1,4 @@
-import { isCfStyleAttribute } from '@contentful/experiences-core';
+import { isCfStyleAttribute, debug } from '@contentful/experiences-core';
 import {
   BoundComponentPropertyTypes,
   BoundValue,
@@ -61,6 +61,8 @@ export const parseComponentProps = ({
   const styleProps: Record<string, DesignValue['valuesByBreakpoint']> = {};
   const customDesignProps: Record<string, PrimitiveValue> = {};
   const contentProps: Record<string, any> = {};
+
+  debug.log('Parsing component props for node with id: ', node.id);
 
   for (const [propName, propDefinition] of Object.entries(componentDefinition.variables)) {
     const propertyValue = node.variables[propName];

--- a/packages/experience-builder-sdk/src/window.d.ts
+++ b/packages/experience-builder-sdk/src/window.d.ts
@@ -6,4 +6,6 @@ type EB_Store = {
   isReadOnlyMode?: boolean;
   isEditorMode?: boolean;
   sdkVersion?: string;
+  enableDebug?: () => void;
+  disableDebug?: () => void;
 };

--- a/packages/test-apps/nextjs/src/app/[[...slug]]/page.tsx
+++ b/packages/test-apps/nextjs/src/app/[[...slug]]/page.tsx
@@ -27,7 +27,7 @@ export default async function ExperiencePage({ params, searchParams }: Page) {
   return (
     <main style={{ width: '100%' }}>
       {stylesheet && <style data-css-ssr>{stylesheet}</style>}
-      <Experience experienceJSON={experienceJSON} locale={locale} />
+      <Experience experienceJSON={experienceJSON} locale={locale} debug={true} />
     </main>
   );
 }

--- a/packages/test-apps/nextjs/src/components/Experience.tsx
+++ b/packages/test-apps/nextjs/src/components/Experience.tsx
@@ -7,10 +7,11 @@ import React from 'react';
 interface ExperienceProps {
   experienceJSON: string | null;
   locale: string;
+  debug?: boolean;
 }
 
-const Experience: React.FC<ExperienceProps> = ({ experienceJSON, locale }) => {
-  return <ExperienceRoot experience={experienceJSON} locale={locale} />;
+const Experience: React.FC<ExperienceProps> = ({ experienceJSON, locale, debug }) => {
+  return <ExperienceRoot experience={experienceJSON} locale={locale} debug={debug} />;
 };
 
 export default Experience;


### PR DESCRIPTION
## Purpose

Adds support for debug logger in experiences SDK.

## Approach

Adds support for debug logger in experiences SDK. Debug logger is disabled by default. There are two ways to enable the logger:
1. By passing a `debug` prop to the `ExperienceRoot`.
This is useful for server side rendering use-cases and cannot be changed during runtime.
2. By calling `window.__EB__.enableDebug()` method during runtime.
When calling this method, we also set `cf_debug` key in localStorage. This is to preserve the state of the logger through a page refresh.
Logger can be disabled by calling `window.__EB__.disableDebug()` 
Note that the `debug` prop will take precedence so if it's passed the `window.__EB__` methods won't be able to override it.

Here is an example when using Client Side Rendering (using method 2.):

https://github.com/user-attachments/assets/2c577560-f051-4343-a1c7-58d856dc149c

And an example of Server Side Rendering (using method 1.):

Passing in `debug: true` to the ExperienceRoot:

<img width="695" alt="Screenshot 2025-03-03 at 14 47 11" src="https://github.com/user-attachments/assets/4bd4c6b1-74c3-4a7a-9ba3-a4adccdbdaad" />

Rebuilding the app and loading an experience page:
<img width="752" alt="Screenshot 2025-03-03 at 13 03 43" src="https://github.com/user-attachments/assets/a0ef7a34-1981-4c49-9503-31bf15bc6908" />

**Note:** You might need to cleanup nextjs cache by deleting the `.next` folder in order for the changes to take effect (at least I had to do it a few times).