### PR TITLE
SPA-2753: split schema between experience and patterns

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45408,7 +45408,28 @@
         "@vitest/coverage-v8": "^2.1.1",
         "typescript": "^5.2.2",
         "vite": "^5.0.8",
+        "vite-tsconfig-paths": "^5.1.4",
         "vitest": "^2.1.1"
+      }
+    },
+    "packages/validators/node_modules/vite-tsconfig-paths": {
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/vite-tsconfig-paths/-/vite-tsconfig-paths-5.1.4.tgz",
+      "integrity": "sha512-cYj0LRuLV2c2sMqhqhGpaO3LretdtMn/BVX4cPLanIZuwwrkVl+lK84E/miEXkCHWXuq65rhNN4rXsBcOB3S4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "globrex": "^0.1.2",
+        "tsconfck": "^3.0.3"
+      },
+      "peerDependencies": {
+        "vite": "*"
+      },
+      "peerDependenciesMeta": {
+        "vite": {
+          "optional": true
+        }
       }
     },
     "packages/visual-editor": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9079,7 +9079,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -14948,9 +14947,10 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.7.7",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.7.tgz",
-      "integrity": "sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.9.0.tgz",
+      "integrity": "sha512-re4CqKTJaURpzbLHtIi6XpDv20/CnpXOtjRY5/CU32L8gU8ek9UIivcfvSWvmKEngmVbrUtPpdDwWDWL7DNHvg==",
+      "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
@@ -17251,17 +17251,50 @@
       }
     },
     "node_modules/contentful-management": {
-      "version": "11.35.1",
-      "resolved": "https://registry.npmjs.org/contentful-management/-/contentful-management-11.35.1.tgz",
-      "integrity": "sha512-PBOFpeOCzwx7+PQtHhgFRNB8wnlgUKUj+3rTucaMIYot5l9YA4804P9VYWq6Mg8/PJnFjavQrtay6HtqWDyYMw==",
+      "version": "11.52.2",
+      "resolved": "https://registry.npmjs.org/contentful-management/-/contentful-management-11.52.2.tgz",
+      "integrity": "sha512-d/7ydc4HOVKNqT789T9hL0fu4i1U1AthjQV+PfJevwZo4JyzNvh2I5wpaJUqV859bJHSNsTfV6gdtLHg9bx0bA==",
+      "license": "MIT",
       "dependencies": {
         "@contentful/rich-text-types": "^16.6.1",
-        "axios": "^1.7.4",
-        "contentful-sdk-core": "^8.3.1",
-        "fast-copy": "^3.0.0"
+        "axios": "^1.8.4",
+        "contentful-sdk-core": "^9.0.1",
+        "fast-copy": "^3.0.0",
+        "globals": "^15.15.0"
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/contentful-management/node_modules/contentful-sdk-core": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/contentful-sdk-core/-/contentful-sdk-core-9.2.0.tgz",
+      "integrity": "sha512-cUvHbC2u8ouJHhG3tofQhUc0FAmM/QBcalYjiczMtFKrR77BW+eSPcPg+A9DQlhIP0UGcQ/knXxoJpBvrERXTA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-copy": "^3.0.2",
+        "lodash": "^4.17.21",
+        "p-throttle": "^6.1.0",
+        "process": "^0.11.10",
+        "qs": "^6.12.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-linux-x64-gnu": "^4.18.0"
+      }
+    },
+    "node_modules/contentful-management/node_modules/p-throttle": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/p-throttle/-/p-throttle-6.2.0.tgz",
+      "integrity": "sha512-NCKkOVj6PZa6NiTmfvGilDdf6vO1rFCD3KDnkHko8dTOtkpk4cSR/VTAhhLMG9aiQ7/A9HYgEDNmxzf6hxzR3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/contentful-resolve-response": {
@@ -23195,10 +23228,10 @@
       }
     },
     "node_modules/globals": {
-      "version": "15.9.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-15.9.0.tgz",
-      "integrity": "sha512-SmSKyLLKFbSr6rptvP8izbyxJL4ILwqO9Jg23UA0sDlGlu58V59D1//I3vlc0KJphVdUR7vMjHIplYnzBxorQA==",
-      "dev": true,
+      "version": "15.15.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-15.15.0.tgz",
+      "integrity": "sha512-7ACyT3wmyp3I61S4fG682L0VA2RGD9otkqGJIwNUMF1SWUombIIk+af1unuDYgMm082aHYwD+mzJvv9Iu8dsgg==",
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       },
@@ -34703,7 +34736,6 @@
       "version": "0.11.10",
       "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
       "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
-      "dev": true,
       "engines": {
         "node": ">= 0.6.0"
       }
@@ -45406,6 +45438,7 @@
       },
       "devDependencies": {
         "@vitest/coverage-v8": "^2.1.1",
+        "contentful-management": "^11.52.2",
         "typescript": "^5.2.2",
         "vite": "^5.0.8",
         "vite-tsconfig-paths": "^5.1.4",

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -357,6 +357,8 @@ export type ExperienceEntry = {
   metadata: Entry['metadata'];
 };
 
+export type { Entry } from 'contentful';
+
 export interface RawCoordinates {
   left: number;
   top: number;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,6 +1,6 @@
 import type { Asset, AssetFile, ChainModifiers, Entry } from 'contentful';
 import { SCROLL_STATES, OUTGOING_EVENTS, INCOMING_EVENTS, INTERNAL_EVENTS } from '@/constants';
-import { EntityStore } from './entity/EntityStore';
+import { EntityStore } from '@/entity';
 import { Document as RichTextDocument } from '@contentful/rich-text-types';
 
 // Types for experience entry fields (as fetched in the API) are inferred by Zod schema in `@contentful/experiences-validators`
@@ -356,8 +356,6 @@ export type ExperienceEntry = {
   fields: ExperienceFields;
   metadata: Entry['metadata'];
 };
-
-export type { Entry } from 'contentful';
 
 export interface RawCoordinates {
   left: number;

--- a/packages/validators/package.json
+++ b/packages/validators/package.json
@@ -42,6 +42,7 @@
     "@vitest/coverage-v8": "^2.1.1",
     "typescript": "^5.2.2",
     "vite": "^5.0.8",
+    "vite-tsconfig-paths": "^5.1.4",
     "vitest": "^2.1.1"
   },
   "dependencies": {

--- a/packages/validators/package.json
+++ b/packages/validators/package.json
@@ -40,6 +40,7 @@
   },
   "devDependencies": {
     "@vitest/coverage-v8": "^2.1.1",
+    "contentful-management": "^11.52.2",
     "typescript": "^5.2.2",
     "vite": "^5.0.8",
     "vite-tsconfig-paths": "^5.1.4",

--- a/packages/validators/src/schemas/componentDefinition.ts
+++ b/packages/validators/src/schemas/componentDefinition.ts
@@ -1,10 +1,10 @@
 import { z } from 'zod';
+import { ComponentVariableSchema } from './v2023_09_28/experience';
 import {
-  ComponentVariableSchema,
   DefinitionPropertyKeySchema,
   DefinitionPropertyTypeSchema,
   PrimitiveValueSchema,
-} from './v2023_09_28/experience';
+} from './v2023_09_28/common';
 
 export const ComponentDefinitionSchema = z.object({
   id: DefinitionPropertyKeySchema,

--- a/packages/validators/src/schemas/componentDefinition.ts
+++ b/packages/validators/src/schemas/componentDefinition.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
-import { ComponentVariableSchema } from './v2023_09_28/experience';
 import {
+  ComponentVariableSchema,
   DefinitionPropertyKeySchema,
   DefinitionPropertyTypeSchema,
   PrimitiveValueSchema,

--- a/packages/validators/src/schemas/index.ts
+++ b/packages/validators/src/schemas/index.ts
@@ -1,10 +1,10 @@
 export {
   BindingSourceTypeEnum,
-  VariableMapping,
   ExperienceFieldsCMAShapeSchema as ExperienceSchema_2023_09_28,
 } from './v2023_09_28/experience';
 export {
   PatternFieldsCMAShapeSchema as PatternSchema_2023_09_28,
   type PatternPropertyDefinition,
+  VariableMapping,
 } from './v2023_09_28/pattern';
 export { ComponentDefinitionSchema } from './componentDefinition';

--- a/packages/validators/src/schemas/index.ts
+++ b/packages/validators/src/schemas/index.ts
@@ -1,8 +1,10 @@
 export {
   BindingSourceTypeEnum,
-  PatternProperty,
-  PatternPropertyDefinition,
   VariableMapping,
-  ExperienceFieldsCMAShapeSchema as Schema_2023_09_28,
+  ExperienceFieldsCMAShapeSchema as ExperienceSchema_2023_09_28,
 } from './v2023_09_28/experience';
+export {
+  PatternFieldsCMAShapeSchema as PatternSchema_2023_09_28,
+  type PatternPropertyDefinition,
+} from './v2023_09_28/pattern';
 export { ComponentDefinitionSchema } from './componentDefinition';

--- a/packages/validators/src/schemas/latest.ts
+++ b/packages/validators/src/schemas/latest.ts
@@ -5,9 +5,16 @@ export { ComponentPropertyValue } from '@/schemas/v2023_09_28/common';
 export { PatternPropertySchema } from '@/schemas/v2023_09_28/common';
 export { PatternPropertiesSchema } from '@/schemas/v2023_09_28/common';
 export { BreakpointSchema } from '@/schemas/v2023_09_28/common';
-export { BaseComponentTreeNodeSchema } from '@/schemas/v2023_09_28/common';
 export { ComponentTreeNode } from '@/schemas/v2023_09_28/common';
 export { ComponentVariableSchema } from '@/schemas/v2023_09_28/common';
 export { ComponentTreeNodeSchema } from '@/schemas/v2023_09_28/common';
 export { ComponentTreeSchema } from '@/schemas/v2023_09_28/common';
 export { localeWrapper } from '@/schemas/v2023_09_28/common';
+export {
+  /**
+   * @deprecated Use `PatternComponentSettings` instead. This will be removed in the next major version
+   */
+  PatternComponentSettings as ExperienceComponentSettings,
+  PatternComponentSettings,
+  VariableMapping,
+} from './v2023_09_28/pattern';

--- a/packages/validators/src/schemas/latest.ts
+++ b/packages/validators/src/schemas/latest.ts
@@ -1,1 +1,2 @@
 export * from './v2023_09_28/experience';
+export { PatternFields } from './v2023_09_28/pattern';

--- a/packages/validators/src/schemas/latest.ts
+++ b/packages/validators/src/schemas/latest.ts
@@ -1,2 +1,13 @@
 export * from './v2023_09_28/experience';
 export { PatternFields } from './v2023_09_28/pattern';
+export { ComponentPropertyValueSchema } from '@/schemas/v2023_09_28/common';
+export { ComponentPropertyValue } from '@/schemas/v2023_09_28/common';
+export { PatternPropertySchema } from '@/schemas/v2023_09_28/common';
+export { PatternPropertiesSchema } from '@/schemas/v2023_09_28/common';
+export { BreakpointSchema } from '@/schemas/v2023_09_28/common';
+export { BaseComponentTreeNodeSchema } from '@/schemas/v2023_09_28/common';
+export { ComponentTreeNode } from '@/schemas/v2023_09_28/common';
+export { ComponentVariableSchema } from '@/schemas/v2023_09_28/common';
+export { ComponentTreeNodeSchema } from '@/schemas/v2023_09_28/common';
+export { ComponentTreeSchema } from '@/schemas/v2023_09_28/common';
+export { localeWrapper } from '@/schemas/v2023_09_28/common';

--- a/packages/validators/src/schemas/v2023_09_28/common.ts
+++ b/packages/validators/src/schemas/v2023_09_28/common.ts
@@ -1,0 +1,164 @@
+import { z } from 'zod';
+import { Breakpoint } from '@/schemas/v2023_09_28/experience';
+
+export const DefinitionPropertyTypeSchema = z.enum([
+  'Text',
+  'RichText',
+  'Number',
+  'Date',
+  'Boolean',
+  'Location',
+  'Media',
+  'Object',
+  'Hyperlink',
+  'Array',
+  'Link',
+]);
+
+export const DefinitionPropertyKeySchema = z
+  .string()
+  .regex(/^[a-zA-Z0-9-_]{1,32}$/, { message: 'Property needs to match: /^[a-zA-Z0-9-_]{1,32}$/' });
+
+export const PrimitiveValueSchema = z.union([
+  z.string(),
+  z.boolean(),
+  z.number(),
+  z.record(z.any(), z.any()),
+  z.undefined(),
+]);
+
+export const UsedComponentsSchema = z.array(
+  z.object({
+    sys: z.object({
+      type: z.literal('Link'),
+      id: z.string(),
+      linkType: z.literal('Entry'),
+    }),
+  }),
+);
+
+export const uuidKeySchema = z
+  .string()
+  .regex(/^[a-zA-Z0-9-_]{1,21}$/, { message: 'Does not match /^[a-zA-Z0-9-_]{1,21}$/' });
+
+export const DataSourceSchema = z.record(
+  uuidKeySchema,
+  z.object({
+    sys: z.object({
+      type: z.literal('Link'),
+      id: z.string(),
+      linkType: z.enum(['Entry', 'Asset']),
+    }),
+  }),
+);
+
+export const UnboundValuesSchema = z.record(
+  uuidKeySchema,
+  z.object({
+    value: PrimitiveValueSchema,
+  }),
+);
+
+/**
+ * Property keys for imported components have a limit of 32 characters (to be implemented) while
+ * property keys for patterns have a limit of 54 characters (<32-char-variable-name>_<21-char-nanoid-id>).
+ * Because we cannot distinguish between the two in the componentTree, we will use the larger limit for both.
+ */
+export const propertyKeySchema = z
+  .string()
+  .regex(/^[a-zA-Z0-9-_]{1,54}$/, { message: 'Does not match /^[a-zA-Z0-9-_]{1,54}$/' });
+
+export const ComponentTreeNodeIdSchema = z
+  .string()
+  .regex(/^[a-zA-Z0-9]{1,8}$/, { message: 'Does not match /^[a-zA-Z0-9]{1,8}$/' });
+
+export const breakpointsRefinement = (value: Breakpoint[], ctx: z.RefinementCtx) => {
+  if (!value.length || value[0].query !== '*') {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: `The first breakpoint should include the following attributes: { "query": "*" }`,
+    });
+  }
+
+  const hasDuplicateIds = value.some((currentBreakpoint, currentBreakpointIndex) => {
+    // check if the current breakpoint id is found in the rest of the array
+    const breakpointIndex = value.findIndex((breakpoint) => breakpoint.id === currentBreakpoint.id);
+    return breakpointIndex !== currentBreakpointIndex;
+  });
+
+  if (hasDuplicateIds) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: `Breakpoint IDs must be unique`,
+    });
+  }
+
+  // Extract the queries boundary by removing the special characters around it
+  const queries = value.map((bp) =>
+    bp.query === '*' ? bp.query : parseInt(bp.query.replace(/px|<|>/, '')),
+  );
+
+  // sort updates queries array in place so we need to create a copy
+  const originalQueries = [...queries];
+  queries.sort((q1, q2) => {
+    if (q1 === '*') {
+      return -1;
+    }
+    if (q2 === '*') {
+      return 1;
+    }
+    return q1 > q2 ? -1 : 1;
+  });
+
+  if (originalQueries.join('') !== queries.join('')) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: `Breakpoints should be ordered from largest to smallest pixel value`,
+    });
+  }
+};
+
+export const ValuesByBreakpointSchema = z.record(z.lazy(() => PrimitiveValueSchema));
+
+export const BindingSourceTypeEnumSchema = z
+  .array(z.enum(['entry', 'asset', 'manual', 'experience']))
+  .nonempty();
+
+export const DesignValueSchema = z
+  .object({
+    type: z.literal('DesignValue'),
+    valuesByBreakpoint: ValuesByBreakpointSchema,
+  })
+  .strict();
+
+export const BoundValueSchema = z
+  .object({
+    type: z.literal('BoundValue'),
+    path: z.string(),
+  })
+  .strict();
+
+export const HyperlinkValueSchema = z
+  .object({
+    type: z.literal('HyperlinkValue'),
+    linkTargetKey: z.string(),
+    /** Allows to override parts of the URL, e.g. the locale */
+    overrides: z.object({}).optional(),
+  })
+  .strict();
+
+export const UnboundValueSchema = z
+  .object({
+    type: z.literal('UnboundValue'),
+    key: z.string(),
+  })
+  .strict();
+
+export const ComponentValueSchema = z
+  .object({
+    type: z.literal('ComponentValue'),
+    key: z.string(),
+  })
+  .strict();
+
+export const NoValueSchema = z.object({ type: z.literal('NoValue') }).strict();

--- a/packages/validators/src/schemas/v2023_09_28/common.ts
+++ b/packages/validators/src/schemas/v2023_09_28/common.ts
@@ -196,7 +196,7 @@ export const BreakpointSchema = z
   .strict();
 
 // Use helper schema to define a recursive schema with its type correctly below
-export const BaseComponentTreeNodeSchema = z.object({
+const BaseComponentTreeNodeSchema = z.object({
   id: ComponentTreeNodeIdSchema.optional(),
   definitionId: DefinitionPropertyKeySchema,
   displayName: z.string().optional(),

--- a/packages/validators/src/schemas/v2023_09_28/experience.ts
+++ b/packages/validators/src/schemas/v2023_09_28/experience.ts
@@ -43,10 +43,3 @@ export type ComponentValue = z.infer<typeof ComponentValueSchema>;
 export type BindingSourceTypeEnum = z.infer<typeof BindingSourceTypeEnumSchema>;
 export type PatternProperty = z.infer<typeof PatternPropertySchema>;
 export { breakpointsRefinement };
-
-// Re-exports for compatibility. Remove when no longer needed
-export { PATTERN_THUMBNAIL_IDS } from './pattern'; // re-export for compatibility
-export type {
-  VariableMapping,
-  PatternComponentSettings as ExperienceComponentSettings,
-} from './pattern';

--- a/packages/validators/src/schemas/v2023_09_28/experience.ts
+++ b/packages/validators/src/schemas/v2023_09_28/experience.ts
@@ -1,104 +1,23 @@
-import { z, ZodTypeAny } from 'zod';
-import { SchemaVersions } from '../schemaVersions';
+import { z } from 'zod';
 import {
   BindingSourceTypeEnumSchema,
   BoundValueSchema,
+  BreakpointSchema,
   breakpointsRefinement,
-  ComponentTreeNodeIdSchema,
+  ComponentTreeSchema,
   ComponentValueSchema,
   DataSourceSchema,
-  DefinitionPropertyKeySchema,
-  DefinitionPropertyTypeSchema,
   DesignValueSchema,
   HyperlinkValueSchema,
+  localeWrapper,
   NoValueSchema,
+  PatternPropertySchema,
   PrimitiveValueSchema,
-  propertyKeySchema,
   UnboundValueSchema,
   UnboundValuesSchema,
   UsedComponentsSchema,
   ValuesByBreakpointSchema,
 } from './common';
-
-const ComponentPropertyValueSchema = z.discriminatedUnion('type', [
-  DesignValueSchema,
-  BoundValueSchema,
-  UnboundValueSchema,
-  HyperlinkValueSchema,
-  ComponentValueSchema,
-  NoValueSchema,
-]);
-
-export type ComponentPropertyValue = z.infer<typeof ComponentPropertyValueSchema>;
-
-// TODO: finalize schema structure before release
-// https://contentful.atlassian.net/browse/LUMOS-523
-const PatternPropertySchema = z.object({
-  type: z.literal('BoundValue'),
-  path: z.string(),
-  contentType: z.string(),
-});
-
-export const PatternPropertiesSchema = z.record(propertyKeySchema, PatternPropertySchema);
-
-export const BreakpointSchema = z
-  .object({
-    id: propertyKeySchema,
-    query: z.string().regex(/^\*$|^<[0-9*]+px$/),
-    previewSize: z.string(),
-    displayName: z.string(),
-    displayIcon: z.enum(['desktop', 'tablet', 'mobile']).optional(),
-  })
-  .strict();
-
-// Use helper schema to define a recursive schema with its type correctly below
-const BaseComponentTreeNodeSchema = z.object({
-  id: ComponentTreeNodeIdSchema.optional(),
-  definitionId: DefinitionPropertyKeySchema,
-  displayName: z.string().optional(),
-  slotId: z.string().optional(),
-  variables: z.record(propertyKeySchema, ComponentPropertyValueSchema),
-  patternProperties: PatternPropertiesSchema.optional(),
-});
-export type ComponentTreeNode = z.infer<typeof BaseComponentTreeNodeSchema> & {
-  children: ComponentTreeNode[];
-};
-const ComponentTreeNodeSchema: z.ZodType<ComponentTreeNode> = BaseComponentTreeNodeSchema.extend({
-  children: z.lazy(() => ComponentTreeNodeSchema.array()),
-});
-
-export const ComponentVariableSchema = z.object({
-  displayName: z.string().optional(),
-  type: DefinitionPropertyTypeSchema,
-  description: z.string().optional(),
-  group: z.string().optional(),
-  defaultValue: PrimitiveValueSchema.or(ComponentPropertyValueSchema).optional(),
-  validations: z
-    .object({
-      bindingSourceType: BindingSourceTypeEnumSchema.optional(),
-      required: z.boolean().optional(),
-      format: z.literal('URL').optional(),
-      in: z
-        .array(
-          z.object({
-            value: z.union([z.string(), z.number()]),
-            displayName: z.string().optional(),
-          }),
-        )
-        .optional(),
-    })
-    .optional(),
-});
-
-export const ComponentTreeSchema = z
-  .object({
-    breakpoints: z.array(BreakpointSchema).superRefine(breakpointsRefinement),
-    children: z.array(ComponentTreeNodeSchema),
-    schemaVersion: SchemaVersions,
-  })
-  .strict();
-
-const localeWrapper = (fieldSchema: ZodTypeAny) => z.record(z.string(), fieldSchema);
 
 export const ExperienceFieldsCMAShapeSchema = z.object({
   componentTree: localeWrapper(ComponentTreeSchema),

--- a/packages/validators/src/schemas/v2023_09_28/experience.ts
+++ b/packages/validators/src/schemas/v2023_09_28/experience.ts
@@ -1,94 +1,24 @@
-import { z } from 'zod';
+import { z, ZodTypeAny } from 'zod';
 import { SchemaVersions } from '../schemaVersions';
-
-export const DefinitionPropertyTypeSchema = z.enum([
-  'Text',
-  'RichText',
-  'Number',
-  'Date',
-  'Boolean',
-  'Location',
-  'Media',
-  'Object',
-  'Hyperlink',
-  'Array',
-  'Link',
-]);
-
-export const DefinitionPropertyKeySchema = z
-  .string()
-  .regex(/^[a-zA-Z0-9-_]{1,32}$/, { message: 'Property needs to match: /^[a-zA-Z0-9-_]{1,32}$/' });
-
-export const PrimitiveValueSchema = z.union([
-  z.string(),
-  z.boolean(),
-  z.number(),
-  z.record(z.any(), z.any()),
-  z.undefined(),
-]);
-
-const uuidKeySchema = z
-  .string()
-  .regex(/^[a-zA-Z0-9-_]{1,21}$/, { message: 'Does not match /^[a-zA-Z0-9-_]{1,21}$/' });
-
-/**
- * Property keys for imported components have a limit of 32 characters (to be implemented) while
- * property keys for patterns have a limit of 54 characters (<32-char-variabl-name>_<21-char-nanoid-id>).
- * Because we cannot distinguish between the two in the componentTree, we will use the larger limit for both.
- */
-const propertyKeySchema = z
-  .string()
-  .regex(/^[a-zA-Z0-9-_]{1,54}$/, { message: 'Does not match /^[a-zA-Z0-9-_]{1,54}$/' });
-
-const DataSourceSchema = z.record(
-  uuidKeySchema,
-  z.object({
-    sys: z.object({
-      type: z.literal('Link'),
-      id: z.string(),
-      linkType: z.enum(['Entry', 'Asset']),
-    }),
-  }),
-);
-
-const ValuesByBreakpointSchema = z.record(z.lazy(() => PrimitiveValueSchema));
-
-const DesignValueSchema = z
-  .object({
-    type: z.literal('DesignValue'),
-    valuesByBreakpoint: ValuesByBreakpointSchema,
-  })
-  .strict();
-const BoundValueSchema = z
-  .object({
-    type: z.literal('BoundValue'),
-    path: z.string(),
-  })
-  .strict();
-const HyperlinkValueSchema = z
-  .object({
-    type: z.literal('HyperlinkValue'),
-    linkTargetKey: z.string(),
-    /** Allows to override parts of the URL, e.g. the locale */
-    overrides: z.object({}).optional(),
-  })
-  .strict();
-const UnboundValueSchema = z
-  .object({
-    type: z.literal('UnboundValue'),
-    key: z.string(),
-  })
-  .strict();
-const ComponentValueSchema = z
-  .object({
-    type: z.literal('ComponentValue'),
-    key: z.string(),
-  })
-  .strict();
-
-// TODO: finalize schema structure before release
-// https://contentful.atlassian.net/browse/LUMOS-523
-const NoValueSchema = z.object({ type: z.literal('NoValue') }).strict();
+import {
+  BindingSourceTypeEnumSchema,
+  BoundValueSchema,
+  breakpointsRefinement,
+  ComponentTreeNodeIdSchema,
+  ComponentValueSchema,
+  DataSourceSchema,
+  DefinitionPropertyKeySchema,
+  DefinitionPropertyTypeSchema,
+  DesignValueSchema,
+  HyperlinkValueSchema,
+  NoValueSchema,
+  PrimitiveValueSchema,
+  propertyKeySchema,
+  UnboundValueSchema,
+  UnboundValuesSchema,
+  UsedComponentsSchema,
+  ValuesByBreakpointSchema,
+} from './common';
 
 const ComponentPropertyValueSchema = z.discriminatedUnion('type', [
   DesignValueSchema,
@@ -103,55 +33,13 @@ export type ComponentPropertyValue = z.infer<typeof ComponentPropertyValueSchema
 
 // TODO: finalize schema structure before release
 // https://contentful.atlassian.net/browse/LUMOS-523
-const VariableMappingSchema = z.object({
-  patternPropertyDefinitionId: propertyKeySchema,
-  type: z.literal('ContentTypeMapping'),
-  pathsByContentType: z.record(z.string(), z.object({ path: z.string() })),
-});
-
-const VariableMappingsSchema = z.record(propertyKeySchema, VariableMappingSchema);
-
-// TODO: finalize schema structure before release
-// https://contentful.atlassian.net/browse/LUMOS-523
-const PatternPropertyDefinitionSchema = z.object({
-  defaultValue: z
-    .record(
-      z.string(),
-      z.object({
-        sys: z.object({
-          type: z.literal('Link'),
-          id: z.string(),
-          linkType: z.enum(['Entry']),
-        }),
-      }),
-    )
-    .optional(),
-  contentTypes: z.record(
-    z.string(),
-    z.object({
-      sys: z.object({
-        type: z.literal('Link'),
-        id: z.string(),
-        linkType: z.enum(['ContentType']),
-      }),
-    }),
-  ),
-});
-
-const PatternPropertyDefinitionsSchema = z.record(
-  propertyKeySchema,
-  PatternPropertyDefinitionSchema,
-);
-
-// TODO: finalize schema structure before release
-// https://contentful.atlassian.net/browse/LUMOS-523
 const PatternPropertySchema = z.object({
   type: z.literal('BoundValue'),
   path: z.string(),
   contentType: z.string(),
 });
 
-const PatternPropertysSchema = z.record(propertyKeySchema, PatternPropertySchema);
+export const PatternPropertiesSchema = z.record(propertyKeySchema, PatternPropertySchema);
 
 export const BreakpointSchema = z
   .object({
@@ -163,17 +51,6 @@ export const BreakpointSchema = z
   })
   .strict();
 
-const UnboundValuesSchema = z.record(
-  uuidKeySchema,
-  z.object({
-    value: PrimitiveValueSchema,
-  }),
-);
-
-export const ComponentTreeNodeIdSchema = z
-  .string()
-  .regex(/^[a-zA-Z0-9]{1,8}$/, { message: 'Does not match /^[a-zA-Z0-9]{1,8}$/' });
-
 // Use helper schema to define a recursive schema with its type correctly below
 const BaseComponentTreeNodeSchema = z.object({
   id: ComponentTreeNodeIdSchema.optional(),
@@ -181,7 +58,7 @@ const BaseComponentTreeNodeSchema = z.object({
   displayName: z.string().optional(),
   slotId: z.string().optional(),
   variables: z.record(propertyKeySchema, ComponentPropertyValueSchema),
-  patternProperties: PatternPropertysSchema.optional(),
+  patternProperties: PatternPropertiesSchema.optional(),
 });
 export type ComponentTreeNode = z.infer<typeof BaseComponentTreeNodeSchema> & {
   children: ComponentTreeNode[];
@@ -189,10 +66,6 @@ export type ComponentTreeNode = z.infer<typeof BaseComponentTreeNodeSchema> & {
 const ComponentTreeNodeSchema: z.ZodType<ComponentTreeNode> = BaseComponentTreeNodeSchema.extend({
   children: z.lazy(() => ComponentTreeNodeSchema.array()),
 });
-
-const BindingSourceTypeEnumSchema = z
-  .array(z.enum(['entry', 'asset', 'manual', 'experience']))
-  .nonempty();
 
 export const ComponentVariableSchema = z.object({
   displayName: z.string().optional(),
@@ -217,100 +90,7 @@ export const ComponentVariableSchema = z.object({
     .optional(),
 });
 
-export const ComponentVariablesSchema = z.record(
-  z.string().regex(/^[a-zA-Z0-9-_]{1,54}$/), // Here the key is <variableName>_<nanoidId> so we need to allow for a longer length
-  ComponentVariableSchema,
-);
-
-const THUMBNAIL_IDS = [
-  'columns',
-  'columnsPlusRight',
-  'imagesSquare',
-  'subtitles',
-  'rowsPlusBottom',
-  'userRectangle',
-  'textbox',
-  'monitorPlay',
-  'article',
-  'table',
-  'star',
-  'heartStraight',
-  'frameCorners',
-  'rows',
-  'dotsThreeOutline',
-  'listDashes',
-  'checkerBoard',
-  'gridFour',
-  'slideshow',
-  'diamondsFour',
-  'cards',
-  'textColumns',
-  'duplex',
-] as const;
-
-const ComponentSettingsSchema = z.object({
-  variableDefinitions: ComponentVariablesSchema,
-  thumbnailId: z.enum(THUMBNAIL_IDS).optional(),
-  category: z.string().max(50, 'Category must contain at most 50 characters').optional(),
-  variableMappings: VariableMappingsSchema.optional(),
-  patternPropertyDefinitions: PatternPropertyDefinitionsSchema.optional(),
-});
-
-const UsedComponentsSchema = z.array(
-  z.object({
-    sys: z.object({
-      type: z.literal('Link'),
-      id: z.string(),
-      linkType: z.literal('Entry'),
-    }),
-  }),
-);
-
-export const breakpointsRefinement = (value: Breakpoint[], ctx: z.RefinementCtx) => {
-  if (!value.length || value[0].query !== '*') {
-    ctx.addIssue({
-      code: z.ZodIssueCode.custom,
-      message: `The first breakpoint should include the following attributes: { "query": "*" }`,
-    });
-  }
-
-  const hasDuplicateIds = value.some((currentBreakpoint, currentBreakpointIndex) => {
-    // check if the current breakpoint id is found in the rest of the array
-    const breakpointIndex = value.findIndex((breakpoint) => breakpoint.id === currentBreakpoint.id);
-    return breakpointIndex !== currentBreakpointIndex;
-  });
-
-  if (hasDuplicateIds) {
-    ctx.addIssue({
-      code: z.ZodIssueCode.custom,
-      message: `Breakpoint IDs must be unique`,
-    });
-  }
-  // Extract the queries boundary by removing the special characters around it
-  const queries = value.map((bp) =>
-    bp.query === '*' ? bp.query : parseInt(bp.query.replace(/px|<|>/, '')),
-  );
-  // sort updates queries array in place so we need to create a copy
-  const originalQueries = [...queries];
-  queries.sort((q1, q2) => {
-    if (q1 === '*') {
-      return -1;
-    }
-    if (q2 === '*') {
-      return 1;
-    }
-    return q1 > q2 ? -1 : 1;
-  });
-
-  if (originalQueries.join('') !== queries.join('')) {
-    ctx.addIssue({
-      code: z.ZodIssueCode.custom,
-      message: `Breakpoints should be ordered from largest to smallest pixel value`,
-    });
-  }
-};
-
-const ComponentTreeSchema = z
+export const ComponentTreeSchema = z
   .object({
     breakpoints: z.array(BreakpointSchema).superRefine(breakpointsRefinement),
     children: z.array(ComponentTreeNodeSchema),
@@ -318,23 +98,19 @@ const ComponentTreeSchema = z
   })
   .strict();
 
-const localeWrapper = (fieldSchema: any) => z.record(z.string(), fieldSchema);
+const localeWrapper = (fieldSchema: ZodTypeAny) => z.record(z.string(), fieldSchema);
 
 export const ExperienceFieldsCMAShapeSchema = z.object({
   componentTree: localeWrapper(ComponentTreeSchema),
   dataSource: localeWrapper(DataSourceSchema),
   unboundValues: localeWrapper(UnboundValuesSchema),
   usedComponents: localeWrapper(UsedComponentsSchema).optional(),
-  componentSettings: localeWrapper(ComponentSettingsSchema).optional(),
 });
-
-export { THUMBNAIL_IDS as PATTERN_THUMBNAIL_IDS };
 
 export type ExperienceFields = z.infer<typeof ExperienceFieldsCMAShapeSchema>;
 export type ExperienceDataSource = z.infer<typeof DataSourceSchema>;
 export type ExperienceUnboundValues = z.infer<typeof UnboundValuesSchema>;
 export type ExperienceUsedComponents = z.infer<typeof UsedComponentsSchema>;
-export type ExperienceComponentSettings = z.infer<typeof ComponentSettingsSchema>;
 export type ExperienceComponentTree = z.infer<typeof ComponentTreeSchema>;
 export type ValuesByBreakpoint = z.infer<typeof ValuesByBreakpointSchema>;
 export type Breakpoint = z.infer<typeof BreakpointSchema>;
@@ -346,6 +122,11 @@ export type UnboundValue = z.infer<typeof UnboundValueSchema>;
 export type HyperlinkValue = z.infer<typeof HyperlinkValueSchema>;
 export type ComponentValue = z.infer<typeof ComponentValueSchema>;
 export type BindingSourceTypeEnum = z.infer<typeof BindingSourceTypeEnumSchema>;
-export type PatternPropertyDefinition = z.infer<typeof PatternPropertyDefinitionSchema>;
 export type PatternProperty = z.infer<typeof PatternPropertySchema>;
-export type VariableMapping = z.infer<typeof VariableMappingSchema>;
+
+// Re-exports for compatibility. Remove when no longer needed
+export { PATTERN_THUMBNAIL_IDS } from './pattern'; // re-export for compatibility
+export type {
+  VariableMapping,
+  PatternComponentSettings as ExperienceComponentSettings,
+} from './pattern';

--- a/packages/validators/src/schemas/v2023_09_28/experience.ts
+++ b/packages/validators/src/schemas/v2023_09_28/experience.ts
@@ -123,6 +123,7 @@ export type HyperlinkValue = z.infer<typeof HyperlinkValueSchema>;
 export type ComponentValue = z.infer<typeof ComponentValueSchema>;
 export type BindingSourceTypeEnum = z.infer<typeof BindingSourceTypeEnumSchema>;
 export type PatternProperty = z.infer<typeof PatternPropertySchema>;
+export { breakpointsRefinement };
 
 // Re-exports for compatibility. Remove when no longer needed
 export { PATTERN_THUMBNAIL_IDS } from './pattern'; // re-export for compatibility

--- a/packages/validators/src/schemas/v2023_09_28/pattern.ts
+++ b/packages/validators/src/schemas/v2023_09_28/pattern.ts
@@ -1,0 +1,193 @@
+import { z, ZodTypeAny } from 'zod';
+import {
+  BindingSourceTypeEnumSchema,
+  BoundValueSchema,
+  breakpointsRefinement,
+  ComponentTreeNodeIdSchema,
+  ComponentValueSchema,
+  DataSourceSchema,
+  DefinitionPropertyKeySchema,
+  DefinitionPropertyTypeSchema,
+  DesignValueSchema,
+  HyperlinkValueSchema,
+  NoValueSchema,
+  PrimitiveValueSchema,
+  UnboundValueSchema,
+  UnboundValuesSchema,
+  UsedComponentsSchema,
+} from '../v2023_09_28/common';
+import { SchemaVersions } from '@/schemas/schemaVersions';
+
+/**
+ * Property keys for patterns have a limit of 54 characters (<32-char-variable-name>_<21-char-nanoid-id>).
+ */
+const propertyKeySchema = z
+  .string()
+  .regex(/^[a-zA-Z0-9-_]{1,54}$/, { message: 'Does not match /^[a-zA-Z0-9-_]{1,54}$/' });
+
+const THUMBNAIL_IDS = [
+  'columns',
+  'columnsPlusRight',
+  'imagesSquare',
+  'subtitles',
+  'rowsPlusBottom',
+  'userRectangle',
+  'textbox',
+  'monitorPlay',
+  'article',
+  'table',
+  'star',
+  'heartStraight',
+  'frameCorners',
+  'rows',
+  'dotsThreeOutline',
+  'listDashes',
+  'checkerBoard',
+  'gridFour',
+  'slideshow',
+  'diamondsFour',
+  'cards',
+  'textColumns',
+  'duplex',
+] as const;
+
+// TODO: finalize schema structure before release
+// https://contentful.atlassian.net/browse/LUMOS-523
+export const PatternPropertySchema = z.object({
+  type: z.literal('BoundValue'),
+  path: z.string(),
+  contentType: z.string(),
+});
+
+// TODO: finalize schema structure before release
+// https://contentful.atlassian.net/browse/LUMOS-523
+const VariableMappingSchema = z.object({
+  patternPropertyDefinitionId: propertyKeySchema,
+  type: z.literal('ContentTypeMapping'),
+  pathsByContentType: z.record(z.string(), z.object({ path: z.string() })),
+});
+
+// TODO: finalize schema structure before release
+// https://contentful.atlassian.net/browse/LUMOS-523
+const PatternPropertyDefinitionSchema = z.object({
+  defaultValue: z
+    .record(
+      z.string(),
+      z.object({
+        sys: z.object({
+          type: z.literal('Link'),
+          id: z.string(),
+          linkType: z.enum(['Entry']),
+        }),
+      }),
+    )
+    .optional(),
+  contentTypes: z.record(z.string(), z.any()),
+});
+
+export const PatternPropertyDefinitionsSchema = z.record(
+  propertyKeySchema,
+  PatternPropertyDefinitionSchema,
+);
+
+const localeWrapper = (fieldSchema: ZodTypeAny) => z.record(z.string(), fieldSchema);
+const VariableMappingsSchema = z.record(propertyKeySchema, VariableMappingSchema);
+
+const ComponentPropertyValueSchema = z.discriminatedUnion('type', [
+  DesignValueSchema,
+  BoundValueSchema,
+  UnboundValueSchema,
+  HyperlinkValueSchema,
+  ComponentValueSchema,
+  NoValueSchema,
+]);
+
+export const ComponentVariableSchema = z.object({
+  displayName: z.string().optional(),
+  type: DefinitionPropertyTypeSchema,
+  description: z.string().optional(),
+  group: z.string().optional(),
+  defaultValue: PrimitiveValueSchema.or(ComponentPropertyValueSchema).optional(),
+  validations: z
+    .object({
+      bindingSourceType: BindingSourceTypeEnumSchema.optional(),
+      required: z.boolean().optional(),
+      format: z.literal('URL').optional(),
+      in: z
+        .array(
+          z.object({
+            value: z.union([z.string(), z.number()]),
+            displayName: z.string().optional(),
+          }),
+        )
+        .optional(),
+    })
+    .optional(),
+});
+
+export const PatternPropertiesSchema = z.record(propertyKeySchema, PatternPropertySchema);
+
+// Use helper schema to define a recursive schema with its type correctly below
+const BaseComponentTreeNodeSchema = z.object({
+  id: ComponentTreeNodeIdSchema.optional(),
+  definitionId: DefinitionPropertyKeySchema,
+  displayName: z.string().optional(),
+  slotId: z.string().optional(),
+  variables: z.record(propertyKeySchema, ComponentPropertyValueSchema),
+  patternProperties: PatternPropertiesSchema.optional(),
+});
+
+export type ComponentTreeNode = z.infer<typeof BaseComponentTreeNodeSchema> & {
+  children: ComponentTreeNode[];
+};
+
+const ComponentTreeNodeSchema: z.ZodType<ComponentTreeNode> = BaseComponentTreeNodeSchema.extend({
+  children: z.lazy(() => ComponentTreeNodeSchema.array()),
+});
+
+export const BreakpointSchema = z
+  .object({
+    id: propertyKeySchema,
+    query: z.string().regex(/^\*$|^<[0-9*]+px$/),
+    previewSize: z.string(),
+    displayName: z.string(),
+    displayIcon: z.enum(['desktop', 'tablet', 'mobile']).optional(),
+  })
+  .strict();
+
+export const ComponentTreeSchema = z
+  .object({
+    breakpoints: z.array(BreakpointSchema).superRefine(breakpointsRefinement),
+    children: z.array(ComponentTreeNodeSchema),
+    schemaVersion: SchemaVersions,
+  })
+  .strict();
+
+export const ComponentVariablesSchema = z.record(
+  z.string().regex(/^[a-zA-Z0-9-_]{1,54}$/), // Here the key is <variableName>_<nanoidId> so we need to allow for a longer length
+  ComponentVariableSchema,
+);
+
+const ComponentSettingsSchema = z.object({
+  variableDefinitions: ComponentVariablesSchema,
+  thumbnailId: z.enum(THUMBNAIL_IDS).optional(),
+  category: z.string().max(50, 'Category must contain at most 50 characters').optional(),
+  variableMappings: VariableMappingsSchema.optional(),
+  patternPropertyDefinitions: PatternPropertyDefinitionsSchema.optional(),
+});
+
+// export const PatternFieldsCMAShapeSchema = ExperienceFieldsCMAShapeSchema;
+export const PatternFieldsCMAShapeSchema = z.object({
+  componentTree: localeWrapper(ComponentTreeSchema),
+  dataSource: localeWrapper(DataSourceSchema),
+  unboundValues: localeWrapper(UnboundValuesSchema),
+  usedComponents: localeWrapper(UsedComponentsSchema).optional(),
+  componentSettings: localeWrapper(ComponentSettingsSchema),
+});
+
+export { THUMBNAIL_IDS as PATTERN_THUMBNAIL_IDS };
+
+export type PatternFields = z.infer<typeof PatternFieldsCMAShapeSchema>;
+export type PatternPropertyDefinition = z.infer<typeof PatternPropertyDefinitionSchema>;
+export type VariableMapping = z.infer<typeof VariableMappingSchema>;
+export type PatternComponentSettings = z.infer<typeof ComponentSettingsSchema>;

--- a/packages/validators/src/schemas/v2023_09_28/pattern.ts
+++ b/packages/validators/src/schemas/v2023_09_28/pattern.ts
@@ -9,7 +9,7 @@ import {
   UsedComponentsSchema,
 } from '../v2023_09_28/common';
 
-const THUMBNAIL_IDS = [
+export const THUMBNAIL_IDS = [
   'columns',
   'columnsPlusRight',
   'imagesSquare',
@@ -97,8 +97,6 @@ export const PatternFieldsCMAShapeSchema = z.object({
   usedComponents: localeWrapper(UsedComponentsSchema).optional(),
   componentSettings: localeWrapper(ComponentSettingsSchema),
 });
-
-export { THUMBNAIL_IDS as PATTERN_THUMBNAIL_IDS };
 
 export type PatternFields = z.infer<typeof PatternFieldsCMAShapeSchema>;
 export type PatternPropertyDefinition = z.infer<typeof PatternPropertyDefinitionSchema>;

--- a/packages/validators/src/schemas/v2023_09_28/pattern.ts
+++ b/packages/validators/src/schemas/v2023_09_28/pattern.ts
@@ -82,7 +82,16 @@ const PatternPropertyDefinitionSchema = z.object({
       }),
     )
     .optional(),
-  contentTypes: z.record(z.string(), z.any()),
+  contentTypes: z.record(
+    z.string(),
+    z.object({
+      sys: z.object({
+        type: z.literal('Link'),
+        id: z.string(),
+        linkType: z.enum(['ContentType']),
+      }),
+    }),
+  ),
 });
 
 export const PatternPropertyDefinitionsSchema = z.record(

--- a/packages/validators/src/schemas/v2023_09_28/pattern.ts
+++ b/packages/validators/src/schemas/v2023_09_28/pattern.ts
@@ -1,29 +1,13 @@
-import { z, ZodTypeAny } from 'zod';
+import { z } from 'zod';
 import {
-  BindingSourceTypeEnumSchema,
-  BoundValueSchema,
-  breakpointsRefinement,
-  ComponentTreeNodeIdSchema,
-  ComponentValueSchema,
+  ComponentTreeSchema,
+  ComponentVariableSchema,
   DataSourceSchema,
-  DefinitionPropertyKeySchema,
-  DefinitionPropertyTypeSchema,
-  DesignValueSchema,
-  HyperlinkValueSchema,
-  NoValueSchema,
-  PrimitiveValueSchema,
-  UnboundValueSchema,
+  localeWrapper,
+  propertyKeySchema,
   UnboundValuesSchema,
   UsedComponentsSchema,
 } from '../v2023_09_28/common';
-import { SchemaVersions } from '@/schemas/schemaVersions';
-
-/**
- * Property keys for patterns have a limit of 54 characters (<32-char-variable-name>_<21-char-nanoid-id>).
- */
-const propertyKeySchema = z
-  .string()
-  .regex(/^[a-zA-Z0-9-_]{1,54}$/, { message: 'Does not match /^[a-zA-Z0-9-_]{1,54}$/' });
 
 const THUMBNAIL_IDS = [
   'columns',
@@ -50,14 +34,6 @@ const THUMBNAIL_IDS = [
   'textColumns',
   'duplex',
 ] as const;
-
-// TODO: finalize schema structure before release
-// https://contentful.atlassian.net/browse/LUMOS-523
-export const PatternPropertySchema = z.object({
-  type: z.literal('BoundValue'),
-  path: z.string(),
-  contentType: z.string(),
-});
 
 // TODO: finalize schema structure before release
 // https://contentful.atlassian.net/browse/LUMOS-523
@@ -99,78 +75,7 @@ export const PatternPropertyDefinitionsSchema = z.record(
   PatternPropertyDefinitionSchema,
 );
 
-const localeWrapper = (fieldSchema: ZodTypeAny) => z.record(z.string(), fieldSchema);
 const VariableMappingsSchema = z.record(propertyKeySchema, VariableMappingSchema);
-
-const ComponentPropertyValueSchema = z.discriminatedUnion('type', [
-  DesignValueSchema,
-  BoundValueSchema,
-  UnboundValueSchema,
-  HyperlinkValueSchema,
-  ComponentValueSchema,
-  NoValueSchema,
-]);
-
-export const ComponentVariableSchema = z.object({
-  displayName: z.string().optional(),
-  type: DefinitionPropertyTypeSchema,
-  description: z.string().optional(),
-  group: z.string().optional(),
-  defaultValue: PrimitiveValueSchema.or(ComponentPropertyValueSchema).optional(),
-  validations: z
-    .object({
-      bindingSourceType: BindingSourceTypeEnumSchema.optional(),
-      required: z.boolean().optional(),
-      format: z.literal('URL').optional(),
-      in: z
-        .array(
-          z.object({
-            value: z.union([z.string(), z.number()]),
-            displayName: z.string().optional(),
-          }),
-        )
-        .optional(),
-    })
-    .optional(),
-});
-
-export const PatternPropertiesSchema = z.record(propertyKeySchema, PatternPropertySchema);
-
-// Use helper schema to define a recursive schema with its type correctly below
-const BaseComponentTreeNodeSchema = z.object({
-  id: ComponentTreeNodeIdSchema.optional(),
-  definitionId: DefinitionPropertyKeySchema,
-  displayName: z.string().optional(),
-  slotId: z.string().optional(),
-  variables: z.record(propertyKeySchema, ComponentPropertyValueSchema),
-  patternProperties: PatternPropertiesSchema.optional(),
-});
-
-export type ComponentTreeNode = z.infer<typeof BaseComponentTreeNodeSchema> & {
-  children: ComponentTreeNode[];
-};
-
-const ComponentTreeNodeSchema: z.ZodType<ComponentTreeNode> = BaseComponentTreeNodeSchema.extend({
-  children: z.lazy(() => ComponentTreeNodeSchema.array()),
-});
-
-export const BreakpointSchema = z
-  .object({
-    id: propertyKeySchema,
-    query: z.string().regex(/^\*$|^<[0-9*]+px$/),
-    previewSize: z.string(),
-    displayName: z.string(),
-    displayIcon: z.enum(['desktop', 'tablet', 'mobile']).optional(),
-  })
-  .strict();
-
-export const ComponentTreeSchema = z
-  .object({
-    breakpoints: z.array(BreakpointSchema).superRefine(breakpointsRefinement),
-    children: z.array(ComponentTreeNodeSchema),
-    schemaVersion: SchemaVersions,
-  })
-  .strict();
 
 export const ComponentVariablesSchema = z.record(
   z.string().regex(/^[a-zA-Z0-9-_]{1,54}$/), // Here the key is <variableName>_<nanoidId> so we need to allow for a longer length
@@ -185,7 +90,6 @@ const ComponentSettingsSchema = z.object({
   patternPropertyDefinitions: PatternPropertyDefinitionsSchema.optional(),
 });
 
-// export const PatternFieldsCMAShapeSchema = ExperienceFieldsCMAShapeSchema;
 export const PatternFieldsCMAShapeSchema = z.object({
   componentTree: localeWrapper(ComponentTreeSchema),
   dataSource: localeWrapper(DataSourceSchema),

--- a/packages/validators/src/test/__fixtures__/v2023_09_28/experience.ts
+++ b/packages/validators/src/test/__fixtures__/v2023_09_28/experience.ts
@@ -1,4 +1,4 @@
-import { EntryProps } from 'contentful-management';
+import type { EntryProps } from 'contentful-management';
 
 export const experience = {
   metadata: {

--- a/packages/validators/src/test/__fixtures__/v2023_09_28/experience.ts
+++ b/packages/validators/src/test/__fixtures__/v2023_09_28/experience.ts
@@ -11,6 +11,7 @@ export const experience = {
       },
     },
     id: '64AN4WV1fN0myahCWSOUhq',
+    revision: 1,
     type: 'Entry',
     createdAt: '2024-02-06T15:05:23.137Z',
     updatedAt: '2024-02-06T15:09:54.939Z',

--- a/packages/validators/src/test/__fixtures__/v2023_09_28/experience.ts
+++ b/packages/validators/src/test/__fixtures__/v2023_09_28/experience.ts
@@ -1,3 +1,5 @@
+import { EntryProps } from 'contentful-management';
+
 export const experience = {
   metadata: {
     tags: [],
@@ -312,4 +314,4 @@ export const experience = {
       },
     },
   },
-};
+} as EntryProps;

--- a/packages/validators/src/types.ts
+++ b/packages/validators/src/types.ts
@@ -15,6 +15,8 @@ export type {
   UnboundValue,
   BoundValue,
   ComponentValue,
+  PatternFields,
+  PatternProperty,
 } from './schemas/latest';
 export type { ComponentDefinitionPropertyType } from './schemas/componentDefinition';
 export type { SchemaVersions } from './schemas/schemaVersions';

--- a/packages/validators/src/validators/tests/componentSettings.spec.ts
+++ b/packages/validators/src/validators/tests/componentSettings.spec.ts
@@ -1,7 +1,7 @@
 import { validateExperienceFields } from '@/validators';
 import { experience, experiencePattern } from '@/test/__fixtures__/v2023_09_28';
 import { describe, it, expect } from 'vitest';
-import { PATTERN_THUMBNAIL_IDS } from '@/schemas/latest';
+import { THUMBNAIL_IDS } from '@/schemas/v2023_09_28/pattern';
 
 const schemaVersion = '2023-09-28' as const;
 const locale = 'en-US';
@@ -100,7 +100,7 @@ describe('componentSettings', () => {
   });
 
   it('allows to have an optional thumbnailId field', () => {
-    PATTERN_THUMBNAIL_IDS.forEach((thumbnailId) => {
+    THUMBNAIL_IDS.forEach((thumbnailId) => {
       const pattern = {
         ...experiencePattern,
         fields: {

--- a/packages/validators/src/validators/tests/componentSettings.spec.ts
+++ b/packages/validators/src/validators/tests/componentSettings.spec.ts
@@ -1,7 +1,7 @@
-import { validateExperienceFields } from '../validateExperienceFields';
-import { experience, experiencePattern } from '../../test/__fixtures__/v2023_09_28';
+import { validateExperienceFields } from '@/validators';
+import { experience, experiencePattern } from '@/test/__fixtures__/v2023_09_28';
 import { describe, it, expect } from 'vitest';
-import { PATTERN_THUMBNAIL_IDS } from '../../schemas/latest';
+import { PATTERN_THUMBNAIL_IDS } from '@/schemas/latest';
 
 const schemaVersion = '2023-09-28' as const;
 const locale = 'en-US';
@@ -92,7 +92,7 @@ describe('componentSettings', () => {
     expect(result.errors).toBeUndefined();
   });
 
-  it('passes if componentSettings is used NOT in conjuction with usedComponents', () => {
+  it('passes if componentSettings is used NOT in conjunction with usedComponents', () => {
     const result = validateExperienceFields(experiencePattern, schemaVersion);
 
     expect(result.success).toBe(true);

--- a/packages/validators/src/validators/tests/experienceValidator.spec.ts
+++ b/packages/validators/src/validators/tests/experienceValidator.spec.ts
@@ -1,6 +1,8 @@
-import { experience, experiencePattern } from '../../test/__fixtures__/v2023_09_28';
+import { experience, experiencePattern } from '@/test/__fixtures__/v2023_09_28';
 import { describe, it, expect } from 'vitest';
 import { validateExperienceFields } from '../validateExperienceFields';
+import * as validatePattern from '@/validators/validatePatternFields';
+import { vi } from 'vitest';
 
 const schemaVersion = '2023-09-28' as const;
 
@@ -46,15 +48,18 @@ describe(`${schemaVersion} version`, () => {
     expect(result.success).toBe(true);
   });
 
-  it('should validate the pattern successfully', () => {
-    const result = validateExperienceFields(experiencePattern, schemaVersion);
-
-    expect(result.success).toBe(true);
+  it('should not use pattern validator to validate experience', () => {
+    const validatePatternFields = vi.spyOn(validatePattern, 'validatePatternFields');
+    const _ = validateExperienceFields(experience, schemaVersion);
+    expect(validatePatternFields).not.toHaveBeenCalled();
   });
 
-  it('should read the schema version from the componentTree if no override is provided', () => {
-    const result = validateExperienceFields(experiencePattern);
-
-    expect(result.success).toBe(true);
+  it('should use pattern validator to validate pattern', () => {
+    const validatePatternFields = vi
+      .spyOn(validatePattern, 'validatePatternFields')
+      .mockReturnValue('mocked result' as any);
+    const result = validateExperienceFields(experiencePattern as any, schemaVersion);
+    expect(validatePatternFields).toHaveBeenCalledWith(experiencePattern, schemaVersion);
+    expect(result).toEqual('mocked result');
   });
 });

--- a/packages/validators/src/validators/tests/patternValidator.spec.ts
+++ b/packages/validators/src/validators/tests/patternValidator.spec.ts
@@ -1,0 +1,34 @@
+import { experiencePattern } from '@/test/__fixtures__/v2023_09_28';
+import { describe, it, expect } from 'vitest';
+import { validatePatternFields } from '@/validators/validatePatternFields';
+
+const schemaVersion = '2023-09-28' as const;
+
+describe(`${schemaVersion} version`, () => {
+  const requiredFields = ['componentTree', 'dataSource', 'unboundValues'] as const;
+
+  it.each(requiredFields)('should return an error if "%s" field is missing', (field) => {
+    const { [field]: _, ...rest } = experiencePattern.fields;
+    const updatedPattern = { ...experiencePattern, fields: rest };
+    const result = validatePatternFields(updatedPattern, schemaVersion);
+
+    expect(result.success).toBe(false);
+    expect(result.errors).toBeDefined();
+    const error = result.errors?.[0];
+
+    expect(error?.name).toBe('required');
+    expect(error?.details).toBe(`The property "${field}" is required here`);
+  });
+
+  it('should validate the pattern successfully', () => {
+    const result = validatePatternFields(experiencePattern, schemaVersion);
+
+    expect(result.success).toBe(true);
+  });
+
+  it('should read the schema version from the componentTree if no override is provided', () => {
+    const result = validatePatternFields(experiencePattern);
+
+    expect(result.success).toBe(true);
+  });
+});

--- a/packages/validators/src/validators/validateBreakpointDefinitions.ts
+++ b/packages/validators/src/validators/validateBreakpointDefinitions.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import { BreakpointSchema, breakpointsRefinement } from '../schemas/latest';
 import { ValidatorReturnValue } from './ValidatorReturnValue';
-import { zodToContentfulError } from '../utils/zodToContentfulError';
+import { zodToContentfulError } from '@/utils/zodToContentfulError';
 
 export const validateBreakpointsDefinition = (breakpoints): ValidatorReturnValue => {
   const result = z

--- a/packages/validators/src/validators/validateExperienceFields.ts
+++ b/packages/validators/src/validators/validateExperienceFields.ts
@@ -8,6 +8,7 @@ const VERSION_SCHEMAS = {
   '2023-09-28': ExperienceSchema_2023_09_28,
 };
 
+// TODO: fix typing when the Entry type is exposed
 function isPattern(experience: any): boolean {
   return experience.fields.componentSettings !== undefined;
 }

--- a/packages/validators/src/validators/validateExperienceFields.ts
+++ b/packages/validators/src/validators/validateExperienceFields.ts
@@ -3,6 +3,7 @@ import { ValidatorReturnValue } from './ValidatorReturnValue';
 import { ExperienceSchema_2023_09_28 } from '../schemas';
 import { zodToContentfulError, CodeNames } from '@/utils/zodToContentfulError';
 import { validatePatternFields } from '@/validators/validatePatternFields';
+import type { EntryProps } from 'contentful-management';
 
 const VERSION_SCHEMAS = {
   '2023-09-28': ExperienceSchema_2023_09_28,
@@ -21,8 +22,7 @@ function isPattern(experience: any): boolean {
  * @returns object with success property and optional errors array
  */
 export const validateExperienceFields = (
-  // TODO: type this as Entry when the type is exposed
-  experience: any,
+  experience: EntryProps,
   schemaVersionOverride?: SchemaVersions,
 ): ValidatorReturnValue => {
   // If this is a pattern, use the pattern validator

--- a/packages/validators/src/validators/validateExperienceFields.ts
+++ b/packages/validators/src/validators/validateExperienceFields.ts
@@ -2,14 +2,13 @@ import { type SchemaVersions } from '../types';
 import { ValidatorReturnValue } from './ValidatorReturnValue';
 import { ExperienceSchema_2023_09_28 } from '../schemas';
 import { zodToContentfulError, CodeNames } from '@/utils/zodToContentfulError';
-import { ExperienceEntry } from '@contentful/experiences-core/types';
 import { validatePatternFields } from '@/validators/validatePatternFields';
 
 const VERSION_SCHEMAS = {
   '2023-09-28': ExperienceSchema_2023_09_28,
 };
 
-function isPattern(experience: ExperienceEntry): boolean {
+function isPattern(experience: any): boolean {
   return experience.fields.componentSettings !== undefined;
 }
 

--- a/packages/validators/src/validators/validatePatternFields.ts
+++ b/packages/validators/src/validators/validatePatternFields.ts
@@ -1,41 +1,31 @@
 import { type SchemaVersions } from '../types';
 import { ValidatorReturnValue } from './ValidatorReturnValue';
-import { ExperienceSchema_2023_09_28 } from '../schemas';
+import { PatternSchema_2023_09_28 } from '../schemas';
 import { zodToContentfulError, CodeNames } from '@/utils/zodToContentfulError';
-import { ExperienceEntry } from '@contentful/experiences-core/types';
-import { validatePatternFields } from '@/validators/validatePatternFields';
 
 const VERSION_SCHEMAS = {
-  '2023-09-28': ExperienceSchema_2023_09_28,
+  '2023-09-28': PatternSchema_2023_09_28,
 };
-
-function isPattern(experience: ExperienceEntry): boolean {
-  return experience.fields.componentSettings !== undefined;
-}
 
 /**
  *
- * @param experience The experience entry to validate
+ * @param pattern The pattern entry to validate
  * @param schemaVersionOverride Optional override for the schema version to validate against.
- * By default, the schema version is read from the experience entry
+ * By default, the schema version is read from the pattern entry
  * @returns object with success property and optional errors array
  */
-export const validateExperienceFields = (
+export const validatePatternFields = (
   // TODO: type this as Entry when the type is exposed
-  experience: any,
+  pattern: any,
   schemaVersionOverride?: SchemaVersions,
 ): ValidatorReturnValue => {
-  // If this is a pattern, use the pattern validator
-  if (isPattern(experience)) {
-    return validatePatternFields(experience, schemaVersionOverride);
-  }
-
   let schemaVersion: SchemaVersions | undefined;
+
   if (schemaVersionOverride) {
     schemaVersion = schemaVersionOverride;
-  } else if (experience.fields.componentTree) {
-    const locale = Object.keys(experience.fields.componentTree)[0];
-    schemaVersion = experience.fields.componentTree[locale].schemaVersion;
+  } else if (pattern.fields.componentTree) {
+    const locale = Object.keys(pattern.fields.componentTree)[0];
+    schemaVersion = pattern.fields.componentTree[locale].schemaVersion;
   }
 
   const schema = schemaVersion && VERSION_SCHEMAS[schemaVersion];
@@ -46,7 +36,7 @@ export const validateExperienceFields = (
       errors: [
         {
           name: schemaVersion ? CodeNames.In : CodeNames.Required,
-          expected: ['2023-09-28'],
+          expected: Object.keys(VERSION_SCHEMAS),
           value: schemaVersion,
           path: ['fields', 'componentTree', 'schemaVersion'],
           details: schemaVersion
@@ -58,10 +48,11 @@ export const validateExperienceFields = (
   }
 
   const fieldsToValidate = {
-    componentTree: experience.fields.componentTree,
-    dataSource: experience.fields.dataSource,
-    unboundValues: experience.fields.unboundValues,
-    usedComponents: experience.fields.usedComponents,
+    componentTree: pattern.fields.componentTree,
+    dataSource: pattern.fields.dataSource,
+    unboundValues: pattern.fields.unboundValues,
+    usedComponents: pattern.fields.usedComponents,
+    componentSettings: pattern.fields.componentSettings,
   };
 
   const result = schema.safeParse(fieldsToValidate);

--- a/packages/validators/src/validators/validatePatternFields.ts
+++ b/packages/validators/src/validators/validatePatternFields.ts
@@ -2,6 +2,7 @@ import { type SchemaVersions } from '../types';
 import { ValidatorReturnValue } from './ValidatorReturnValue';
 import { PatternSchema_2023_09_28 } from '../schemas';
 import { zodToContentfulError, CodeNames } from '@/utils/zodToContentfulError';
+import type { EntryProps } from 'contentful-management';
 
 const VERSION_SCHEMAS = {
   '2023-09-28': PatternSchema_2023_09_28,
@@ -15,8 +16,7 @@ const VERSION_SCHEMAS = {
  * @returns object with success property and optional errors array
  */
 export const validatePatternFields = (
-  // TODO: type this as Entry when the type is exposed
-  pattern: any,
+  pattern: EntryProps,
   schemaVersionOverride?: SchemaVersions,
 ): ValidatorReturnValue => {
   let schemaVersion: SchemaVersions | undefined;

--- a/packages/validators/vite.config.mts
+++ b/packages/validators/vite.config.mts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vite'
+import tsconfigPaths from 'vite-tsconfig-paths'
+
+export default defineConfig({
+  plugins: [tsconfigPaths({
+    ignoreConfigErrors: true,
+  })],
+})


### PR DESCRIPTION
## Purpose
Split the validation schema for experience and pattern such that each can be validated independently.

## Approach
Effort has been made to avoid any breaking changes. This includes re-exporting things from their original location and making the experiences validator call the pattern validator if it detects a pattern. Any potential breaking change found during review (including typing) should be flagged.

A common file has been created to reuse common schemas and reduce duplication.

## Ticket
https://contentful.atlassian.net/browse/SPA-2753
