### PR TITLE
refactor: remove unused code dragging and tree diffing [SPA-2610]

### DIFF
--- a/packages/experience-builder-sdk/src/core/preview/assemblyUtils.spec.ts
+++ b/packages/experience-builder-sdk/src/core/preview/assemblyUtils.spec.ts
@@ -15,28 +15,6 @@ import { EntityStore } from '@contentful/experiences-core';
 import { resolveAssembly } from './assemblyUtils';
 
 describe('resolveAssembly', () => {
-  it('should return the input node when it is not a assembly', () => {
-    const containerNode: ComponentTreeNode = {
-      definitionId: CONTENTFUL_COMPONENTS.container.id,
-      variables: {},
-      children: [],
-    };
-    const entityStore = new EntityStore({
-      experienceEntry: experienceEntry as unknown as Entry,
-      entities: [...entries, ...assets],
-      locale: 'en-US',
-    });
-
-    const result = resolveAssembly({
-      node: containerNode,
-      entityStore,
-      parentPatternProperties: {},
-      patternNodeIdsChain: '',
-    });
-
-    expect(result).toBe(containerNode);
-  });
-
   it('should return the input node when the entity store is undefined', () => {
     const containerNode: ComponentTreeNode = {
       definitionId: CONTENTFUL_COMPONENTS.container.id,

--- a/packages/experience-builder-sdk/src/core/preview/assemblyUtils.ts
+++ b/packages/experience-builder-sdk/src/core/preview/assemblyUtils.ts
@@ -1,4 +1,4 @@
-import { checkIsAssemblyNode, EntityStore } from '@contentful/experiences-core';
+import { EntityStore } from '@contentful/experiences-core';
 import md5 from 'md5';
 import type {
   ComponentPropertyValue,
@@ -118,15 +118,6 @@ export const resolveAssembly = ({
   parentPatternProperties: Record<string, PatternProperty>;
   patternNodeIdsChain: string;
 }) => {
-  const isAssembly = checkIsAssemblyNode({
-    componentId: node.definitionId,
-    usedComponents: entityStore.usedComponents,
-  });
-
-  if (!isAssembly) {
-    return node;
-  }
-
   const componentId = node.definitionId as string;
   const assembly = entityStore.usedComponents?.find(
     (component) => component.sys.id === componentId,

--- a/packages/visual-editor/src/store/editor.ts
+++ b/packages/visual-editor/src/store/editor.ts
@@ -34,8 +34,7 @@ export const useEditorStore = create<EditorStore>((set, get) => ({
   dataSource: {},
   hyperLinkPattern: undefined,
   unboundValues: {},
-  isDragging: false,
-  dragItem: '',
+
   selectedNodeId: null,
   locale: null,
   setHyperLinkPattern: (pattern: string) => {

--- a/packages/visual-editor/src/utils/treeHelpers.ts
+++ b/packages/visual-editor/src/utils/treeHelpers.ts
@@ -1,5 +1,4 @@
 import type { ExperienceTreeNode } from '@contentful/experiences-core/types';
-import { isEqual } from 'lodash-es';
 import { getChildFromTree } from './getItem';
 
 export function updateNode(
@@ -29,54 +28,6 @@ export function replaceNode(
   }
 
   node.children.forEach((childNode) => replaceNode(indexToReplace, updatedNode, childNode));
-}
-
-export function reorderChildrenNodes(
-  nodeId: string,
-  updatedChildren: ExperienceTreeNode[],
-  node: ExperienceTreeNode,
-) {
-  if (node.data.id === nodeId) {
-    node.children = updatedChildren;
-    return;
-  }
-
-  node.children.forEach((childNode) => reorderChildrenNodes(nodeId, updatedChildren, childNode));
-}
-
-export function addChildToNode(
-  nodeId: string,
-  oldChildren: ExperienceTreeNode[],
-  updatedChildren: ExperienceTreeNode[],
-  node: ExperienceTreeNode,
-) {
-  if (node.data.id !== nodeId) {
-    node.children.forEach((childNode) =>
-      addChildToNode(nodeId, oldChildren, updatedChildren, childNode),
-    );
-  }
-
-  let changed = false;
-
-  oldChildren.forEach((child, i) => {
-    if (isEqual(child, updatedChildren[i])) {
-      return;
-    }
-
-    changed = true;
-    addChildNode(i, node.data.id, updatedChildren[i], node);
-  });
-
-  if (!changed) {
-    // we iterated over the old children and didn't introduce a change.
-    // that means the child node is added to the end of the array.
-    addChildNode(
-      oldChildren.length,
-      node.data.id,
-      updatedChildren[updatedChildren.length - 1],
-      node,
-    );
-  }
 }
 
 export function removeChildNode(


### PR DESCRIPTION
## Purpose

I noticed some logic in the SDK that wasn't used at all while scanning the code.