### PR TITLE
feat: introduce SDK capability dndMigration [SPA-2745]

### DIFF
--- a/packages/experience-builder-sdk/src/core/sdkFeatures.ts
+++ b/packages/experience-builder-sdk/src/core/sdkFeatures.ts
@@ -5,5 +5,5 @@ export const sdkFeatures: Record<string, unknown> = {
   cfVisibility: true,
   patternResolution: true,
   // DND is moving to the host application enabling smoother native event handling
-  nativeDnd: true,
+  dndMigration: true,
 };

--- a/packages/experience-builder-sdk/src/core/sdkFeatures.ts
+++ b/packages/experience-builder-sdk/src/core/sdkFeatures.ts
@@ -4,4 +4,6 @@ export const sdkFeatures: Record<string, unknown> = {
   hasVersionHistory: true,
   cfVisibility: true,
   patternResolution: true,
+  // DND is moving to the host application enabling smoother native event handling
+  nativeDnd: true,
 };


### PR DESCRIPTION
## Purpose
We will remove all dnd related code from the SDK. To allow a smooth transition, there is a new branch `v3-prerelease`. All dnd related code will be removed from the codebase in this branch.

## Approach
To indicate to the web app that this SDK version supports the new native dnd handling, a new SDK capability is added called `nativeDnd`. The name might not be self-explanatory, so I added a comment as well.