### PR TITLE
fix: remove the key update via the use effect []

### DIFF
--- a/packages/experience-builder-sdk/src/blocks/preview/CompositionBlock.tsx
+++ b/packages/experience-builder-sdk/src/blocks/preview/CompositionBlock.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, useEffect, useMemo, useState } from 'react';
+import React, { ReactNode, useMemo } from 'react';
 import type { UnresolvedLink } from 'contentful';
 import {
   EntityStore,
@@ -56,12 +56,7 @@ export const CompositionBlock = ({
   wrappingPatternIds: parentWrappingPatternIds = new Set(),
   patternNodeIdsChain = '',
 }: CompositionBlockProps) => {
-  const [hasRendered, setHasRendered] = useState(false);
   patternNodeIdsChain = `${patternNodeIdsChain}${rawNode.id}`;
-
-  useEffect(() => {
-    setHasRendered(true);
-  }, []);
 
   const isAssembly = useMemo(
     () =>
@@ -100,7 +95,7 @@ export const CompositionBlock = ({
     return registration;
   }, [isAssembly, node.definitionId]);
 
-  const { ssrProps, customDesignProps, contentProps, props, mediaQuery } = useMemo(() => {
+  const { ssrProps, contentProps, props, mediaQuery } = useMemo(() => {
     // In SSR, we store the className under breakpoints[0] which is resolved here to the actual string
     const cfSsrClassNameValues = node.variables.cfSsrClassName as DesignValue | undefined;
     const mainBreakpoint = entityStore.breakpoints[0];
@@ -327,7 +322,6 @@ export const CompositionBlock = ({
   return React.createElement(
     component,
     {
-      key: Object.keys(customDesignProps).length ? `${node.id}-${hasRendered}` : node.id,
       ...sanitizeNodeProps(props),
     },
     children ?? (typeof props.children === 'string' ? props.children : null),

--- a/packages/test-apps/nextjs/src/components/CustomButton.tsx
+++ b/packages/test-apps/nextjs/src/components/CustomButton.tsx
@@ -1,0 +1,61 @@
+import { ComponentDefinition } from '@contentful/experiences-sdk-react';
+import React, { useMemo } from 'react';
+
+type CustomButtonProps = {
+  backgroundColor: string;
+  textColor: string;
+  fontSize: number;
+  value: string;
+};
+
+export const CustomButton = ({
+  backgroundColor,
+  textColor,
+  fontSize,
+  value,
+  ...props
+}: CustomButtonProps) => {
+  const style = useMemo(() => {
+    return {
+      backgroundColor,
+      color: textColor,
+      fontSize: `${fontSize}px`,
+    };
+  }, [backgroundColor, textColor, fontSize]);
+
+  return (
+    <button style={style} {...props}>
+      {value}
+    </button>
+  );
+};
+
+export const CustomButtonComponentDefinition: ComponentDefinition = {
+  id: 'custom-buttom-component',
+  name: 'Custom Button',
+  variables: {
+    backgroundColor: {
+      type: 'Text',
+      defaultValue: 'white',
+      group: 'style',
+      displayName: 'Background',
+    },
+    textColor: {
+      type: 'Text',
+      defaultValue: 'black',
+      group: 'style',
+      displayName: 'Text color',
+    },
+    fontSize: {
+      type: 'Number',
+      defaultValue: 16,
+      group: 'style',
+      displayName: 'Font size',
+    },
+    value: {
+      type: 'Text',
+      defaultValue: 'Button',
+      displayName: 'Button text',
+    },
+  },
+};

--- a/packages/test-apps/nextjs/src/studio-config.ts
+++ b/packages/test-apps/nextjs/src/studio-config.ts
@@ -8,9 +8,14 @@ import { LinkComponent } from './components/LinkComponent';
 import { CustomImageComponent } from './components/CustomImageComponent';
 import NestedSlots from './components/NestedSlots';
 import KitchenSink from './components/KitchenSink';
+import { CustomButton, CustomButtonComponentDefinition } from './components/CustomButton';
 
 defineComponents(
   [
+    {
+      component: CustomButton,
+      definition: CustomButtonComponentDefinition,
+    },
     {
       component: ComponentWithChildren,
       definition: {


### PR DESCRIPTION
## Purpose

Removing the key overwrite after a use effect as we have fixed the breakpoint update.


This is where the useEffect was introduced: https://github.com/contentful/experience-builder/pull/979
