### PR TITLE
feat: stretch option for vertical and horizontal alignment [SPA-2836]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2507,6 +2507,7 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {

--- a/packages/core/src/definitions/styles.ts
+++ b/packages/core/src/definitions/styles.ts
@@ -18,6 +18,10 @@ export const builtInStyles: Partial<DesignVariableMap> = {
           value: 'end',
           displayName: 'Align right',
         },
+        {
+          value: 'stretch',
+          displayName: 'Stretch',
+        },
       ],
     },
     type: 'Text',
@@ -40,6 +44,10 @@ export const builtInStyles: Partial<DesignVariableMap> = {
         {
           value: 'end',
           displayName: 'Align bottom',
+        },
+        {
+          value: 'stretch',
+          displayName: 'Stretch',
         },
       ],
     },
@@ -416,6 +424,10 @@ export const singleColumnBuiltInStyles: Partial<DesignVariableMap> = {
           value: 'end',
           displayName: 'Align right',
         },
+        {
+          value: 'stretch',
+          displayName: 'Stretch',
+        },
       ],
     },
     type: 'Text',
@@ -438,6 +450,10 @@ export const singleColumnBuiltInStyles: Partial<DesignVariableMap> = {
         {
           value: 'end',
           displayName: 'Align bottom',
+        },
+        {
+          value: 'stretch',
+          displayName: 'Stretch',
         },
       ],
     },

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -208,8 +208,8 @@ export type ExperienceTree = {
 // FIXME: Check whether this should be the same as CF_STYLE_ATTRIBUTES
 export type StyleProps = {
   cfVisibility: boolean;
-  cfHorizontalAlignment: 'start' | 'end' | 'center';
-  cfVerticalAlignment: 'start' | 'end' | 'center';
+  cfHorizontalAlignment: 'start' | 'end' | 'center' | 'stretch';
+  cfVerticalAlignment: 'start' | 'end' | 'center' | 'stretch';
   cfMargin: string;
   cfPadding: string;
   cfBackgroundColor: string;

--- a/packages/core/src/utils/styleUtils/styleTransformers.ts
+++ b/packages/core/src/utils/styleUtils/styleTransformers.ts
@@ -98,6 +98,7 @@ export const transformBackgroundImage = (
     }
     let [horizontalAlignment, verticalAlignment] = alignment.trim().split(/\s+/, 2);
 
+    // TODO: drop this backward compatibility in the next major version as we don't use single values since a year ago
     // Special case for handling single values
     // for backwards compatibility with single values 'right','left', 'center', 'top','bottom'
     if (horizontalAlignment && !verticalAlignment) {
@@ -128,8 +129,8 @@ export const transformBackgroundImage = (
       }
     }
 
-    const isHorizontalValid = ['left', 'right', 'center'].includes(horizontalAlignment);
-    const isVerticalValid = ['top', 'bottom', 'center'].includes(verticalAlignment);
+    const isHorizontalValid = ['left', 'right', 'center', 'stretch'].includes(horizontalAlignment);
+    const isVerticalValid = ['top', 'bottom', 'center', 'stretch'].includes(verticalAlignment);
 
     horizontalAlignment = isHorizontalValid ? horizontalAlignment : 'left';
     verticalAlignment = isVerticalValid ? verticalAlignment : 'top';

--- a/packages/storybook-addon/src/utils/variables.ts
+++ b/packages/storybook-addon/src/utils/variables.ts
@@ -22,6 +22,10 @@ export const builtInStyles: Record<
           value: 'end',
           displayName: 'Align right',
         },
+        {
+          value: 'stretch',
+          displayName: 'Stretch',
+        },
       ],
     },
     type: 'Text',
@@ -44,6 +48,10 @@ export const builtInStyles: Record<
         {
           value: 'end',
           displayName: 'Align bottom',
+        },
+        {
+          value: 'stretch',
+          displayName: 'Stretch',
         },
       ],
     },


### PR DESCRIPTION
## Purpose

When using deeper flexbox layouts, users can't make all children inside a container have the same height.

## Approach

To enable this use case, a new option `stretch` is added, which translates directly to the similarly named option for `justify-content` and `align-items`.