### PR TITLE
chore: resolve version conflict [SPA-2729]

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contentful/experiences-components-react",
-  "version": "1.36.0-beta.3",
+  "version": "1.37.0-beta.1",
   "description": "A basic set of components to use with Studio Experiences",
   "homepage": "https://github.com/contentful/experience-builder/tree/next/packages/components#readme",
   "repository": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contentful/experiences-core",
-  "version": "1.36.0-beta.3",
+  "version": "1.37.0-beta.1",
   "description": "",
   "main": "dist/index.js",
   "module": "dist/index.js",

--- a/packages/create-contentful-studio-experiences/package.json
+++ b/packages/create-contentful-studio-experiences/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contentful/create-contentful-studio-experiences",
-  "version": "1.36.0-beta.3",
+  "version": "1.37.0-beta.1",
   "description": "A CLI tool to get up and running with Contentful Studio Experiences quickly",
   "homepage": "https://github.com/contentful/experience-builder/tree/next/packages/create-contentful-studio-experiences#readme",
   "repository": {

--- a/packages/experience-builder-sdk/package.json
+++ b/packages/experience-builder-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contentful/experiences-sdk-react",
-  "version": "1.36.0-beta.3",
+  "version": "1.37.0-beta.1",
   "main": "./dist/index.js",
   "module": "./dist/index.js",
   "typings": "./dist/src/index.d.ts",

--- a/packages/validators/package.json
+++ b/packages/validators/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contentful/experiences-validators",
-  "version": "1.36.0-beta.3",
+  "version": "1.37.0-beta.1",
   "main": "./dist/index.js",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/visual-editor/package.json
+++ b/packages/visual-editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contentful/experiences-visual-editor-react",
-  "version": "1.36.0-beta.3",
+  "version": "1.37.0-beta.1",
   "type": "module",
   "main": "./dist/index.js",
   "module": "./dist/index.js",


### PR DESCRIPTION
For some reason we have a version conflict.
Probably because the main branch failed the last times, it didn't bump the version correctly in next & development. here I'm manually bumping it now.

<img width="1177" alt="Screenshot 2025-04-22 at 18 33 27" src="https://github.com/user-attachments/assets/a2efc74f-b788-412f-abc0-c8bad977f161" />
