### PR TITLE
[SPA-2787] Update validation/types for patternPropertyDefinitions contentTypes

### DIFF
--- a/packages/validators/src/schemas/v2023_09_28/experience.ts
+++ b/packages/validators/src/schemas/v2023_09_28/experience.ts
@@ -126,7 +126,16 @@ const PatternPropertyDefinitionSchema = z.object({
       }),
     )
     .optional(),
-  contentTypes: z.record(z.string(), z.any()),
+  contentTypes: z.record(
+    z.string(),
+    z.object({
+      sys: z.object({
+        type: z.literal('Link'),
+        id: z.string(),
+        linkType: z.enum(['ContentType']),
+      }),
+    }),
+  ),
 });
 
 const PatternPropertyDefinitionsSchema = z.record(

--- a/packages/validators/src/test/__fixtures__/v2023_09_28/experiencePattern.ts
+++ b/packages/validators/src/test/__fixtures__/v2023_09_28/experiencePattern.ts
@@ -294,6 +294,28 @@ export const experiencePattern = {
     },
     componentSettings: {
       'en-US': {
+        patternPropertyDefinitions: {
+          '8v3GB67qF5f': {
+            defaultValue: {
+              productFeatureTopic: {
+                sys: {
+                  id: '2hpuOIh8POJcekFdOLlaDa',
+                  linkType: 'Entry',
+                  type: 'Link',
+                },
+              },
+            },
+            contentTypes: {
+              productFeatureTopic: {
+                sys: {
+                  id: 'productFeatureTopic',
+                  type: 'Link',
+                  linkType: 'ContentType',
+                },
+              },
+            },
+          },
+        },
         variableDefinitions: {
           cfBackgroundImageUrl_AtBrirchNbwfpkWlSfTD6: {
             displayName: 'Background image',

--- a/packages/validators/src/validators/tests/experienceValidator.spec.ts
+++ b/packages/validators/src/validators/tests/experienceValidator.spec.ts
@@ -20,6 +20,26 @@ describe(`${schemaVersion} version`, () => {
     expect(error?.details).toBe(`The property "${field}" is required here`);
   });
 
+  it('should return an error if patternPropertyDefinitions contentTypes do not use a link reference', () => {
+    const clonedExperiencePattern = JSON.parse(JSON.stringify(experiencePattern));
+    // @ts-ignore - force type for invalid contentTypes test
+    clonedExperiencePattern.fields.componentSettings['en-US'].patternPropertyDefinitions[
+      '8v3GB67qF5f'
+    ].contentTypes.productFeatureTopic = {
+      ...clonedExperiencePattern.fields.componentSettings['en-US'].patternPropertyDefinitions[
+        '8v3GB67qF5f'
+      ].contentTypes.productFeatureTopic.sys,
+    };
+    const result = validateExperienceFields(clonedExperiencePattern, schemaVersion);
+
+    expect(result.success).toBe(false);
+    expect(result.errors).toBeDefined();
+    const error = result.errors?.[0];
+
+    expect(error?.name).toBe('required');
+    expect(error?.details).toBe(`The property "sys" is required here`);
+  });
+
   it('should validate the experience successfully', () => {
     const result = validateExperienceFields(experience, schemaVersion);
 


### PR DESCRIPTION
## Purpose

[SPA-2787] Update validation/types for patternPropertyDefinitions contentTypes

Ticket: https://contentful.atlassian.net/browse/SPA-2787

## Approach

Update type and create zod schema.

Current data format:
```
"patternPropertyDefinitions": {
  "PJDwAa2v2Ip": {
    "contentTypes": {
      "productTopic": {
        "id": "productTopic",
        "type": "Link",
        "linkType": "ContentType"
      }
    }
```

New data format:
```
"patternPropertyDefinitions": {
  "PJDwAa2v2Ip": {
    "contentTypes": {
      "productTopic": { 
        "sys": {
          "id": "productTopic",
          "type": "Link",
          "linkType": "ContentType"
        }
      }
    }
```
