### PR TITLE
fix(core): throw error for invalid store objects [SPA-2862]

### DIFF
--- a/packages/core/src/entity/EntityStoreBase.ts
+++ b/packages/core/src/entity/EntityStoreBase.ts
@@ -3,6 +3,7 @@ import type { Asset, ChainModifiers, Entry, UnresolvedLink } from 'contentful';
 import { get } from '../utils/get';
 import { isLink } from '../utils/isLink';
 import { isDeepPath, parseDataSourcePathIntoFieldset } from '@/utils/pathSchema';
+import { isAsset, isEntry } from '@/utils/entityTypeChecks';
 
 /**
  * Base Store for entities
@@ -50,9 +51,13 @@ export abstract class EntityStoreBase {
         return;
       }
       entity = resolvedEntity;
-    } else {
+    } else if (isAsset(linkOrEntryOrAsset) || isEntry(linkOrEntryOrAsset)) {
       // We already have the complete entity in preview & delivery (resolved by the CMA client)
       entity = linkOrEntryOrAsset;
+    } else {
+      throw new Error(
+        `Unexpected object when resolving entity: ${JSON.stringify(linkOrEntryOrAsset)}`,
+      );
     }
     return entity;
   }
@@ -113,12 +118,14 @@ export abstract class EntityStoreBase {
   }
 
   protected addEntity(entity: Entry | Asset): void {
-    if (this.isAsset(entity)) {
+    if (isAsset(entity)) {
       this.assetMap.set(entity.sys.id, entity);
-    } else if (this.isEntry(entity)) {
+    } else if (isEntry(entity)) {
       this.entryMap.set(entity.sys.id, entity);
     } else {
-      console.warn('Attempted to add an entity that is neither Asset nor Entry:', entity);
+      throw new Error(
+        `Attempted to add an entity to the store that is neither Asset nor Entry: '${JSON.stringify(entity)}'`,
+      );
     }
   }
 
@@ -205,7 +212,7 @@ export abstract class EntityStoreBase {
           }
           resolvedFieldset.push([entityToResolveFieldsFrom, field, _localeQualifier]);
           entityToResolveFieldsFrom = entity; // we move up
-        } else if (this.isAsset(fieldValue) || this.isEntry(fieldValue)) {
+        } else if (isAsset(fieldValue) || isEntry(fieldValue)) {
           resolvedFieldset.push([entityToResolveFieldsFrom, field, _localeQualifier]);
           entityToResolveFieldsFrom = fieldValue; // we move up
         } else {
@@ -248,24 +255,6 @@ export abstract class EntityStoreBase {
     }
     const [leafEntity] = resolvedFieldset[resolvedFieldset.length - 1];
     return leafEntity;
-  }
-
-  private isAsset(value: unknown): value is Asset {
-    return (
-      null !== value &&
-      typeof value === 'object' &&
-      'sys' in value &&
-      (value as Asset).sys?.type === 'Asset'
-    );
-  }
-
-  private isEntry(value: unknown): value is Entry {
-    return (
-      null !== value &&
-      typeof value === 'object' &&
-      'sys' in value &&
-      (value as Entry).sys?.type === 'Entry'
-    );
   }
 
   private getEntity(type: 'Asset' | 'Entry', id: string) {

--- a/packages/core/src/utils/entityTypeChecks.ts
+++ b/packages/core/src/utils/entityTypeChecks.ts
@@ -1,0 +1,19 @@
+import { Asset, Entry } from 'contentful';
+
+export const isAsset = (value: unknown): value is Asset => {
+  return (
+    null !== value &&
+    typeof value === 'object' &&
+    'sys' in value &&
+    (value as Asset).sys?.type === 'Asset'
+  );
+};
+
+export const isEntry = (value: unknown): value is Entry => {
+  return (
+    null !== value &&
+    typeof value === 'object' &&
+    'sys' in value &&
+    (value as Entry).sys?.type === 'Entry'
+  );
+};

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -14,3 +14,4 @@ export * from './treeTraversal';
 export * from './typeguards';
 export * from './utils';
 export * from './validations';
+export * from './entityTypeChecks';

--- a/packages/core/src/utils/transformers/getResolvedEntryFromLink.ts
+++ b/packages/core/src/utils/transformers/getResolvedEntryFromLink.ts
@@ -1,14 +1,17 @@
 import { Asset, Entry, UnresolvedLink } from 'contentful';
 import { get } from '../get';
 import { EntityStoreBase } from '@/entity';
+import { isAsset, isEntry } from '../entityTypeChecks';
 
 export function getResolvedEntryFromLink(
   entryOrAsset: Entry | Asset,
   path: string,
   entityStore: EntityStoreBase,
 ) {
-  if (entryOrAsset.sys.type === 'Asset') {
+  if (isAsset(entryOrAsset)) {
     return entryOrAsset;
+  } else if (!isEntry(entryOrAsset)) {
+    throw new Error(`Expected an Entry or Asset, but got: ${JSON.stringify(entryOrAsset)}`);
   }
 
   const value = get<UnresolvedLink<'Entry'>>(entryOrAsset, path.split('/').slice(2, -1));

--- a/packages/visual-editor/src/hooks/useSingleColumn.ts
+++ b/packages/visual-editor/src/hooks/useSingleColumn.ts
@@ -22,7 +22,7 @@ export default function useSingleColumn(
     }
 
     const { cfWrapColumns } = parentNode.data.props;
-    if (cfWrapColumns.type !== 'DesignValue') {
+    if (cfWrapColumns?.type !== 'DesignValue') {
       return false;
     }
 


### PR DESCRIPTION
## Purpose

We're often seeing this error: `Cannot read properties of undefined (reading 'type')`
I discovered two causes for this:
- Either the parent in `useSingleColumn` is not a "columns" node
- The entry/ asset in the EntityStore is neither an entry nor an asset (e.g. see ZEND-6498, caused by wrong JSON serialization logic)

## Approach
In both cases, the page crashes, leaving little information to investigate. As it already crashes for those unexpected situations, the logic catches those now more explicit and throws an explicit error instead. The main reason seems to be having objects in the store that are neither entries nor assets which will also be addressed by [this change](https://github.com/contentful/experience-builder/commit/556fd40f7fe5c100a7b8e534df5c9b29ed9295b4).

As they are not necessary for the store, I moved the class methods `isAsset` and `isEntry` into a separate util file.