### PR TITLE
fix: pattern wrapper height to 100% only when the main component has 100% height [SPA-2580]

### DIFF
--- a/packages/visual-editor/src/components/DraggableBlock/Dropzone.tsx
+++ b/packages/visual-editor/src/components/DraggableBlock/Dropzone.tsx
@@ -1,7 +1,11 @@
 import React, { ElementType, useCallback, useMemo } from 'react';
 import { Droppable } from '@hello-pangea/dnd';
 import { isComponentAllowedOnRoot } from '@contentful/experiences-core';
-import type { ResolveDesignValueType, DragWrapperProps } from '@contentful/experiences-core/types';
+import type {
+  ResolveDesignValueType,
+  DragWrapperProps,
+  DesignValue,
+} from '@contentful/experiences-core/types';
 import { EditorBlock } from './EditorBlock';
 import { ComponentData } from '@/types/Config';
 import { useTreeStore } from '@/store/tree';
@@ -157,6 +161,14 @@ export function Dropzone({
     return null;
   }
 
+  const isPatternWrapperComponentFullHeight = isRootAssembly
+    ? node.children.length === 1 &&
+      resolveDesignValue(
+        (node?.children[0]?.data.props.cfHeight as DesignValue)?.valuesByBreakpoint ?? {},
+        'cfHeight',
+      ) === '100%'
+    : false;
+
   return (
     <Droppable
       droppableId={zoneId}
@@ -195,6 +207,7 @@ export function Dropzone({
               [styles.isEmptyZone]: !content.length,
               [styles.isAssembly]: isRootAssembly,
               [styles.isSlot]: Boolean(slotId),
+              [styles.fullHeight]: isPatternWrapperComponentFullHeight,
             })}>
             {isEmptyCanvas ? (
               <EmptyContainer isDragging={isRootZone && userIsDragging} />

--- a/packages/visual-editor/src/components/DraggableBlock/styles.module.css
+++ b/packages/visual-editor/src/components/DraggableBlock/styles.module.css
@@ -32,6 +32,9 @@
 
 .Dropzone.isAssembly {
   width: 100%;
+}
+
+.Dropzone.fullHeight {
   height: 100%;
 }
 


### PR DESCRIPTION
## Purpose

I recorded the video with the explanation, but as it's a public repository, I won't attach it here.

Find it [here](https://contentful.slack.com/archives/C01R9P3CBH7/p1743760799219389?thread_ts=1740556729.913469&cid=C01R9P3CBH7) instead

## Approach

Basically if the pattern's wrapper component doesn't have the `100%` height, then the dropzone component in the editor mode also shouldn't have it.