### PR TITLE
fix: not throw logic error if a resolved entity was detected [ZEND-6229]

### DIFF
--- a/packages/core/src/entity/EntityStoreBase.ts
+++ b/packages/core/src/entity/EntityStoreBase.ts
@@ -203,11 +203,6 @@ export abstract class EntityStoreBase {
           }
           resolvedFieldset.push([entityToResolveFieldsFrom, field, _localeQualifier]);
           entityToResolveFieldsFrom = entity; // we move up
-        } else {
-          // TODO: Eg. when someone changed the schema and the field is not a link anymore, what should we return then?
-          throw new Error(
-            `LogicError: Invalid value of a field we consider a reference field. Cannot resolve field ${field} of a fieldset as it is not a link, neither undefined.`,
-          );
         }
       }
       return {


### PR DESCRIPTION
## Purpose

Temporarily, we remove the logic error and let the automatic reference resolution be applied.

Later, we plan to release a major version of the SDK, where we remove automatic link resolution and instead will provide a tool to resolve the entities via a provided utility (synchronously).

The reason why we need to make such a change is that we don't want to set an expectation that the SDK will resolve all references. We pre-fetch only up to 3 levels of entities and stop at that level, while the current approach makes an impression that references are resolved all the time automatically.

Since it's going to be a breaking change, we will release it as such in a later version.

## Approach