### PR TITLE
fix(visual-editor): pattern only has width 100% if its first top level node has [SPA-2722]

### DIFF
--- a/packages/visual-editor/src/components/DraggableBlock/Dropzone.tsx
+++ b/packages/visual-editor/src/components/DraggableBlock/Dropzone.tsx
@@ -169,6 +169,14 @@ export function Dropzone({
       ) === '100%'
     : false;
 
+  const isPatternWrapperComponentFullWidth = isRootAssembly
+    ? node.children.length === 1 &&
+      resolveDesignValue(
+        (node?.children[0]?.data.props.cfWidth as DesignValue)?.valuesByBreakpoint ?? {},
+        'cfWidth',
+      ) === '100%'
+    : false;
+
   return (
     <Droppable
       droppableId={zoneId}
@@ -205,9 +213,9 @@ export function Dropzone({
               [styles.isDestination]: isDestination && !isAssembly,
               [styles.isRoot]: isRootZone,
               [styles.isEmptyZone]: !content.length,
-              [styles.isAssembly]: isRootAssembly,
               [styles.isSlot]: Boolean(slotId),
               [styles.fullHeight]: isPatternWrapperComponentFullHeight,
+              [styles.fullWidth]: isPatternWrapperComponentFullWidth,
             })}>
             {isEmptyCanvas ? (
               <EmptyContainer isDragging={isRootZone && userIsDragging} />

--- a/packages/visual-editor/src/components/DraggableBlock/styles.module.css
+++ b/packages/visual-editor/src/components/DraggableBlock/styles.module.css
@@ -30,12 +30,12 @@
   pointer-events: all;
 }
 
-.Dropzone.isAssembly {
-  width: 100%;
-}
-
 .Dropzone.fullHeight {
   height: 100%;
+}
+
+.Dropzone.fullWidth {
+  width: 100%;
 }
 
 .isRoot,


### PR DESCRIPTION
## Purpose

When rendering patterns in editor, the DND wrapper would always apply width `100%` to it. This creates a mismatch between editor and delivery as the latter has no DND wrapper and thus might render nodes with width being `auto` ("fit").

**Demoing the bug:**
The moment the container is turned into a pattern, we apply the width `100%` and thus create a lot of spacing (which doens't exist in delivery).

https://github.com/user-attachments/assets/0436d827-cd49-4c69-9dc5-a858b0db19ef

## Approach

Similar to [this previous fix](https://github.com/contentful/experience-builder/pull/1080) for `height: 100%`, we define the width of the pattern wrapper depending on the width of its first top-level container node. Only if that uses full width, will the pattern render with full width.

## Note ⚠️ 

While this resolves most scenarios, it still solves this issue for all scenarios. As soon as there are multiple top-level nodes, there might be another mismatch between editor and delivery mode, as the pattern wrapper will render one width value to rule them all. If the first container defines auto width and the second one uses full width, both will get auto width in editor mode.

If we wanted to solve that as well, there are at least three ways going forward:
- Avoid mismatches between editor and preview mode by moving the whole DND logic to the web app (ongoing investigations)
- Find the maximum percentage width of all top-level nodes inside the pattern and use that for the pattern wrapper (if there are no percentage values, fall back to auto). If there are different percentage values, we would have to adjust those, e.g. the pattern wrapper defines `width: 80%` and another node that used `40%` would now have to use `width: 50%` as its relative to those `80%`
- Provide guidance on such scenarios and promote having only one top level container inside the pattern that wraps all content. This way, you can be certain that editor and delivery mode will match.