### PR TITLE
fix: hiding nodes bug [SPA-2656]

### DIFF
--- a/packages/visual-editor/src/hooks/useComponentProps.spec.ts
+++ b/packages/visual-editor/src/hooks/useComponentProps.spec.ts
@@ -295,7 +295,7 @@ describe('useComponentProps', () => {
       type: 'block',
     };
 
-    it.only('should NOT set the component size in wrapperStyles when drag wrapper is enabled', () => {
+    it('should NOT set the component size in wrapperStyles when drag wrapper is enabled', () => {
       const newNode: ExperienceTreeNode = structuredClone(node);
       newNode.data.props['cfVisibility'] = {
         type: 'DesignValue',

--- a/packages/visual-editor/src/hooks/useComponentProps.spec.ts
+++ b/packages/visual-editor/src/hooks/useComponentProps.spec.ts
@@ -295,7 +295,7 @@ describe('useComponentProps', () => {
       type: 'block',
     };
 
-    it('should NOT set the component size in wrapperStyles when drag wrapper is enabled', () => {
+    it.only('should NOT set the component size in wrapperStyles when drag wrapper is enabled', () => {
       const newNode: ExperienceTreeNode = structuredClone(node);
       newNode.data.props['cfVisibility'] = {
         type: 'DesignValue',
@@ -317,7 +317,13 @@ describe('useComponentProps', () => {
       );
 
       expect(result.current.wrapperStyles).toEqual({}); // it will have { width: undefined }, but it still resolves to {} during ... destructuring
-      expect(result.current.componentStyles).toEqual({});
+
+      expect(result.current.componentStyles.display).toEqual('none !important');
+      // Seems leaving in the props below does no harm (as `none !important` makes node disappear)
+      expect(result.current.componentStyles.width).toEqual('100%');
+      expect(result.current.componentStyles.height).toEqual('100%');
+      expect(result.current.componentStyles.maxWidth).toEqual('none');
+      expect(result.current.componentStyles.margin).toEqual('0');
     });
 
     // it('should set the component size in wrapperStyles when drag wrapper is enabled', () => {

--- a/packages/visual-editor/src/hooks/useComponentProps.ts
+++ b/packages/visual-editor/src/hooks/useComponentProps.ts
@@ -225,6 +225,7 @@ export const useComponentProps = ({
   ]);
 
   const cfStyles = useMemo(() => buildCfStyles(props as StyleProps), [props]);
+  const cfVisibility: boolean = Boolean((props as StyleProps).cfVisibility);
 
   const isAssemblyBlock = node.type === ASSEMBLY_BLOCK_NODE_TYPE;
   const isSingleColumn = node?.data.blockId === CONTENTFUL_COMPONENTS.columns.id;
@@ -237,10 +238,15 @@ export const useComponentProps = ({
     const wrapperStyles: CSSProperties = { width: options?.wrapContainerWidth };
 
     if (requiresDragWrapper) {
-      if (cfStyles.width) wrapperStyles.width = cfStyles.width;
-      if (cfStyles.height) wrapperStyles.height = cfStyles.height;
-      if (cfStyles.maxWidth) wrapperStyles.maxWidth = cfStyles.maxWidth;
-      if (cfStyles.margin) wrapperStyles.margin = cfStyles.margin;
+      // when element is marked by user as not-visible, on that element the node `display: none !important`
+      // will be set and it will disappear. However, when such a node has a wrapper div, the wrapper
+      // should not have any css properties (at least not ones which force size), as such div should
+      // simply be a zero height wrapper around element with `display: none !important`.
+      // Hence we guard all wrapperStyles with `cfVisibility` check.
+      if (cfVisibility && cfStyles.width) wrapperStyles.width = cfStyles.width;
+      if (cfVisibility && cfStyles.height) wrapperStyles.height = cfStyles.height;
+      if (cfVisibility && cfStyles.maxWidth) wrapperStyles.maxWidth = cfStyles.maxWidth;
+      if (cfVisibility && cfStyles.margin) wrapperStyles.margin = cfStyles.margin;
     }
 
     // Override component styles to fill the wrapper
@@ -268,6 +274,7 @@ export const useComponentProps = ({
     node.data.id,
     draggingId,
     nodeRect,
+    cfVisibility,
   ]);
 
   // Styles that will be applied to the component element

--- a/packages/visual-editor/src/hooks/useComponentProps.ts
+++ b/packages/visual-editor/src/hooks/useComponentProps.ts
@@ -93,6 +93,9 @@ export const useComponentProps = ({
       return propsBase;
     }
 
+    // Note, that here we iterate over DEFINITION variables, not the actual node variables
+    // this means that node may have "orphan" props, or some "newborn" props will be initialized
+    // with the default values.
     const extractedProps = Object.entries(definition.variables).reduce(
       (acc, [variableName, variableDefinition]) => {
         const variableMapping = node.data.props[variableName];
@@ -225,7 +228,7 @@ export const useComponentProps = ({
   ]);
 
   const cfStyles = useMemo(() => buildCfStyles(props as StyleProps), [props]);
-  const cfVisibility: boolean = Boolean((props as StyleProps).cfVisibility);
+  const cfVisibility: boolean = props['cfVisibility'] as boolean;
 
   const isAssemblyBlock = node.type === ASSEMBLY_BLOCK_NODE_TYPE;
   const isSingleColumn = node?.data.blockId === CONTENTFUL_COMPONENTS.columns.id;


### PR DESCRIPTION
## Purpose

adds check for `cfVisibility` when generating wrapper styles. 
This bug (and this logic from `useComponentProps`) only applies to packages/visual-editor, when breakpoints always have current one (eg. defined via `useBreakpoints`  and `resolveDesignValue()` )

Within tests, it is important that component definition contains `cfVisibility` property. Otherwise iteration won't work. 

