### PR TITLE
fix(validators): remove unused full EntryProps type [SPA-2753]

### DIFF
--- a/packages/validators/src/test/__fixtures__/v2023_09_28/experience.ts
+++ b/packages/validators/src/test/__fixtures__/v2023_09_28/experience.ts
@@ -1,5 +1,3 @@
-import type { EntryProps } from 'contentful-management';
-
 export const experience = {
   metadata: {
     tags: [],
@@ -314,4 +312,4 @@ export const experience = {
       },
     },
   },
-} as EntryProps;
+};

--- a/packages/validators/src/validators/validateExperienceFields.ts
+++ b/packages/validators/src/validators/validateExperienceFields.ts
@@ -3,7 +3,6 @@ import { ValidatorReturnValue } from './ValidatorReturnValue';
 import { ExperienceSchema_2023_09_28 } from '../schemas';
 import { zodToContentfulError, CodeNames } from '@/utils/zodToContentfulError';
 import { validatePatternFields } from '@/validators/validatePatternFields';
-import type { EntryProps } from 'contentful-management';
 
 const VERSION_SCHEMAS = {
   '2023-09-28': ExperienceSchema_2023_09_28,
@@ -22,7 +21,8 @@ function isPattern(experience: any): boolean {
  * @returns object with success property and optional errors array
  */
 export const validateExperienceFields = (
-  experience: EntryProps,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- matches KeyValueMap in EntryProps['fields']
+  experience: { fields: Record<string, any> },
   schemaVersionOverride?: SchemaVersions,
 ): ValidatorReturnValue => {
   // If this is a pattern, use the pattern validator

--- a/packages/validators/src/validators/validatePatternFields.ts
+++ b/packages/validators/src/validators/validatePatternFields.ts
@@ -2,7 +2,6 @@ import { type SchemaVersions } from '../types';
 import { ValidatorReturnValue } from './ValidatorReturnValue';
 import { PatternSchema_2023_09_28 } from '../schemas';
 import { zodToContentfulError, CodeNames } from '@/utils/zodToContentfulError';
-import type { EntryProps } from 'contentful-management';
 
 const VERSION_SCHEMAS = {
   '2023-09-28': PatternSchema_2023_09_28,
@@ -16,7 +15,8 @@ const VERSION_SCHEMAS = {
  * @returns object with success property and optional errors array
  */
 export const validatePatternFields = (
-  pattern: EntryProps,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- matches KeyValueMap in EntryProps['fields']
+  pattern: { fields: Record<string, any> },
   schemaVersionOverride?: SchemaVersions,
 ): ValidatorReturnValue => {
   let schemaVersion: SchemaVersions | undefined;


### PR DESCRIPTION
We introduced the `EntryProps` type in https://github.com/contentful/experience-builder/pull/1132 for stricter typing. However, we're only interested in `entry.fields` and don't need a specific format for metadata in `sys`.

To support both backend & frontend, I first went with `{ fields: EntryProps['fields'] }`. But I noticed that this equal to `{ fields: Record<string, any> }`. So there is no real need to use `EntryProps` at all as the only thing it enforces is not used by the validators package at all.


