### PR TITLE
style: simplify resolveDesignValue by dropping the unused name arg [SPA-2610]

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -381,7 +381,7 @@ export interface Experience<T extends EntityStore = EntityStore> {
 
 export type ResolveDesignValueType = (
   valuesByBreakpoint: ValuesByBreakpoint | undefined,
-  variableName: string,
+  propertyName?: string,
 ) => PrimitiveValue;
 
 // The 'contentful' package only exposes CDA types while we received CMA ones in editor mode

--- a/packages/core/src/utils/breakpoints.ts
+++ b/packages/core/src/utils/breakpoints.ts
@@ -102,13 +102,17 @@ export const getValueForBreakpoint = (
   breakpoints: Breakpoint[],
   activeBreakpointIndex: number,
   fallbackBreakpointIndex: number,
-  variableName: string,
-  resolveDesignTokens = true,
+  /** Provide the name for built-in styles to replace design tokens. Supported properties are:
+   * cfMargin, cfPadding, cfGap, cfWidth, cfHeight, cfBackgroundColor,
+   * cfBorder, cfBorderRadius, cfFontSize, cfLineHeight, cfLetterSpacing,
+   * cfTextColor, cfMaxWidth
+   */
+  propertyName?: string,
 ) => {
   const eventuallyResolveDesignTokens = (value: PrimitiveValue) => {
     // For some built-in design properties, we support design tokens
-    if (builtInStylesWithDesignTokens.includes(variableName)) {
-      return getDesignTokenRegistration(value as string, variableName);
+    if (propertyName && builtInStylesWithDesignTokens.includes(propertyName)) {
+      return getDesignTokenRegistration(value as string, propertyName);
     }
     // For all other properties, we just return the breakpoint-specific value
     return value;
@@ -120,19 +124,13 @@ export const getValueForBreakpoint = (
       const breakpointId = breakpoints[index]?.id;
       if (isValidBreakpointValue(valuesByBreakpoint[breakpointId])) {
         // If the value is defined, we use it and stop the breakpoints cascade
-        if (resolveDesignTokens) {
-          return eventuallyResolveDesignTokens(valuesByBreakpoint[breakpointId]);
-        }
-        return valuesByBreakpoint[breakpointId];
+        return eventuallyResolveDesignTokens(valuesByBreakpoint[breakpointId]);
       }
     }
 
     const fallbackBreakpointId = breakpoints[fallbackBreakpointIndex]?.id;
     if (isValidBreakpointValue(valuesByBreakpoint[fallbackBreakpointId])) {
-      if (resolveDesignTokens) {
-        return eventuallyResolveDesignTokens(valuesByBreakpoint[fallbackBreakpointId]);
-      }
-      return valuesByBreakpoint[fallbackBreakpointId];
+      return eventuallyResolveDesignTokens(valuesByBreakpoint[fallbackBreakpointId]);
     }
   } else {
     // Old design properties did not support breakpoints, keep for backward compatibility

--- a/packages/core/src/utils/breakpoints.ts
+++ b/packages/core/src/utils/breakpoints.ts
@@ -107,9 +107,14 @@ export const getValueForBreakpoint = (
    * cfBorder, cfBorderRadius, cfFontSize, cfLineHeight, cfLetterSpacing,
    * cfTextColor, cfMaxWidth
    */
-  propertyName?: string,
+  propertyName: string | undefined,
+  resolveDesignTokens = true,
 ) => {
   const eventuallyResolveDesignTokens = (value: PrimitiveValue) => {
+    // This is used externally in the web app to determine the original persisted value
+    if (!resolveDesignTokens) {
+      return value;
+    }
     // For some built-in design properties, we support design tokens
     if (propertyName && builtInStylesWithDesignTokens.includes(propertyName)) {
       return getDesignTokenRegistration(value as string, propertyName);

--- a/packages/core/src/utils/breakpoints.ts
+++ b/packages/core/src/utils/breakpoints.ts
@@ -107,7 +107,7 @@ export const getValueForBreakpoint = (
    * cfBorder, cfBorderRadius, cfFontSize, cfLineHeight, cfLetterSpacing,
    * cfTextColor, cfMaxWidth
    */
-  propertyName: string | undefined,
+  propertyName?: string,
   resolveDesignTokens = true,
 ) => {
   const eventuallyResolveDesignTokens = (value: PrimitiveValue) => {

--- a/packages/core/src/utils/transformers/media/transformMedia.ts
+++ b/packages/core/src/utils/transformers/media/transformMedia.ts
@@ -34,7 +34,6 @@ export const transformMedia = (
       variables[optionsVariableName]?.type === 'DesignValue'
         ? variables[optionsVariableName].valuesByBreakpoint
         : {},
-      optionsVariableName,
     ) as ImageOptions | undefined;
     if (!options) {
       console.error(
@@ -68,7 +67,6 @@ export const transformMedia = (
       variables[optionsVariableName]?.type === 'DesignValue'
         ? variables[optionsVariableName].valuesByBreakpoint
         : {},
-      optionsVariableName,
     ) as BackgroundImageOptions | undefined;
     if (!options) {
       console.error(

--- a/packages/core/src/utils/transformers/transformBoundContentValue.spec.ts
+++ b/packages/core/src/utils/transformers/transformBoundContentValue.spec.ts
@@ -20,6 +20,7 @@ import {
 } from '@/types';
 import { vitest, it, describe } from 'vitest';
 import { UnresolvedLink } from 'contentful';
+import { cloneDeep } from 'lodash-es';
 
 const entityStore = new EditorModeEntityStore({
   entities: [
@@ -113,23 +114,28 @@ describe('transformBoundContentValue', () => {
     describe('when the variable is a cfBackgroundImageOptions', () => {
       const variablesWithImageOptions = {
         ...variables,
+        cfBackgroundImageOptions: {
+          type: 'DesignValue' as const,
+          valuesByBreakpoint: {
+            desktop: {
+              quality: '100%',
+              format: 'jpg',
+              targetSize: '1060px',
+            },
+          },
+        },
+        cfWidth: {
+          type: 'DesignValue' as const,
+          valuesByBreakpoint: {
+            desktop: '1024px',
+          },
+        },
       };
+      const resolveDesignValue = (valuesByBreakpoint) => valuesByBreakpoint.desktop;
       it('should transform value to OptimizedBackgroundImageAsset', () => {
         const binding: UnresolvedLink<'Asset'> = {
           sys: { type: 'Link', linkType: 'Asset', id: 'asset1' },
         };
-        const resolveDesignValue = vitest.fn((_, variableName) => {
-          if (variableName === 'cfBackgroundImageOptions') {
-            return {
-              quality: '100%',
-              format: 'jpg',
-              targetSize: '1060px',
-            };
-          }
-          if (variableName === 'cfWidth') {
-            return '1024px';
-          }
-        });
         const variableName = 'cfBackgroundImageUrl';
 
         const path = (variables.image as BoundValue).path;
@@ -149,23 +155,15 @@ describe('transformBoundContentValue', () => {
         const binding: UnresolvedLink<'Asset'> = {
           sys: { type: 'Link', linkType: 'Asset', id: 'asset1' },
         };
-        const resolveDesignValue = vitest.fn((_, variableName) => {
-          if (variableName === 'cfBackgroundImageOptions') {
-            return {
-              quality: '100%',
-              format: 'jpg',
-              targetSize: '300px',
-            };
-          }
-          if (variableName === 'cfWidth') {
-            return '1024px';
-          }
-        });
+        const adjustedVariablesWithImageOptions = cloneDeep(variablesWithImageOptions);
+        adjustedVariablesWithImageOptions.cfBackgroundImageOptions.valuesByBreakpoint.desktop.targetSize =
+          '300px';
+
         const variableName = 'cfBackgroundImageUrl';
 
         const path = (variables.image as BoundValue).path;
         const result = transformBoundContentValue(
-          variablesWithImageOptions,
+          adjustedVariablesWithImageOptions,
           entityStore,
           binding,
           resolveDesignValue,
@@ -180,23 +178,13 @@ describe('transformBoundContentValue', () => {
         const binding: UnresolvedLink<'Asset'> = {
           sys: { type: 'Link', linkType: 'Asset', id: 'asset1' },
         };
-        const resolveDesignValue = vitest.fn((_, variableName) => {
-          if (variableName === 'cfBackgroundImageOptions') {
-            return {
-              quality: '100%',
-              format: 'jpg',
-              targetSize: '1060px',
-            };
-          }
-          if (variableName === 'cfWidth') {
-            return undefined; // cfWidth is not defined
-          }
-        });
+        const adjustedVariablesWithImageOptions = cloneDeep(variablesWithImageOptions);
+        adjustedVariablesWithImageOptions.cfWidth.valuesByBreakpoint.desktop = undefined as any;
         const variableName = 'cfBackgroundImageUrl';
 
         const path = (variables.image as BoundValue).path;
         const result = transformBoundContentValue(
-          variablesWithImageOptions,
+          adjustedVariablesWithImageOptions,
           entityStore,
           binding,
           resolveDesignValue,

--- a/packages/core/src/utils/transformers/transformBoundContentValue.spec.ts
+++ b/packages/core/src/utils/transformers/transformBoundContentValue.spec.ts
@@ -179,6 +179,7 @@ describe('transformBoundContentValue', () => {
           sys: { type: 'Link', linkType: 'Asset', id: 'asset1' },
         };
         const adjustedVariablesWithImageOptions = cloneDeep(variablesWithImageOptions);
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         adjustedVariablesWithImageOptions.cfWidth.valuesByBreakpoint.desktop = undefined as any;
         const variableName = 'cfBackgroundImageUrl';
 

--- a/packages/experience-builder-sdk/src/blocks/preview/CompositionBlock.tsx
+++ b/packages/experience-builder-sdk/src/blocks/preview/CompositionBlock.tsx
@@ -155,9 +155,7 @@ export const CompositionBlock = ({
       componentDefinition: componentRegistration.definition,
       patternNodeIdsChain,
       node,
-      // The property name is only used for built-in styles to resolve design tokens.
-      // So we can ignore it here and just pass 'custom'.
-      resolveCustomDesignValue: (valuesByBreakpoint) => resolveDesignValue(valuesByBreakpoint),
+      resolveDesignValue,
       resolveBoundValue: ({ binding, propertyName, dataType }) => {
         const [, uuid] = binding.path.split('/');
         const boundEntityLink = entityStore.dataSource[uuid] as UnresolvedLink<'Entry' | 'Asset'>;

--- a/packages/experience-builder-sdk/src/blocks/preview/CompositionBlock.tsx
+++ b/packages/experience-builder-sdk/src/blocks/preview/CompositionBlock.tsx
@@ -155,9 +155,9 @@ export const CompositionBlock = ({
       componentDefinition: componentRegistration.definition,
       patternNodeIdsChain,
       node,
-      resolveCustomDesignValue: ({ propertyName, valuesByBreakpoint }) => {
-        return resolveDesignValue(valuesByBreakpoint, propertyName);
-      },
+      // The property name is only used for built-in styles to resolve design tokens.
+      // So we can ignore it here and just pass 'custom'.
+      resolveCustomDesignValue: (valuesByBreakpoint) => resolveDesignValue(valuesByBreakpoint),
       resolveBoundValue: ({ binding, propertyName, dataType }) => {
         const [, uuid] = binding.path.split('/');
         const boundEntityLink = entityStore.dataSource[uuid] as UnresolvedLink<'Entry' | 'Asset'>;
@@ -269,7 +269,7 @@ export const CompositionBlock = ({
       const classesForNode: DesignValue | undefined = node.variables.cfSsrClassName?.[nodeIdsChain];
 
       if (!classesForNode) return undefined;
-      return resolveDesignValue(classesForNode.valuesByBreakpoint, 'cfSsrClassName') as string;
+      return resolveDesignValue(classesForNode.valuesByBreakpoint) as string;
     }
     return getPatternChildNodeClassName?.(`${node.id}${childNodeId}`);
   };

--- a/packages/experience-builder-sdk/src/hooks/useBreakpoints.ts
+++ b/packages/experience-builder-sdk/src/hooks/useBreakpoints.ts
@@ -44,7 +44,7 @@ export const useBreakpoints = (breakpoints: Breakpoint[]) => {
   }, [breakpoints]);
 
   const resolveDesignValue: ResolveDesignValueType = useCallback(
-    (valuesByBreakpoint, variableName) => {
+    (valuesByBreakpoint, propertyName) => {
       const fallbackBreakpointIndex = getFallbackBreakpointIndex(breakpoints);
 
       const activeBreakpointIndex = getActiveBreakpointIndex(
@@ -58,7 +58,7 @@ export const useBreakpoints = (breakpoints: Breakpoint[]) => {
         breakpoints,
         activeBreakpointIndex,
         fallbackBreakpointIndex,
-        variableName,
+        propertyName,
       );
     },
     [mediaQueryMatches, breakpoints],

--- a/packages/experience-builder-sdk/src/utils/parseComponentProps.spec.ts
+++ b/packages/experience-builder-sdk/src/utils/parseComponentProps.spec.ts
@@ -3,7 +3,7 @@ import { getValueForBreakpoint } from '@contentful/experiences-core';
 import { createBreakpoints } from '../../test/__fixtures__/breakpoints';
 import { createComponentDefinition } from '../../test/__fixtures__/componentDefinition';
 import { createComponentTreeNode } from '../../test/__fixtures__/componentTreeNode';
-import { PrimitiveValue } from '@contentful/experiences-validators';
+import { ValuesByBreakpoint } from '@contentful/experiences-validators';
 
 describe('parseComponentProps', () => {
   const breakpoints = createBreakpoints();
@@ -11,7 +11,7 @@ describe('parseComponentProps', () => {
   const mainBreakpoint = breakpoints[0];
   const componentDefinition = createComponentDefinition();
   const node = createComponentTreeNode();
-  const resolveDesignValue = (valuesByBreakpoint: Record<string, PrimitiveValue>) =>
+  const resolveDesignValue = (valuesByBreakpoint: ValuesByBreakpoint | undefined) =>
     getValueForBreakpoint(valuesByBreakpoint, breakpoints, activeBreakpointIndex, 0);
 
   const resolveBoundValue = () => 'resolvedBoundValue';

--- a/packages/experience-builder-sdk/src/utils/parseComponentProps.spec.ts
+++ b/packages/experience-builder-sdk/src/utils/parseComponentProps.spec.ts
@@ -11,14 +11,8 @@ describe('parseComponentProps', () => {
   const mainBreakpoint = breakpoints[0];
   const componentDefinition = createComponentDefinition();
   const node = createComponentTreeNode();
-  const resolveDesignValue = ({
-    propertyName,
-    valuesByBreakpoint,
-  }: {
-    propertyName: string;
-    valuesByBreakpoint: Record<string, PrimitiveValue>;
-  }) =>
-    getValueForBreakpoint(valuesByBreakpoint, breakpoints, activeBreakpointIndex, 0, propertyName);
+  const resolveDesignValue = (valuesByBreakpoint: Record<string, PrimitiveValue>) =>
+    getValueForBreakpoint(valuesByBreakpoint, breakpoints, activeBreakpointIndex, 0);
 
   const resolveBoundValue = () => 'resolvedBoundValue';
   const resolveHyperlinkValue = () => 'resolvedHyperlinkValue';
@@ -29,7 +23,7 @@ describe('parseComponentProps', () => {
     breakpoints,
     componentDefinition,
     node,
-    resolveCustomDesignValue: resolveDesignValue,
+    resolveDesignValue,
     resolveBoundValue,
     resolveHyperlinkValue,
     resolveUnboundValue,

--- a/packages/experience-builder-sdk/src/utils/parseComponentProps.ts
+++ b/packages/experience-builder-sdk/src/utils/parseComponentProps.ts
@@ -45,10 +45,7 @@ export const parseComponentProps = ({
   componentDefinition: ComponentDefinition;
   patternNodeIdsChain?: string;
   node: ComponentTreeNode;
-  resolveCustomDesignValue: (data: {
-    propertyName: string;
-    valuesByBreakpoint: Record<string, PrimitiveValue>;
-  }) => PrimitiveValue;
+  resolveCustomDesignValue: (valuesByBreakpoint: Record<string, PrimitiveValue>) => PrimitiveValue;
   resolveBoundValue: (data: {
     propertyName: string;
     dataType: ComponentDefinitionVariableType;
@@ -77,10 +74,7 @@ export const parseComponentProps = ({
           styleProps[propName] = propertyValue.valuesByBreakpoint;
         } else {
           // for custom design props, the value will be resolved with the javascript per breakpoint at runtime
-          customDesignProps[propName] = resolveCustomDesignValue({
-            propertyName: propName,
-            valuesByBreakpoint: propertyValue.valuesByBreakpoint,
-          });
+          customDesignProps[propName] = resolveCustomDesignValue(propertyValue.valuesByBreakpoint);
         }
         break;
       }

--- a/packages/experience-builder-sdk/src/utils/parseComponentProps.ts
+++ b/packages/experience-builder-sdk/src/utils/parseComponentProps.ts
@@ -9,6 +9,7 @@ import {
   ComponentTreeNode,
   DesignValue,
   PrimitiveValue,
+  ResolveDesignValueType,
 } from '@contentful/experiences-core/types';
 import { convertResolvedDesignValuesToMediaQuery } from '../hooks/useMediaQuery';
 import { createStylesheetsForBuiltInStyles } from '../hooks/useMediaQuery';
@@ -35,7 +36,7 @@ export const parseComponentProps = ({
   componentDefinition,
   patternNodeIdsChain,
   node,
-  resolveCustomDesignValue,
+  resolveDesignValue,
   resolveBoundValue,
   resolveHyperlinkValue,
   resolveUnboundValue,
@@ -45,7 +46,7 @@ export const parseComponentProps = ({
   componentDefinition: ComponentDefinition;
   patternNodeIdsChain?: string;
   node: ComponentTreeNode;
-  resolveCustomDesignValue: (valuesByBreakpoint: Record<string, PrimitiveValue>) => PrimitiveValue;
+  resolveDesignValue: ResolveDesignValueType;
   resolveBoundValue: (data: {
     propertyName: string;
     dataType: ComponentDefinitionVariableType;
@@ -74,7 +75,7 @@ export const parseComponentProps = ({
           styleProps[propName] = propertyValue.valuesByBreakpoint;
         } else {
           // for custom design props, the value will be resolved with the javascript per breakpoint at runtime
-          customDesignProps[propName] = resolveCustomDesignValue(propertyValue.valuesByBreakpoint);
+          customDesignProps[propName] = resolveDesignValue(propertyValue.valuesByBreakpoint);
         }
         break;
       }

--- a/packages/visual-editor/src/hooks/useBreakpoints.ts
+++ b/packages/visual-editor/src/hooks/useBreakpoints.ts
@@ -44,7 +44,7 @@ export const useBreakpoints = (breakpoints: Breakpoint[]) => {
   }, [breakpoints]);
 
   const resolveDesignValue: ResolveDesignValueType = useCallback(
-    (valuesByBreakpoint, variableName) => {
+    (valuesByBreakpoint, propertyName) => {
       const fallbackBreakpointIndex = getFallbackBreakpointIndex(breakpoints);
 
       const activeBreakpointIndex = getActiveBreakpointIndex(
@@ -58,7 +58,7 @@ export const useBreakpoints = (breakpoints: Breakpoint[]) => {
         breakpoints,
         activeBreakpointIndex,
         fallbackBreakpointIndex,
-        variableName,
+        propertyName,
       );
     },
     [mediaQueryMatches, breakpoints],

--- a/packages/visual-editor/src/hooks/useComponentProps.ts
+++ b/packages/visual-editor/src/hooks/useComponentProps.ts
@@ -83,7 +83,6 @@ export const useComponentProps = ({
       cfSsrClassName: node.data.props.cfSsrClassName
         ? (resolveDesignValue(
             (node.data.props.cfSsrClassName as DesignValue).valuesByBreakpoint,
-            'cfSsrClassName',
           ) as string)
         : undefined,
     };

--- a/packages/visual-editor/src/hooks/useDropzoneDirection.ts
+++ b/packages/visual-editor/src/hooks/useDropzoneDirection.ts
@@ -37,7 +37,7 @@ export const useDropzoneDirection = ({ resolveDesignValue, node, zoneId }: Param
         return 'vertical';
       }
 
-      const direction = resolveDesignValue(designValues.valuesByBreakpoint, 'cfFlexDirection');
+      const direction = resolveDesignValue(designValues.valuesByBreakpoint);
 
       if (direction === 'row') {
         return 'horizontal';

--- a/packages/visual-editor/src/hooks/useSingleColumn.ts
+++ b/packages/visual-editor/src/hooks/useSingleColumn.ts
@@ -26,7 +26,7 @@ export default function useSingleColumn(
       return false;
     }
 
-    return resolveDesignValue(cfWrapColumns.valuesByBreakpoint, 'cfWrapColumns') as boolean;
+    return resolveDesignValue(cfWrapColumns.valuesByBreakpoint) as boolean;
   }, [tree, node, isSingleColumn, resolveDesignValue]);
 
   return {


### PR DESCRIPTION
## Purpose
I noticed that `resolveDesignValue` required the `variableName` parameter while that was only used in very special cases, i.e. when it's a built-in property that supports design token. 90% of the cases passed explicitly a string that didn't match that condition. In those cases, we can also leave out the ignored parameter.

## Approach
Make the `propertyName` argument optional and adjust all the places that passed a name that had no effect.