### PR TITLE
fix: merge override and default design values by breakpoint in CSR preview [SPA-2602]

### DIFF
--- a/packages/experience-builder-sdk/src/core/preview/assemblyUtils.spec.ts
+++ b/packages/experience-builder-sdk/src/core/preview/assemblyUtils.spec.ts
@@ -146,13 +146,13 @@ describe('resolveAssembly', () => {
       });
     });
 
-    it('resolves a style component value with the value of the assembly instance', () => {
+    it('resolves a style component value by merging the instance value with the default one', () => {
       const assemblyNode: ComponentTreeNode = {
         definitionId: 'assembly-id',
         variables: {
           [assemblyGeneratedDesignVariableName]: {
             type: 'DesignValue',
-            valuesByBreakpoint: { desktop: '99px' },
+            valuesByBreakpoint: { desktop: '99px', tablet: '11px' },
           },
         },
         children: [],
@@ -167,7 +167,7 @@ describe('resolveAssembly', () => {
 
       expect(result.children[0].variables.cfWidth).toEqual({
         type: 'DesignValue',
-        valuesByBreakpoint: { desktop: '99px' },
+        valuesByBreakpoint: { desktop: '99px', tablet: '11px', mobile: '24px' },
       });
     });
 
@@ -187,7 +187,7 @@ describe('resolveAssembly', () => {
 
       expect(result.children[0].variables.cfWidth).toEqual({
         type: 'DesignValue',
-        valuesByBreakpoint: { desktop: '42px' },
+        valuesByBreakpoint: { desktop: '42px', mobile: '24px' },
       });
     });
   });

--- a/packages/experience-builder-sdk/src/core/preview/assemblyUtils.ts
+++ b/packages/experience-builder-sdk/src/core/preview/assemblyUtils.ts
@@ -1,4 +1,4 @@
-import { EntityStore } from '@contentful/experiences-core';
+import { EntityStore, mergeDesignValuesByBreakpoint } from '@contentful/experiences-core';
 import md5 from 'md5';
 import type {
   ComponentPropertyValue,
@@ -71,10 +71,10 @@ export const deserializeAssemblyNode = ({
           linkTargetKey: instanceProperty.linkTargetKey,
         };
       } else if (instanceProperty?.type === 'DesignValue') {
-        variables[variableName] = {
-          type: 'DesignValue',
-          valuesByBreakpoint: instanceProperty.valuesByBreakpoint,
-        };
+        variables[variableName] = mergeDesignValuesByBreakpoint(
+          defaultValue as DesignValue,
+          instanceProperty,
+        );
       } else if (!instanceProperty && defaultValue) {
         // So far, we only automatically fallback to the defaultValue for design properties
         if (variableDefinition.group === 'style') {

--- a/packages/experience-builder-sdk/src/utils/parseComponentProps.ts
+++ b/packages/experience-builder-sdk/src/utils/parseComponentProps.ts
@@ -127,6 +127,9 @@ export const parseComponentProps = ({
         // We're rendering a pattern entry. Content cannot be set for ComponentValue type properties
         // directly in the pattern so we can safely use the default value
         // This can either be a design (style) or a content variable
+        // FIXME: When previewing a pattern entry along with its nested patterns, the design values are not correctly resolved.
+        // To support that, we could replace all ComponentValues with the actual design values initially or try to do the recursive
+        // lookup in here.
         contentProps[propName] = propDefinition.defaultValue;
         break;
       default:

--- a/packages/experience-builder-sdk/test/__fixtures__/assembly.ts
+++ b/packages/experience-builder-sdk/test/__fixtures__/assembly.ts
@@ -106,7 +106,10 @@ export const createAssemblyEntry = ({
             displayName: 'Width',
             type: 'Text',
             group: 'style',
-            defaultValue: { type: 'DesignValue', valuesByBreakpoint: { desktop: '42px' } },
+            defaultValue: {
+              type: 'DesignValue',
+              valuesByBreakpoint: { desktop: '42px', mobile: '24px' },
+            },
           },
         },
       } satisfies ExperienceComponentSettings,


### PR DESCRIPTION
## Purpose
Setting the design value for one specific breakpoint on a pattern instance, should not vanish the default value for other breakpoints.

## Approach
Merge design values by breakpoint.

Based on top of https://github.com/contentful/experience-builder/pull/1125