### PR TITLE
chore: remove reduntant private NPM registry authentication

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -2,9 +2,6 @@ name: Build and Test
 
 on:
   workflow_call:
-    secrets:
-      NPM_TOKEN:
-        required: true
 
 jobs:
   install-build:
@@ -26,8 +23,6 @@ jobs:
           path: ~/.cache/Cypress
           key: cypress-${{ runner.os }}-${{ hashFiles('./package-lock.json') }}
           restore-keys: cypress-${{ runner.os }}-
-      - name: Authenticate with private NPM package
-        run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > ~/.npmrc
       - name: Install dependencies
         run: npm ci
       - name: Save Cypress Binary

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -2,9 +2,6 @@ name: 'Run Checks: Lint & Tests'
 
 on:
   workflow_call:
-    secrets:
-      NPM_TOKEN:
-        required: true
 
 jobs:
   # this job relies on the install-build workflow to run first
@@ -25,8 +22,6 @@ jobs:
           path: ~/.cache/Cypress
           key: cypress-${{ runner.os }}-${{ hashFiles('./package-lock.json') }}
           restore-keys: cypress-${{ runner.os }}-
-      - name: Authenticate with private NPM package
-        run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > ~/.npmrc
       - name: Install dependencies
         run: npm ci
       - name: Restore the build folders

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,13 +20,9 @@ on:
 jobs:
   install-build:
     uses: ./.github/workflows/build.yaml
-    secrets:
-      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
   check:
     needs: install-build
     uses: ./.github/workflows/check.yaml
-    secrets:
-      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
   vercel:
     needs: [install-build, check]
     uses: ./.github/workflows/vercel.yaml

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -11,8 +11,6 @@ on:
     secrets:
       VAULT_URL:
         required: true
-      NPM_TOKEN:
-        required: true
 
 jobs:
   publish:
@@ -59,8 +57,8 @@ jobs:
             packages/templates/nextjs-marketing-demo/.next
             packages/templates/react-vite-ts/dist
           key: build-cache-${{ github.run_id }}-${{ github.run_attempt }}
-      - name: Authenticate with private NPM and GH package
-        run: echo -e "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}\n//npm.pkg.github.com/:_authToken=${{ steps.vault.outputs.GITHUB_PACKAGES_WRITE_TOKEN }}\n@contentful:registry=https://npm.pkg.github.com" > ./.npmrc
+      - name: Authenticate with private GH package
+        run: echo -e "//npm.pkg.github.com/:_authToken=${{ steps.vault.outputs.GITHUB_PACKAGES_WRITE_TOKEN }}\n@contentful:registry=https://npm.pkg.github.com" > ./.npmrc
         env:
           GITHUB_TOKEN: ${{ steps.vault.outputs.GITHUB_PACKAGES_WRITE_TOKEN }}
       # We only want to publish if there are changes to any package. Since the lerna --force-publish flag publishes even if there are no changes


### PR DESCRIPTION
## Purpose

We no longer use a private npm.js registry (we're using the GH one). Also build and check steps don't require access to private registries.

