### PR TITLE
fix(core): handle null or disabled localStorage [SPA-2838] [ZEND-6469]

### DIFF
--- a/packages/core/src/utils/debugLogger.ts
+++ b/packages/core/src/utils/debugLogger.ts
@@ -5,7 +5,7 @@ export class DebugLogger {
   private enabled: boolean;
 
   constructor() {
-    if (typeof localStorage === 'undefined') {
+    if (!checkLocalStorageAvailability()) {
       this.enabled = false;
       return;
     }
@@ -64,4 +64,29 @@ export const enableDebug = () => {
 export const disableDebug = () => {
   debug.setEnabled(false);
   console.log('Debug mode disabled');
+};
+
+/**
+ * To ensure that the localStorage API can be used safely, we check
+ * for availability (e.g. undefined in Node.js). Additionally, we
+ * check if the localStorage can be used as some browsers throw a
+ * SecurityError (e.g. Brave or Chromium with specific settings).
+ */
+const checkLocalStorageAvailability = () => {
+  if (typeof localStorage === 'undefined' || localStorage === null) {
+    return false;
+  }
+  try {
+    // Attempt to set and remove an item to check if localStorage is enabled
+    const TEST_KEY = 'cf_test_local_storage';
+    localStorage.setItem(TEST_KEY, 'yes');
+    if (localStorage.getItem(TEST_KEY) === 'yes') {
+      localStorage.removeItem(TEST_KEY);
+      return true;
+    } else {
+      return false;
+    }
+  } catch (_error) {
+    return false;
+  }
 };


### PR DESCRIPTION
## Purpose
When the localStorage is `null` instead of `undefined` or when it is present but using it raises a security error, the SDK would cause an uncaught exception.
For reference, this is how you can disable usage of localStorage in your browser and safe browsers like Brave seem to do this by default: https://stackoverflow.com/questions/30481516/iframe-in-chrome-error-failed-to-read-localstorage-from-window-access-deni

## Approach
Check of `null` explicitly and use a try-catch block to test storage functionality.