### PR TITLE
chore: address path-to-regexp vulnerabilities

### DIFF
--- a/examples/gatsby/gatsby-spa/package-lock.json
+++ b/examples/gatsby/gatsby-spa/package-lock.json
@@ -9779,12 +9779,6 @@
         "url": "https://opencollective.com/eslint"
       }
     },
-    "node_modules/gatsby/node_modules/path-to-regexp": {
-      "version": "0.1.10",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.10.tgz",
-      "integrity": "sha512-7lf7qcQidTku0Gu3YDPc8DJ1q7OOucfa/BSsIwjuh56VU7katFvuM8hULfkwB3Fns/rsVF7PwPKVw1sl5KQS9w==",
-      "license": "MIT"
-    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -24263,7 +24257,7 @@
         "opentracing": "^0.14.7",
         "p-defer": "^3.0.0",
         "parseurl": "^1.3.3",
-        "path-to-regexp": "0.1.10",
+        "path-to-regexp": "0.1.12",
         "physical-cpu-count": "^2.0.0",
         "platform": "^1.3.6",
         "postcss": "^8.4.24",
@@ -24438,11 +24432,6 @@
           "version": "3.4.3",
           "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
           "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="
-        },
-        "path-to-regexp": {
-          "version": "0.1.10",
-          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.10.tgz",
-          "integrity": "sha512-7lf7qcQidTku0Gu3YDPc8DJ1q7OOucfa/BSsIwjuh56VU7katFvuM8hULfkwB3Fns/rsVF7PwPKVw1sl5KQS9w=="
         }
       }
     },

--- a/examples/gatsby/gatsby-spa/package.json
+++ b/examples/gatsby/gatsby-spa/package.json
@@ -28,5 +28,10 @@
     "@types/react": "^18.2.55",
     "@types/react-dom": "^18.2.19",
     "typescript": "^5.3.3"
+  },
+  "overrides": {
+    "gatsby": {
+      "path-to-regexp": "0.1.12"
+    }
   }
 }

--- a/examples/gatsby/gatsby-ssg/package-lock.json
+++ b/examples/gatsby/gatsby-ssg/package-lock.json
@@ -10578,12 +10578,6 @@
         "url": "https://opencollective.com/eslint"
       }
     },
-    "node_modules/gatsby/node_modules/path-to-regexp": {
-      "version": "0.1.10",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.10.tgz",
-      "integrity": "sha512-7lf7qcQidTku0Gu3YDPc8DJ1q7OOucfa/BSsIwjuh56VU7katFvuM8hULfkwB3Fns/rsVF7PwPKVw1sl5KQS9w==",
-      "license": "MIT"
-    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -24615,7 +24609,7 @@
         "opentracing": "^0.14.7",
         "p-defer": "^3.0.0",
         "parseurl": "^1.3.3",
-        "path-to-regexp": "0.1.10",
+        "path-to-regexp": "0.1.12",
         "physical-cpu-count": "^2.0.0",
         "platform": "^1.3.6",
         "postcss": "^8.4.24",
@@ -24790,11 +24784,6 @@
           "version": "3.4.3",
           "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
           "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="
-        },
-        "path-to-regexp": {
-          "version": "0.1.10",
-          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.10.tgz",
-          "integrity": "sha512-7lf7qcQidTku0Gu3YDPc8DJ1q7OOucfa/BSsIwjuh56VU7katFvuM8hULfkwB3Fns/rsVF7PwPKVw1sl5KQS9w=="
         }
       }
     },

--- a/examples/gatsby/gatsby-ssg/package.json
+++ b/examples/gatsby/gatsby-ssg/package.json
@@ -28,5 +28,10 @@
     "@types/react": "^18.2.55",
     "@types/react-dom": "^18.2.19",
     "typescript": "^5.3.3"
+  },
+  "overrides": {
+    "gatsby": {
+      "path-to-regexp": "0.1.12"
+    }
   }
 }


### PR DESCRIPTION
## Purpose

Addressing one more vulnerability - path-to-regexp. I had to set an override for it as gatsby pins the version to 0.1.10.


