### PR TITLE
feat: use offsetHeight for canvasGeometry [SPA-2804]

### DIFF
--- a/packages/visual-editor/src/components/RootRenderer/sendCanvasGeometryUpdatedMessage.ts
+++ b/packages/visual-editor/src/components/RootRenderer/sendCanvasGeometryUpdatedMessage.ts
@@ -24,8 +24,8 @@ export const sendCanvasGeometryUpdatedMessage = async (
   collectNodeCoordinates(tree.root, nodeToCoordinatesMap);
   sendMessage(OUTGOING_EVENTS.CanvasGeometryUpdated, {
     size: {
-      width: document.documentElement.scrollWidth,
-      height: document.documentElement.scrollHeight,
+      width: document.documentElement.offsetWidth,
+      height: document.documentElement.offsetHeight,
     },
     nodes: nodeToCoordinatesMap,
     sourceEvent,


### PR DESCRIPTION
## Purpose

Use `document.documentElement.offsetHeight` instead of `document.documentElement.scrollHeight`.

When the node is removed, `scrollHeight` doesn’t change, and iframe height stays the same, because in the web app the iframe is stretched to 100% of the container that has the height based off the last iframe size.
