### PR TITLE
chore: keep new v3-prerelease branch up to date and publish as alpha version [SPA-2745]

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,6 +37,7 @@ jobs:
       (github.ref_name == 'main' ||
         github.ref_name == 'development' ||
         github.ref_name == 'next' ||
+        github.ref_name == 'v3-prerelease' ||
         inputs.publish-prerelease 
       ) &&
       !contains(github.event.head_commit.message, 'skip-release') &&

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -86,6 +86,8 @@ jobs:
             npx lerna publish --conventional-commits --conventional-prerelease --exact --force-publish --preid prerelease-$(date +%Y%m%dT%H%M)-$(git rev-parse HEAD | cut -c1-7) --no-changelog --no-push --yes --no-private --dist-tag prerelease --allow-branch ${{ github.ref_name }} --git-tag-command="echo 'skipping git tag for prereleases'"
           elif [ ${{ github.ref_name }} = development ]; then
             npx lerna publish --conventional-commits --conventional-prerelease --exact --force-publish --preid dev-$(date +%Y%m%dT%H%M)-$(git rev-parse HEAD | cut -c1-7) --dist-tag dev --no-changelog --no-push --yes --no-private --git-tag-command="echo 'skipping git tag for prereleases'"
+          elif [ ${{ github.ref_name }} = v3-prerelease ]; then
+            npx lerna publish --conventional-commits --conventional-prerelease --exact --force-publish --preid alpha-$(date +%Y%m%dT%H%M)-$(git rev-parse HEAD | cut -c1-7) --dist-tag alpha --no-changelog --no-push --yes --no-private --git-tag-command="echo 'skipping git tag for prereleases'"
           elif [ ${{ github.ref_name }} = next ]; then
             npx lerna publish --conventional-commits --conventional-prerelease --exact --force-publish --preid beta --dist-tag next --no-changelog --yes --no-private --git-tag-command="echo 'skipping git tag for prereleases'"
           else
@@ -110,4 +112,13 @@ jobs:
             git pull
             git rebase next
             git push origin
+          elif [ ${{ github.ref_name }} = development ]; then
+             git checkout v3-prerelease
+             git pull
+            { # try
+              git rebase development &&
+              git push origin
+            } || { # catch
+              echo "⚠️  Silently failed to update v3-prerelease"
+            }
           fi


### PR DESCRIPTION
This uses the same publishing logic as for `development` but uses the `alpha` tag instead of `dev`.
Also, we try to keep it up to date with `development` by an automatic rebase. This might fail depending on the changes made on both sides, so I wrapped the `rebase` command to not make the pipeline indicate a failure.