### PR TITLE
chore: remove leftover NPM_TOKEN that breaks main.yml

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,7 +50,6 @@ jobs:
       publish-prelease: ${{ !!inputs.publish-prerelease }}
     secrets:
       VAULT_URL: ${{ secrets.VAULT_URL }}
-      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
   upload-artifact-cleanup:
     if: ${{ always() }}
     needs: [install-build, check, publish, vercel]


### PR DESCRIPTION
## Purpose

After #1068 main.yml is throwing an error because of the leftover NPM_TOKEN. This PR fixes that.