### PR TITLE
feat(test-apps/react-vite): add new component with Link field for testing [SPA-2692]

### DIFF
--- a/packages/test-apps/react-vite/src/components/ComponentUsingReferences/ComponentUsingReferences.module.css
+++ b/packages/test-apps/react-vite/src/components/ComponentUsingReferences/ComponentUsingReferences.module.css
@@ -1,0 +1,9 @@
+.entryReference {
+  background: #ccc;
+  padding: 1rem;
+  border-radius: 8px;
+  margin: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}

--- a/packages/test-apps/react-vite/src/components/ComponentUsingReferences/ComponentUsingReferences.tsx
+++ b/packages/test-apps/react-vite/src/components/ComponentUsingReferences/ComponentUsingReferences.tsx
@@ -1,0 +1,50 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { Entry } from 'contentful';
+import styles from './ComponentUsingReferences.module.css';
+
+type ComponentUsingReferencesProperties = {
+  title: string;
+  description: string;
+  entry?: Entry;
+};
+
+export function ComponentUsingReferences({
+  title,
+  description,
+  entry,
+  ...rest
+}: ComponentUsingReferencesProperties) {
+  const stringFields = collectStringFields(entry);
+  return (
+    <div {...rest}>
+      <h2>{title}</h2>
+      <p>{description}</p>
+      {stringFields.length > 0 && (
+        <div className={styles.entryReference}>
+          <i>Reference</i>
+          {stringFields.map(([key, value]) => (
+            <div>
+              <b>{key}</b>
+              <div>
+                {'> '}
+                {value}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}{' '}
+    </div>
+  );
+}
+
+const collectStringFields = (entry?: Entry): Array<[string, string]> => {
+  return Object.keys(entry?.fields ?? {})
+    .map((key) => {
+      const field: any = entry?.fields[key];
+      if (typeof field === 'string') {
+        return [key, field] as [string, string];
+      }
+      return null;
+    })
+    .filter(Boolean) as Array<[string, string]>;
+};

--- a/packages/test-apps/react-vite/src/components/ComponentUsingReferences/index.ts
+++ b/packages/test-apps/react-vite/src/components/ComponentUsingReferences/index.ts
@@ -1,0 +1,1 @@
+export { ComponentUsingReferences } from './ComponentUsingReferences';

--- a/packages/test-apps/react-vite/src/studio-config.ts
+++ b/packages/test-apps/react-vite/src/studio-config.ts
@@ -5,6 +5,7 @@ import { CustomImageComponent } from './components/CustomImageComponent';
 import NestedSlots from './components/NestedSlots';
 import KitchenSink from './components/KitchenSink';
 import ColorfulBox from './components/ColorfulBox/ColorfulBox';
+import { ComponentUsingReferences } from './components/ComponentUsingReferences';
 
 defineComponents(
   [
@@ -40,6 +41,32 @@ defineComponents(
       },
       options: {
         wrapComponent: false,
+      },
+    },
+    {
+      component: ComponentUsingReferences,
+      definition: {
+        id: 'component-using-references',
+        name: 'Component Using References',
+        category: 'Custom Components',
+        builtInStyles: ['cfMargin', 'cfPadding', 'cfWidth', 'cfMaxWidth'],
+        variables: {
+          title: {
+            displayName: 'Title',
+            type: 'Text',
+          },
+          description: {
+            displayName: 'Description',
+            type: 'Text',
+          },
+          entry: {
+            displayName: 'Entry Reference',
+            type: 'Link',
+          },
+        },
+      },
+      options: {
+        wrapComponent: true,
       },
     },
     {


### PR DESCRIPTION
## Purpose

So far, we had no example where a component would render content from a content that is linked through a reference field of an entry.
When using the type `Link` for a variable definition, it allows binding to the whole reference field so the rendering code can pick up any fields from that referenced entity.

We adjusted the fetching logic in the user interface recently for that use case and now add an example use case.

https://github.com/user-attachments/assets/85fad642-8de4-43fe-a1ce-b2f3e62364c7

