### PR TITLE
fix: ensure debug log for every SDK message [SPA-2692]

### DIFF
--- a/packages/experience-builder-sdk/src/hooks/useClassName.ts
+++ b/packages/experience-builder-sdk/src/hooks/useClassName.ts
@@ -63,6 +63,8 @@ export const useInjectStylesheet = (stylesheet?: { css: string; className: strin
     styleTag.setAttribute('type', 'text/css');
     styleTag.innerHTML = stylesheet.css;
 
+    // This might cause an error with `document.head` being undefined, e.g. when the client-side
+    // hydration in SSR applications failed and thus the document is not initialized.
     document.head.appendChild(styleTag);
   }, [stylesheet]);
 };

--- a/packages/visual-editor/src/hooks/useEditorSubscriber.ts
+++ b/packages/visual-editor/src/hooks/useEditorSubscriber.ts
@@ -177,14 +177,15 @@ export function useEditorSubscriber() {
       }
 
       const eventData = tryParseMessage(event);
-      if (eventData.eventType === PostMessageMethods.REQUESTED_ENTITIES) {
-        // Expected message: This message is handled in the EntityStore to store fetched entities
-        return;
-      }
       console.debug(
         `[experiences-sdk-react::onMessage] Received message [${eventData.eventType}]`,
         eventData,
       );
+
+      if (eventData.eventType === PostMessageMethods.REQUESTED_ENTITIES) {
+        // Expected message: This message is handled in the EntityStore to store fetched entities
+        return;
+      }
 
       switch (eventData.eventType) {
         case INCOMING_EVENTS.ExperienceUpdated: {


### PR DESCRIPTION
## Purpose

So far, we could see every SDK message in our debug logs except for the response `REQUESTED_ENTITIES`. As this is a crucial part of the initialization phase that is likely to cause issues, make sure that we have eyes on this as well.
