### PR TITLE
fix(core): deep binding resolution with reference field already being a resolve entity [SPA-2843]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2507,6 +2507,7 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {

--- a/packages/core/src/entity/EntityStoreBase.spec.ts
+++ b/packages/core/src/entity/EntityStoreBase.spec.ts
@@ -5,7 +5,6 @@ const entityIds = {
   ENTRY1: 'entry1',
   ENTRY2: 'entry2',
   ENTRY3: 'entry3',
-  ENTRY4: 'entry4',
   ASSET1: 'asset1',
 };
 const entities = [
@@ -13,6 +12,8 @@ const entities = [
     fields: {
       title: 'Entry 1',
       logo: { sys: { id: entityIds.ASSET1, linkType: 'Asset', type: 'Link' } },
+      // Since [SPA-2697], reference fields might already be resolved entities
+      thumbnail: assets[0],
     },
   }),
   createEntry(entityIds.ENTRY2, {
@@ -94,6 +95,26 @@ describe('EntityStoreBase', () => {
             '/some-uuid/fields/nonexisting/~locale/fields/file/~locale',
           ),
         ).toBeUndefined();
+      });
+
+      describe('when the referenced entity is already resolved', () => {
+        it('should return the referenced entity', () => {
+          expect(
+            store.getEntryOrAsset(
+              { sys: { id: entityIds.ENTRY1, linkType: 'Entry', type: 'Link' } },
+              '/some-uuid/fields/thumbnail/~locale/fields/file/~locale',
+            ),
+          ).toEqual(assets[0]);
+        });
+
+        it('should return the two levels deep referenced entity', () => {
+          expect(
+            store.getEntryOrAsset(
+              { sys: { id: entityIds.ENTRY2, linkType: 'Entry', type: 'Link' } },
+              '/some-uuid/fields/reference1/~locale/fields/thumbnail/~locale/fields/file/~locale',
+            ),
+          ).toEqual(assets[0]);
+        });
       });
     });
   });

--- a/packages/core/src/entity/EntityStoreBase.ts
+++ b/packages/core/src/entity/EntityStoreBase.ts
@@ -203,7 +203,7 @@ export abstract class EntityStoreBase {
           }
           resolvedFieldset.push([entityToResolveFieldsFrom, field, _localeQualifier]);
           entityToResolveFieldsFrom = entity; // we move up
-        } else if (typeof fieldValue === 'object' && this.isAsset(fieldValue)) {
+        } else if (this.isAsset(fieldValue)) {
           resolvedFieldset.push([entityToResolveFieldsFrom, field, _localeQualifier]);
           entityToResolveFieldsFrom = fieldValue; // we move up
         }
@@ -242,8 +242,13 @@ export abstract class EntityStoreBase {
     return leafEntity;
   }
 
-  private isAsset(entity: Entry | Asset): entity is Asset {
-    return entity.sys.type === 'Asset';
+  private isAsset(value: unknown): value is Asset {
+    return (
+      null !== value &&
+      typeof value === 'object' &&
+      'sys' in value &&
+      (value as Asset).sys?.type === 'Asset'
+    );
   }
 
   private getEntity(type: 'Asset' | 'Entry', id: string) {

--- a/packages/core/src/entity/EntityStoreBase.ts
+++ b/packages/core/src/entity/EntityStoreBase.ts
@@ -206,6 +206,12 @@ export abstract class EntityStoreBase {
         } else if (this.isAsset(fieldValue) || this.isEntry(fieldValue)) {
           resolvedFieldset.push([entityToResolveFieldsFrom, field, _localeQualifier]);
           entityToResolveFieldsFrom = fieldValue; // we move up
+        } else {
+          return {
+            resolvedFieldset,
+            isFullyResolved: false,
+            reason: `Deep path points to an invalid field value of type '${typeof fieldValue}' (value=${fieldValue})`,
+          };
         }
       }
       return {

--- a/packages/core/src/entity/EntityStoreBase.ts
+++ b/packages/core/src/entity/EntityStoreBase.ts
@@ -181,7 +181,7 @@ export abstract class EntityStoreBase {
           break;
         }
 
-        const fieldValue = get<string | UnresolvedLink<'Entry' | 'Asset'>>(
+        const fieldValue = get<string | UnresolvedLink<'Entry' | 'Asset'> | Entry | Asset>(
           entityToResolveFieldsFrom,
           ['fields', field],
         );
@@ -203,6 +203,9 @@ export abstract class EntityStoreBase {
           }
           resolvedFieldset.push([entityToResolveFieldsFrom, field, _localeQualifier]);
           entityToResolveFieldsFrom = entity; // we move up
+        } else if (typeof fieldValue === 'object' && this.isAsset(fieldValue)) {
+          resolvedFieldset.push([entityToResolveFieldsFrom, field, _localeQualifier]);
+          entityToResolveFieldsFrom = fieldValue; // we move up
         }
       }
       return {
@@ -227,6 +230,7 @@ export abstract class EntityStoreBase {
       unresolvedFieldset,
       headEntity,
     );
+
     if (!isFullyResolved) {
       reason &&
         console.debug(

--- a/packages/core/src/entity/EntityStoreBase.ts
+++ b/packages/core/src/entity/EntityStoreBase.ts
@@ -203,7 +203,7 @@ export abstract class EntityStoreBase {
           }
           resolvedFieldset.push([entityToResolveFieldsFrom, field, _localeQualifier]);
           entityToResolveFieldsFrom = entity; // we move up
-        } else if (this.isAsset(fieldValue)) {
+        } else if (this.isAsset(fieldValue) || this.isEntry(fieldValue)) {
           resolvedFieldset.push([entityToResolveFieldsFrom, field, _localeQualifier]);
           entityToResolveFieldsFrom = fieldValue; // we move up
         }
@@ -248,6 +248,15 @@ export abstract class EntityStoreBase {
       typeof value === 'object' &&
       'sys' in value &&
       (value as Asset).sys?.type === 'Asset'
+    );
+  }
+
+  private isEntry(value: unknown): value is Entry {
+    return (
+      null !== value &&
+      typeof value === 'object' &&
+      'sys' in value &&
+      (value as Entry).sys?.type === 'Entry'
     );
   }
 

--- a/packages/test-apps/react-vite/src/components/ComponentUsingReferences/ComponentUsingReferences.tsx
+++ b/packages/test-apps/react-vite/src/components/ComponentUsingReferences/ComponentUsingReferences.tsx
@@ -23,7 +23,7 @@ export function ComponentUsingReferences({
         <div className={styles.entryReference}>
           <i>Reference</i>
           {stringFields.map(([key, value]) => (
-            <div>
+            <div key={key}>
               <b>{key}</b>
               <div>
                 {'> '}


### PR DESCRIPTION
## Purpose

A customer noticed that assets stopped rendering when another component on the experience used the recently added L2 resolution of reference fields.

## Approach

As soon a registered component uses the `'Link'` variable type, the SDK receives entities with the reference fields not being links but actual entities already.
When resolving deep bindings (for assets), the entity store is now able to handle this scenario as well. I added a test that also showcases this scenario.