### PR TITLE
chore(prebinding): modify schema to support entity link directly on defaultValue [LUMOS-594]

### DIFF
--- a/packages/validators/src/schemas/v2023_09_28/experience.ts
+++ b/packages/validators/src/schemas/v2023_09_28/experience.ts
@@ -115,11 +115,16 @@ const VariableMappingsSchema = z.record(propertyKeySchema, VariableMappingSchema
 // https://contentful.atlassian.net/browse/LUMOS-523
 const PatternPropertyDefinitionSchema = z.object({
   defaultValue: z
-    .object({
-      path: z.string(),
-      type: z.literal('BoundValue'),
-      contentType: z.string(),
-    })
+    .record(
+      z.string(),
+      z.object({
+        sys: z.object({
+          type: z.literal('Link'),
+          id: z.string(),
+          linkType: z.enum(['Entry']),
+        }),
+      }),
+    )
     .optional(),
   contentTypes: z.record(z.string(), z.any()),
 });


### PR DESCRIPTION
## Purpose
Modifies the defaultValue of patternPropertyDefinitions to remove the need for using `dataSource` on a pattern entry and directly link the entry in the defaultValue.

Ticket: https://contentful.atlassian.net/browse/LUMOS-594