### PR TITLE
fix: only enrich experience field with hyperlinkPattern when experience is defiend [SPA-2842]

### DIFF
--- a/packages/experience-builder-sdk/src/hooks/useFetchById.spec.ts
+++ b/packages/experience-builder-sdk/src/hooks/useFetchById.spec.ts
@@ -53,6 +53,13 @@ describe('useFetchById', () => {
       },
     });
 
+    expect(result.current).toEqual({
+      error: undefined,
+      experience: undefined,
+      isLoading: true,
+      mode: StudioCanvasMode.NONE,
+    });
+
     await waitFor(() => {
       const store = result.current;
 

--- a/packages/experience-builder-sdk/src/hooks/useFetchById.ts
+++ b/packages/experience-builder-sdk/src/hooks/useFetchById.ts
@@ -30,5 +30,16 @@ export const useFetchById = ({
 
   const fetchResult = useFetchByBase(fetchMethod, mode);
 
-  return { ...fetchResult, experience: { ...fetchResult.experience, hyperlinkPattern } };
+  if (!fetchResult.experience) {
+    return fetchResult;
+  }
+
+  // enriches fetchResult.experience with the hyperlinkPattern, only when fetchResult.experience exists
+  return {
+    ...fetchResult,
+    experience: {
+      ...fetchResult.experience,
+      hyperlinkPattern,
+    },
+  };
 };

--- a/packages/experience-builder-sdk/src/hooks/useFetchBySlug.spec.ts
+++ b/packages/experience-builder-sdk/src/hooks/useFetchBySlug.spec.ts
@@ -57,7 +57,7 @@ describe('useFetchBySlug', () => {
 
     expect(result.current).toEqual({
       error: undefined,
-      experience: { hyperlinkPattern: undefined },
+      experience: undefined,
       isLoading: true,
       mode: StudioCanvasMode.NONE,
     });
@@ -131,7 +131,7 @@ describe('useFetchBySlug', () => {
     await waitFor(() => expect(result.current.error).toBeUndefined());
   });
 
-  it('should return an error if multiple experience entries were found, then when slug changes to only one entry, then the error should be undefined', async () => {
+  it('should return an error if multiple experience entries were found, then when slug changes to just one entry, then the error should be undefined', async () => {
     clientMock.getEntries = jest
       .fn()
       .mockResolvedValue({ items: [experienceEntry, experienceEntry] });

--- a/packages/experience-builder-sdk/src/hooks/useFetchBySlug.ts
+++ b/packages/experience-builder-sdk/src/hooks/useFetchBySlug.ts
@@ -31,5 +31,16 @@ export const useFetchBySlug = ({
 
   const fetchResult = useFetchByBase(fetchMethod, mode);
 
-  return { ...fetchResult, experience: { ...fetchResult.experience, hyperlinkPattern } };
+  if (!fetchResult.experience) {
+    return fetchResult;
+  }
+
+  // enriches fetchResult.experience with the hyperlinkPattern, only when fetchResult.experience exists
+  return {
+    ...fetchResult,
+    experience: {
+      ...fetchResult.experience,
+      hyperlinkPattern,
+    },
+  };
 };


### PR DESCRIPTION
## Purpose


Ensures that caller of `useFetchBy{Slug,Id}` can rely on the presence of the field `.experience` as signal for experience loaded. (before that due to enriching of `hyperlinkPattern` such method of checking would result in false positive>

This is to release with v2 of the SDK (as it fixes older less consistent logic). 



## Approach

<!--
Remember when merging:
- Use "Squash and merge" when merging changes into development.
- Use "Create a merge commit" when releasing changes into next and main.

Three important notes on pull requests:
- In general, you should ask yourself whether this code change will improve or worsen the overall code quality. Any new tech debt will probably never be cleaned up.
- Please remember that newly introduced logic should be validated and protected through testing.
- Take a look at PR guides:
  Google's Code Review Guidelines: https://google.github.io/eng-practices/
  Blockly - Writing a Good Pull Request: https://developers.google.com/blockly/guides/contribute/get-started/write_a_good_pr
-->
