### PR TITLE
feat(proposal): resolve deep entities client-side [SPA-2697]

### DIFF
--- a/packages/test-apps/react-vite/src/Page.tsx
+++ b/packages/test-apps/react-vite/src/Page.tsx
@@ -4,6 +4,8 @@ import './styles.css';
 import { ExperienceRoot, useFetchBySlug } from '@contentful/experiences-sdk-react';
 import { useContentfulClient } from './hooks/useContentfulClient';
 import { useContentfulConfig } from './hooks/useContentfulConfig';
+import { useEffect } from 'react';
+import { customEntityStore } from './custom-store';
 
 export default function Page() {
   const { slug = 'home-page', locale } = useParams<{ slug: string; locale?: string }>();
@@ -18,6 +20,15 @@ export default function Page() {
     experienceTypeId: config.experienceTypeId,
     hyperlinkPattern: '/{entry.fields.slug}',
   });
+
+  // Pass the client to the custom entity store
+  useEffect(() => customEntityStore.setClient(client), [client]);
+  useEffect(() => {
+    if (isLoading || !experience) return;
+    if (!experience.entityStore?.entities) return;
+    // In delivery, store all fetched entities
+    customEntityStore.storeEntities(experience.entityStore?.entities);
+  }, [experience, isLoading]);
 
   if (isLoading) return <div>Loading...</div>;
 

--- a/packages/test-apps/react-vite/src/components/ComponentUsingDeepReferences/ComponentUsingDeepReferences.module.css
+++ b/packages/test-apps/react-vite/src/components/ComponentUsingDeepReferences/ComponentUsingDeepReferences.module.css
@@ -1,0 +1,15 @@
+.entryReference {
+  background: #ccc;
+  padding: 1rem;
+  border-radius: 8px;
+  margin: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.thumbnail {
+  width: auto;
+  height: 200px;
+  margin-right: auto;
+}

--- a/packages/test-apps/react-vite/src/components/ComponentUsingDeepReferences/ComponentUsingDeepReferences.tsx
+++ b/packages/test-apps/react-vite/src/components/ComponentUsingDeepReferences/ComponentUsingDeepReferences.tsx
@@ -1,0 +1,75 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { Asset, Entry, UnresolvedLink } from 'contentful';
+import styles from './ComponentUsingDeepReferences.module.css';
+import { useEffect, useState } from 'react';
+import { customEntityStore } from '../../custom-store';
+
+type ComponentUsingDeepReferencesProperties = {
+  title: string;
+  items?: Entry[];
+};
+
+export function ComponentUsingDeepReferences({
+  title,
+  items,
+  ...rest
+}: ComponentUsingDeepReferencesProperties) {
+  return (
+    <div {...rest}>
+      <h2>{title}</h2>
+      {items?.map((entry) => {
+        const thumbnail = entry.fields?.thumbnail;
+        const name = entry.fields?.name as unknown as string;
+        return (
+          <div key={entry.sys.id} className={styles.entryReference}>
+            <i>Character Reference</i>
+            <div>
+              <b>Name: </b>
+              <span>{name}</span>
+            </div>
+            <ThumnailImage thumbnail={thumbnail as any} />
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+const ThumnailImage = ({ thumbnail }: { thumbnail?: UnresolvedLink<'Asset'> | Asset }) => {
+  const [fetched, setFetched] = useState(
+    !thumbnail || isAssetLink(thumbnail) ? undefined : thumbnail,
+  );
+
+  useEffect(() => {
+    if (fetched || !thumbnail || !isAssetLink(thumbnail)) return;
+    (async function () {
+      const fetchedEntity = (await customEntityStore.getEntityByLink(thumbnail)) as Asset;
+      setFetched(fetchedEntity);
+    })();
+  }, [fetched, thumbnail]);
+
+  if (!fetched) {
+    return <>Loading...</>;
+  }
+  const url = fetched.fields?.file?.url;
+  if (typeof url !== 'string') {
+    return <span>No thumbnail URL available</span>;
+  }
+  return <img className={styles.thumbnail} src={url}></img>;
+};
+
+const isAssetLink = (
+  maybeLink: UnresolvedLink<'Asset'> | Asset,
+): maybeLink is UnresolvedLink<'Asset'> => {
+  if (maybeLink === null) return false;
+  if (typeof maybeLink !== 'object') return false;
+
+  const link = maybeLink as {
+    sys?: {
+      id?: string;
+      type?: string;
+    };
+  };
+
+  return Boolean(maybeLink.sys?.id) && link.sys?.type === 'Link';
+};

--- a/packages/test-apps/react-vite/src/components/ComponentUsingDeepReferences/index.ts
+++ b/packages/test-apps/react-vite/src/components/ComponentUsingDeepReferences/index.ts
@@ -1,0 +1,1 @@
+export { ComponentUsingDeepReferences } from './ComponentUsingDeepReferences';

--- a/packages/test-apps/react-vite/src/custom-store.ts
+++ b/packages/test-apps/react-vite/src/custom-store.ts
@@ -1,0 +1,38 @@
+import { Asset, ContentfulClientApi, Entry, UnresolvedLink } from 'contentful';
+
+export const customEntityStore = {
+  entitiesById: {} as Record<string, Asset | Entry>,
+  client: undefined as ContentfulClientApi<undefined> | undefined,
+
+  getEntityByLink: async (
+    link: UnresolvedLink<'Asset' | 'Entry'>,
+  ): Promise<Asset | Entry | undefined> => {
+    const stored = customEntityStore.entitiesById[link.sys.id];
+    if (stored) return stored;
+    if (!customEntityStore.client) return undefined;
+
+    const fetched = await fetchByLink(customEntityStore.client, link);
+    console.log('TK fetched', fetched);
+    customEntityStore.entitiesById[link.sys.id] = fetched;
+    return fetched;
+  },
+  storeEntities: (entities: Array<Asset | Entry>) => {
+    entities.forEach((entity) => {
+      customEntityStore.entitiesById[entity.sys.id] = entity;
+    });
+    console.log('TK stored everything', { entitiesById: customEntityStore.entitiesById });
+  },
+  setClient: (client: ContentfulClientApi<undefined>) => {
+    customEntityStore.client = client;
+  },
+};
+
+const fetchByLink = async (
+  client: ContentfulClientApi<undefined>,
+  link: UnresolvedLink<'Asset' | 'Entry'>,
+) => {
+  if (link.sys.linkType === 'Asset') {
+    return client.getAsset(link.sys.id);
+  }
+  return client.getEntry(link.sys.id);
+};

--- a/packages/test-apps/react-vite/src/custom-store.ts
+++ b/packages/test-apps/react-vite/src/custom-store.ts
@@ -12,7 +12,6 @@ export const customEntityStore = {
     if (!customEntityStore.client) return undefined;
 
     const fetched = await fetchByLink(customEntityStore.client, link);
-    console.log('TK fetched', fetched);
     customEntityStore.entitiesById[link.sys.id] = fetched;
     return fetched;
   },
@@ -20,7 +19,6 @@ export const customEntityStore = {
     entities.forEach((entity) => {
       customEntityStore.entitiesById[entity.sys.id] = entity;
     });
-    console.log('TK stored everything', { entitiesById: customEntityStore.entitiesById });
   },
   setClient: (client: ContentfulClientApi<undefined>) => {
     customEntityStore.client = client;

--- a/packages/test-apps/react-vite/src/studio-config.ts
+++ b/packages/test-apps/react-vite/src/studio-config.ts
@@ -6,6 +6,7 @@ import NestedSlots from './components/NestedSlots';
 import KitchenSink from './components/KitchenSink';
 import ColorfulBox from './components/ColorfulBox/ColorfulBox';
 import { ComponentUsingReferences } from './components/ComponentUsingReferences';
+import { ComponentUsingDeepReferences } from './components/ComponentUsingDeepReferences';
 
 defineComponents(
   [
@@ -62,6 +63,28 @@ defineComponents(
           entry: {
             displayName: 'Entry Reference',
             type: 'Link',
+          },
+        },
+      },
+      options: {
+        wrapComponent: true,
+      },
+    },
+    {
+      component: ComponentUsingDeepReferences,
+      definition: {
+        id: 'component-using-deep-references',
+        name: '[Deep] Component Using References',
+        category: 'Custom Components',
+        builtInStyles: ['cfMargin', 'cfPadding', 'cfWidth', 'cfMaxWidth'],
+        variables: {
+          title: {
+            displayName: 'Title',
+            type: 'Text',
+          },
+          items: {
+            displayName: 'Entry References',
+            type: 'Array',
           },
         },
       },


### PR DESCRIPTION
## Purpose

In some scenarios, customers rely on very deep references for the bound content that is passed to their customer components.
Since the editor only resolves references two levels deep and the delivery SDK three levels deep, users would face unresolved links in their customer components for components like a carousel.

## Approach

To avoid double fetching, I added a "custom entity store". In production, it will get initialized with the already-fetched entities.
When facing a link somewhere in a custom component, it will lazy-load the required entity.

## Demo
The example component has a content property `entries` of type `Array`. It points to the field "Characters" of a "Movie" entity. This characters field is a multi reference field containing a list of entries. Each of these entries contains a field "Thumbnail" which is an asset reference field.

This specific example will already in delivery without any adjustments but will fail to render the thumbnail in editor mode. In the recorded video, you'll see the editor initializing and the image being populated with a small delay (a disadvantage of this approach). In the network tab, you'll see that it will use the already initialized client, which will either use CPA or CDA.

https://github.com/user-attachments/assets/62879abc-3c86-41c2-9dc6-573f635d8b69
