### PR TITLE
docs: remove outdated expEditorMode note

### DIFF
--- a/examples/next-app-router/README.md
+++ b/examples/next-app-router/README.md
@@ -26,11 +26,7 @@ Next, you will need to set up your environment variables. Copy the `.env.local.e
 - NEXT_PUBLIC_CTFL_ENVIRONMENT: This is the environment of your Contentful space. This can be found in Settings>General Settings. This can be found in Settings>Environments.
 - NEXT_PUBLIC_CTFL_EXPERIENCE_TYPE= This is the content type id of the Experience content type in your Contentful space. This can be found in Content Model>Experience.
 
-### Step 3: Add expEditorMode query param to the Content Preview Url
-
-In order to preview your Experiences in the Contentful web app, you will need to add the `expEditorMode` query parameter to the Content Preview URL. This parameter should be set to `true`. For example, if your Content Preview URL is `https://example.com`, you should set it to `https://example.com?expEditorMode=true`.
-
-### Step 4: Start the development server
+### Step 3: Start the development server
 
 Now that you have set up your environment variables, you can start the development server:
 
@@ -41,6 +37,4 @@ npm run dev
 The app is set up to run on `http://localhost:3000`. By default, the root URL will pull up an experience with the slug of 'home-page'. The locale will be determined by your browser settings. You can change the slug and locale by modifying the URL. For example, to view the experience with the slug of 'about-page' and a locale of 'de', you would navigate to `http://localhost:3000/de/about-page`.
 
 For the localization, this app uses the [Next i18n Router plugin](https://github.com/i18nexus/next-i18n-router#readme) for Next.js. You can configure locales by adding them to the `i18n` section in the `src/middleware.ts` file.
-
-## 
 


### PR DESCRIPTION
## Purpose

The web app is adding `expEditorMode` automatically, which is why we can drop those related notes.
