### PR TITLE
chore: use --git-tag-command to override lerna version tag for prereleases

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -85,11 +85,11 @@ jobs:
           git config user.email "${{ github.actor}}@users.noreply.github.com"
 
           if [ ${{ inputs.publish-prerelease }} ]; then
-            npx lerna publish --conventional-commits --conventional-prerelease --exact --force-publish --preid prerelease-$(date +%Y%m%dT%H%M)-$(git rev-parse HEAD | cut -c1-7) --no-changelog --no-push --yes --no-private --dist-tag prerelease --allow-branch ${{ github.ref_name }}
+            npx lerna publish --conventional-commits --conventional-prerelease --exact --force-publish --preid prerelease-$(date +%Y%m%dT%H%M)-$(git rev-parse HEAD | cut -c1-7) --no-changelog --no-push --yes --no-private --dist-tag prerelease --allow-branch ${{ github.ref_name }} --git-tag-command="echo 'skipping git tag for prereleases'"
           elif [ ${{ github.ref_name }} = development ]; then
-            npx lerna publish --conventional-commits --conventional-prerelease --exact --force-publish --preid dev-$(date +%Y%m%dT%H%M)-$(git rev-parse HEAD | cut -c1-7) --dist-tag dev --no-changelog --no-push --yes --no-private 
+            npx lerna publish --conventional-commits --conventional-prerelease --exact --force-publish --preid dev-$(date +%Y%m%dT%H%M)-$(git rev-parse HEAD | cut -c1-7) --dist-tag dev --no-changelog --no-push --yes --no-private --git-tag-command="echo 'skipping git tag for prereleases'"
           elif [ ${{ github.ref_name }} = next ]; then
-            npx lerna publish --conventional-commits --conventional-prerelease --exact --force-publish --preid beta --dist-tag next --no-changelog --yes --no-private
+            npx lerna publish --conventional-commits --conventional-prerelease --exact --force-publish --preid beta --dist-tag next --no-changelog --yes --no-private --git-tag-command="echo 'skipping git tag for prereleases'"
           else
             npx lerna publish --conventional-commits --conventional-graduate --exact --force-publish --yes --no-private --dist-tag latest --create-release github
           fi


### PR DESCRIPTION
## Purpose

This is an attempt to force lerna to generate changelog from the last stable version. 

## Approach

Right now the problem is that, on the last step of releasing the package when merging to `main` we instruct lerna to generate a changelog using the `--conventional-commits` argument. This generates the changelog but updates it with placeholder text like:

<img width="589" alt="Screenshot 2025-03-26 at 12 07 46" src="https://github.com/user-attachments/assets/61a4e78d-af52-4f96-8b50-b3999b661ce5" />

This is because lerna will use commits between the latest version and the last beta version, e.g. `v1.34.1-beta.0..v1.34.1`. But this diff doesn't include any meaningful commits, e.g.

<img width="774" alt="Screenshot 2025-03-26 at 11 59 13" src="https://github.com/user-attachments/assets/9cba5678-f367-4ac6-bb90-21917df0e0f0" />

In reality what we need is the diff `v1.34.0..v1.34.1`

It seems that lerna is using the git tags for this comparison, so if we don't generate tags for the prerelease versions then the changelog will compare with the last stable version. This is a solution suggested in the relevant [thread](https://github.com/lerna/lerna/issues/2248). It's a bit obscure but there doesn't seem to be any better solution.

<!--
Remember when merging:
- Use "Squash and merge" when merging changes into development.
- Use "Create a merge commit" when releasing changes into next and main.

Three important notes on pull requests:
- In general, you should ask yourself whether this code change will improve or worsen the overall code quality. Any new tech debt will probably never be cleaned up.
- Please remember that newly introduced logic should be validated and protected through testing.
- Take a look at PR guides:
  Google's Code Review Guidelines: https://google.github.io/eng-practices/
  Blockly - Writing a Good Pull Request: https://developers.google.com/blockly/guides/contribute/get-started/write_a_good_pr
-->
