### PR TITLE
fix(core): move typeof localStorage check into try catch block to support aggressive cookie settings in Brave [SPA-2838]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2507,6 +2507,7 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {

--- a/packages/core/src/utils/debugLogger.ts
+++ b/packages/core/src/utils/debugLogger.ts
@@ -7,10 +7,11 @@ const CF_DEBUG_KEY = 'cf_debug';
  * SecurityError (e.g. Brave or Chromium with specific settings).
  */
 const checkLocalStorageAvailability = () => {
-  if (typeof localStorage === 'undefined' || localStorage === null) {
-    return false;
-  }
   try {
+    // Even the typeof check can throw an error in an agressive browser like Brave (requires using the deprecated flag #block-all-cookies-toggle)
+    if (typeof localStorage === 'undefined' || localStorage === null) {
+      return false;
+    }
     // Attempt to set and remove an item to check if localStorage is enabled
     const TEST_KEY = 'cf_test_local_storage';
     localStorage.setItem(TEST_KEY, 'yes');


### PR DESCRIPTION
## Purpose

When using the Brave browser, activating the deprecated flag `#block-all-cookies-toggle` and toggling on the legacy option "Block all cookies", a check like `typeof localStorage` will throw an error. While logic like `typeof asdf` will gracefully return `undefined`, the browser seems to even punish the this check with an error.

<img width="735" alt="Screenshot 2025-06-06 at 13 33 09" src="https://github.com/user-attachments/assets/4af489f4-2609-45a4-8e14-5df2336a962d" />

<img width="700" alt="Screenshot 2025-06-06 at 13 33 14" src="https://github.com/user-attachments/assets/4d6ed4de-14ab-4695-b76d-4d42319ead70" />

<img width="545" alt="Screenshot 2025-06-06 at 13 33 31" src="https://github.com/user-attachments/assets/449acfe5-0f7b-4158-bbe0-5de01374ac94" />

**Background to this flag:**
It "broke the web" for users as the aggressive behavior would cause several issues on web page with Studio just being yet another anecdote that proves it.
- https://github.com/brave/brave-browser/issues/42061
- https://github.com/brave/brave-browser/wiki/Block-all-cookies-global-Shields-setting

## Approach
Moving the `typeof localStorage` check inside the try-catch-block will also handle this case gracefully from now on.