### PR TITLE
fix: remove unused variable from useSingleColumn hook [SPA-2738]

### DIFF
--- a/packages/core/src/utils/styleUtils/styleTransformers.ts
+++ b/packages/core/src/utils/styleUtils/styleTransformers.ts
@@ -16,6 +16,7 @@ export const transformVisibility = (value?: boolean): CSSProperties => {
   return {};
 };
 
+// TODO: Remove in next major version v2 since the change is 17 months old
 // Keep this for backwards compatibility - deleting this would be a breaking change
 // because existing components on a users experience will have the width value as fill
 // rather than 100%

--- a/packages/visual-editor/src/hooks/useSingleColumn.ts
+++ b/packages/visual-editor/src/hooks/useSingleColumn.ts
@@ -9,42 +9,28 @@ export default function useSingleColumn(
   resolveDesignValue: ResolveDesignValueType,
 ) {
   const tree = useTreeStore((store) => store.tree);
-
   const isSingleColumn = node.data.blockId === CONTENTFUL_COMPONENTS.singleColumn.id;
 
-  const { isWrapped, wrapColumnsCount } = useMemo(() => {
-    let isWrapped = false;
-    let wrapColumnsCount = 0;
-
+  const isWrapped = useMemo(() => {
     if (!node.parentId || !isSingleColumn) {
-      return { isWrapped, wrapColumnsCount };
+      return false;
     }
 
     const parentNode = getItem({ id: node.parentId }, tree);
-
     if (!parentNode || parentNode.data.blockId !== CONTENTFUL_COMPONENTS.columns.id) {
-      return { isWrapped, wrapColumnsCount };
+      return false;
     }
 
-    const { cfWrapColumns, cfWrapColumnsCount } = parentNode.data.props;
-
-    if (cfWrapColumns.type === 'DesignValue') {
-      isWrapped = resolveDesignValue(cfWrapColumns.valuesByBreakpoint, 'cfWrapColumns') as boolean;
+    const { cfWrapColumns } = parentNode.data.props;
+    if (cfWrapColumns.type !== 'DesignValue') {
+      return false;
     }
 
-    if (cfWrapColumnsCount.type === 'DesignValue') {
-      wrapColumnsCount = resolveDesignValue(
-        cfWrapColumnsCount.valuesByBreakpoint,
-        'cfWrapColumnsCount',
-      ) as number;
-    }
-
-    return { isWrapped, wrapColumnsCount };
+    return resolveDesignValue(cfWrapColumns.valuesByBreakpoint, 'cfWrapColumns') as boolean;
   }, [tree, node, isSingleColumn, resolveDesignValue]);
 
   return {
     isSingleColumn,
     isWrapped,
-    wrapColumnsCount,
   };
 }


### PR DESCRIPTION
## Purpose

When testing columns wrap count, I first assumed this was handled in the SDK and debugged the code in `useSingleColumn` (the only place referring this variable). Only after some log debugging, I figured this is solely handled in the web app by setting the `columnsSpan` accordingly so there was no work necessary in the SDK.

However, I found that we run some logic in here for every node that is never used which is why I removed that part form the hook.
