### PR TITLE
fix: publish create package to github registry [SPA-2729]

### DIFF
--- a/packages/create-contentful-studio-experiences/package.json
+++ b/packages/create-contentful-studio-experiences/package.json
@@ -12,6 +12,9 @@
     "url": "https://github.com/contentful/experience-builder/issues"
   },
   "type": "module",
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com/"
+  },
   "main": "./dist/index.js",
   "module": "./dist/esm/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
Added originally [here](https://github.com/contentful/experience-builder/commit/4495c1e1f98d6b1c66d54f003d8b2d21867f0f08#diff-ff10ee50b08de281bf55bbc3ff00039a12ab5d873341ee2c9f0562a807baacf0) and removed [here](https://github.com/contentful/experience-builder/pull/676/files#diff-7be23c66a973d29dddba6d84d4202a23810f186390de0ae10e17c400284c7e2cL22).
Caused pipeline failure since [this PR](https://github.com/contentful/experience-builder/pull/1068/files).