### PR TITLE
fix: add relative position wrapper for misaligned image placeholder [SPA-2764]

### DIFF
--- a/packages/components/src/components/Image/Image.css
+++ b/packages/components/src/components/Image/Image.css
@@ -1,9 +1,16 @@
 @import url('../variables.css');
 
+div.cf-placeholder-wrapper {
+  /* Required for the absolute positioned icon to render in the center */
+  position: relative;
+}
+
 img.cf-placeholder-image {
   background-color: var(--cf-color-gray100);
   outline-offset: -2px;
   outline: 2px solid rgba(var(--cf-color-gray400-rgb), 0.5);
+  width: 100%;
+  height: 100%;
 }
 
 svg.cf-placeholder-icon {

--- a/packages/components/src/components/Image/Image.tsx
+++ b/packages/components/src/components/Image/Image.tsx
@@ -10,9 +10,9 @@ export interface ImageProps extends React.ImgHTMLAttributes<HTMLImageElement> {
 export const Image: React.FC<ImageProps> = ({ className = '', src, cfImageAsset, ...props }) => {
   if (!cfImageAsset && !src) {
     return (
-      <>
+      <div className={combineClasses('cf-placeholder-wrapper', className)}>
         <img
-          className={combineClasses('cf-placeholder-image', className)}
+          className={'cf-placeholder-image'}
           src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAA"
           {...props}
         />
@@ -26,7 +26,7 @@ export const Image: React.FC<ImageProps> = ({ className = '', src, cfImageAsset,
             d="M13.5 2h-10a1 1 0 0 0-1 1v10a1 1 0 0 0 1 1h10a1 1 0 0 0 1-1V3a1 1 0 0 0-1-1m-10 1h10v4.836l-1.543-1.543a1 1 0 0 0-1.414 0L3.836 13H3.5zm10 10H5.25l6-6 2.25 2.25zm-7-5.5a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3m0-2a.5.5 0 1 1 0 1 .5.5 0 0 1 0-1"
           />
         </svg>
-      </>
+      </div>
     );
   }
 


### PR DESCRIPTION
## Purpose
The placeholder icon is aligned through absolute positioning. As there was not relative wrapper directly above it, it would be rendered out of bounds in some scenarios.

## Before
<img width="313" alt="Screenshot 2025-05-12 at 15 07 45" src="https://github.com/user-attachments/assets/b5e36d6c-cf76-4c15-81d7-c348009b1bc4" />

## After
<img width="284" alt="Screenshot 2025-05-12 at 15 14 23" src="https://github.com/user-attachments/assets/56fa315c-34b6-4ced-a25c-cf131df6e3d0" />
