### PR TITLE
fix(core): consolidate CSS generation for cfVisibility in SSR and CSR [SPA-2782]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2507,6 +2507,7 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {

--- a/packages/core/src/utils/styleUtils/index.ts
+++ b/packages/core/src/utils/styleUtils/index.ts
@@ -1,3 +1,4 @@
 export * from './stylesUtils';
 export * from './ssrStyles';
+export { toMediaQuery } from './toMediaQuery';
 export { transformVisibility } from './styleTransformers';

--- a/packages/core/src/utils/styleUtils/ssrStyles.spec.ts
+++ b/packages/core/src/utils/styleUtils/ssrStyles.spec.ts
@@ -12,7 +12,6 @@ import {
   isCfStyleAttribute,
   maybePopulateDesignTokenValue,
   resolveBackgroundImageBinding,
-  toMediaQuery,
 } from './ssrStyles';
 
 describe('isCfStyleAttribute', () => {
@@ -1314,49 +1313,5 @@ describe('flattenDesignTokenRegistry', () => {
       'textColor.muted': 'gray',
       'textColor.accent': 'blue',
     });
-  });
-});
-
-describe('toMediaQuery', () => {
-  it('should return css for default breakpoint without wrapping it into a media query', () => {
-    const res = toMediaQuery({
-      condition: '*',
-      cssByClassName: {
-        className1: 'background:green;color:white;font-size:1rem;',
-        className2: 'background:red;color:black;font-size:1.5rem;',
-      },
-    });
-
-    expect(res).toBe(
-      '.className1{background:green;color:white;font-size:1rem;}.className2{background:red;color:black;font-size:1.5rem;}',
-    );
-  });
-
-  it('should wrap styles for non default breakpoint into a media query', () => {
-    const res = toMediaQuery({
-      condition: '<950px',
-      cssByClassName: {
-        className1: 'background:green;color:white;font-size:1rem;',
-        className2: 'background:red;color:black;font-size:1.5rem;',
-      },
-    });
-
-    expect(res).toBe(
-      '@media(max-width:950px){.className1{background:green;color:white;font-size:1rem;}.className2{background:red;color:black;font-size:1.5rem;}}',
-    );
-  });
-
-  it('should support min-width media query rule', () => {
-    const res = toMediaQuery({
-      condition: '>950px',
-      cssByClassName: {
-        className1: 'background:green;color:white;font-size:1rem;',
-        className2: 'background:red;color:black;font-size:1.5rem;',
-      },
-    });
-
-    expect(res).toBe(
-      '@media(min-width:950px){.className1{background:green;color:white;font-size:1rem;}.className2{background:red;color:black;font-size:1.5rem;}}',
-    );
   });
 });

--- a/packages/core/src/utils/styleUtils/toMediaQuery.spec.ts
+++ b/packages/core/src/utils/styleUtils/toMediaQuery.spec.ts
@@ -1,0 +1,68 @@
+import { toMediaQuery } from './toMediaQuery';
+
+describe('toMediaQuery', () => {
+  it('should return css for default breakpoint without wrapping it into a media query', () => {
+    const res = toMediaQuery({
+      condition: '*',
+      cssByClassName: {
+        className1: 'background:green;color:white;font-size:1rem;',
+        className2: 'background:red;color:black;font-size:1.5rem;',
+      },
+    });
+
+    expect(res).toBe(
+      '.className1{background:green;color:white;font-size:1rem;}.className2{background:red;color:black;font-size:1.5rem;}',
+    );
+  });
+
+  it('should wrap styles for non default breakpoint into a media query', () => {
+    const res = toMediaQuery({
+      condition: '<950px',
+      cssByClassName: {
+        className1: 'background:green;color:white;font-size:1rem;',
+        className2: 'background:red;color:black;font-size:1.5rem;',
+      },
+    });
+
+    expect(res).toBe(
+      '@media(max-width:950px){.className1{background:green;color:white;font-size:1rem;}.className2{background:red;color:black;font-size:1.5rem;}}',
+    );
+  });
+
+  it('should support min-width media query rule', () => {
+    const res = toMediaQuery({
+      condition: '>950px',
+      cssByClassName: {
+        className1: 'background:green;color:white;font-size:1rem;',
+        className2: 'background:red;color:black;font-size:1.5rem;',
+      },
+    });
+
+    expect(res).toBe(
+      '@media(min-width:950px){.className1{background:green;color:white;font-size:1rem;}.className2{background:red;color:black;font-size:1.5rem;}}',
+    );
+  });
+
+  describe('when nextCondition is provided', () => {
+    const cssByClassName = { className1: 'background:green;' };
+    const resultCss = '.className1{background:green;}';
+
+    it('should create a negated media query rule', () => {
+      const res = toMediaQuery({
+        condition: '*',
+        nextCondition: '<950px',
+        cssByClassName,
+      });
+      expect(res).toBe(`@media not (max-width:950px){${resultCss}}`);
+    });
+
+    it('should should create a disjunct media query rule with not operator', () => {
+      const res = toMediaQuery({
+        condition: '<950px',
+        nextCondition: '>500px',
+        cssByClassName,
+      });
+      expect(res).toBe(`@media(max-width:950px) and (not (min-width:500px)){${resultCss}}`);
+    });
+  });
+});

--- a/packages/core/src/utils/styleUtils/toMediaQuery.ts
+++ b/packages/core/src/utils/styleUtils/toMediaQuery.ts
@@ -1,0 +1,59 @@
+/**
+ * Turns a condition like `<768px` or `>1024px` into a media query rule.
+ * For example, `<768px` becomes `max-width:768px` and `>1024px` becomes `min-width:1024px`.
+ */
+const toMediaQueryRule = (condition: string) => {
+  const [evaluation, pixelValue] = [condition[0], condition.substring(1)];
+  const mediaQueryRule = evaluation === '<' ? 'max-width' : 'min-width';
+  return `(${mediaQueryRule}:${pixelValue})`;
+};
+
+/**
+ * Converts a map of class names to CSS strings into a single CSS string.
+ *
+ * @param cssByClassName map of class names to CSS strings containing all rules for each class
+ * @returns joined string of all CSS class definitions
+ */
+const toCompoundCss = (cssByClassName: Record<string, string>): string => {
+  return Object.entries(cssByClassName).reduce<string>((acc, [className, css]) => {
+    if (css === '') return acc;
+    return `${acc}.${className}{${css}}`;
+  }, ``);
+};
+
+/**
+ * Create a single CSS string containing all class definitions for a given media query.
+ *
+ * @param cssByClassName map of class names to CSS strings containing all rules for each class
+ * @param condition e.g. "*", "<520px", ">520px"
+ * @param nextCondition optional next condition to create a disjunct media query that doesn't affect the next breakpoint
+ * @returns joined string of all CSS class definitions wrapped into media queries
+ */
+export const toMediaQuery = ({
+  cssByClassName,
+  condition,
+  nextCondition,
+}: {
+  cssByClassName: Record<string, string>;
+  condition: string;
+  nextCondition?: string;
+}) => {
+  const compoundCss = toCompoundCss(cssByClassName);
+  if (compoundCss === '') {
+    return '';
+  }
+
+  const queryRule = toMediaQueryRule(condition);
+  if (!nextCondition) {
+    if (condition === '*') {
+      return compoundCss;
+    }
+    return `@media${queryRule}{${compoundCss}}`;
+  }
+
+  const nextRule = toMediaQueryRule(nextCondition);
+  if (condition === '*') {
+    return `@media not ${nextRule}{${compoundCss}}`;
+  }
+  return `@media${queryRule} and (not ${nextRule}){${compoundCss}}`;
+};

--- a/packages/core/src/utils/transformers/media/transformMedia.ts
+++ b/packages/core/src/utils/transformers/media/transformMedia.ts
@@ -10,6 +10,7 @@ import { Asset, AssetDetails, AssetFile } from 'contentful';
 import { getOptimizedBackgroundImageAsset } from './getOptimizedBackgroundImageAsset';
 import { getOptimizedImageAsset } from './getOptimizedImageAsset';
 import { getBoundValue } from '@/utils/transformers/getBoundValue';
+// FIXME: Importing the parents parent folder is creating a circular dependency
 import { getTargetValueInPixels, isDeepPath, lastPathNamedSegmentEq, parseCSSValue } from '@/utils';
 import { ValidFormats } from './mediaUtils';
 

--- a/packages/experience-builder-sdk/src/hooks/useMediaQuery.spec.ts
+++ b/packages/experience-builder-sdk/src/hooks/useMediaQuery.spec.ts
@@ -128,7 +128,7 @@ describe('useMediaQuery', () => {
         `@media not (max-width:992px){.${desktop.className}{display:none !important;}}`,
       );
       expect(expectedResult.css).toContain(
-        `@media (max-width:992px) and (not (max-width:576px)){.${tablet.className}{display:none !important;}}`,
+        `@media(max-width:992px) and (not (max-width:576px)){.${tablet.className}{display:none !important;}}`,
       );
     });
   });


### PR DESCRIPTION
## Purpose

To fix the rendering of "mobile-only" nodes, the CSS transformation for `cfVisibility` was moved out of `buildCfStyles` and handled separately. ([PR](https://github.com/contentful/experience-builder/pull/1158))

Thanks to a customer, we learned today that this approach didn't cover SSR and instead even broke the functionality of `cfVisibility` as a whole.

## Approach

To get a back control on the flow for generating media queries in CSS, all related code was moved into a separate place `toMediaQuery.ts` which conditionally accepts the `nextCondition` parameter to create negated or disjunct media queries (required for visibility rendering).