### PR TITLE
fix: remove contentType from PatternProperty schema [SPA-2791]

### DIFF
--- a/packages/experience-builder-sdk/src/core/preview/assemblyUtils.spec.ts
+++ b/packages/experience-builder-sdk/src/core/preview/assemblyUtils.spec.ts
@@ -112,7 +112,6 @@ describe('resolveAssembly', () => {
         children: [],
         patternProperties: {
           [patternPropertyId]: {
-            contentType: 'testContentType',
             path: '/1230948',
             type: 'BoundValue',
           },
@@ -125,7 +124,6 @@ describe('resolveAssembly', () => {
         patternRootNodeIdsChain: 'assembly-id',
         parentPatternProperties: {
           [patternPropertyId2]: {
-            contentType: 'testContentType',
             path: '/4091203i9',
             type: 'BoundValue',
           },
@@ -134,12 +132,10 @@ describe('resolveAssembly', () => {
 
       expect(result.patternProperties).toEqual({
         ['patternPropertyId']: {
-          contentType: 'testContentType',
           path: '/1230948',
           type: 'BoundValue',
         },
         ['patternPropertyId2']: {
-          contentType: 'testContentType',
           path: '/4091203i9',
           type: 'BoundValue',
         },

--- a/packages/experience-builder-sdk/src/core/preview/assemblyUtils.ts
+++ b/packages/experience-builder-sdk/src/core/preview/assemblyUtils.ts
@@ -17,11 +17,13 @@ export const deserializeAssemblyNode = ({
   componentInstanceVariables,
   componentSettings,
   patternProperties,
+  entityStore,
 }: {
   node: ComponentTreeNode;
   componentInstanceVariables: ComponentTreeNode['variables'];
   componentSettings: ExperienceComponentSettings;
   patternProperties: Record<string, PatternProperty>;
+  entityStore: EntityStore;
 }): ComponentTreeNode => {
   const variables: Record<string, ComponentPropertyValue> = {};
 
@@ -43,6 +45,7 @@ export const deserializeAssemblyNode = ({
         componentSettings,
         componentValueKey,
         patternProperties,
+        entityStore,
       });
 
       if (usePrebinding && path) {
@@ -93,6 +96,7 @@ export const deserializeAssemblyNode = ({
       componentInstanceVariables,
       componentSettings,
       patternProperties,
+      entityStore,
     }),
   );
 
@@ -165,6 +169,7 @@ export const resolveAssembly = ({
     componentInstanceVariables: node.variables,
     componentSettings: componentFields.componentSettings!,
     patternProperties,
+    entityStore,
   });
 
   entityStore.addAssemblyUnboundValues(componentFields.unboundValues);

--- a/packages/experience-builder-sdk/src/utils/prebindingUtils.ts
+++ b/packages/experience-builder-sdk/src/utils/prebindingUtils.ts
@@ -1,3 +1,4 @@
+import { EntityStore } from '@contentful/experiences-core';
 import {
   ComponentPropertyValue,
   ExperienceComponentSettings,
@@ -33,10 +34,12 @@ export const resolvePrebindingPath = ({
   componentValueKey,
   componentSettings,
   patternProperties,
+  entityStore,
 }: {
   componentValueKey: string;
   componentSettings: ExperienceComponentSettings;
   patternProperties: Record<string, PatternProperty>;
+  entityStore: EntityStore;
 }) => {
   const variableMapping = componentSettings.variableMappings?.[componentValueKey];
 
@@ -46,7 +49,15 @@ export const resolvePrebindingPath = ({
 
   if (!patternProperty) return '';
 
-  const contentType = patternProperty.contentType;
+  const dataSourceKey = patternProperty.path.split('/')[1];
+
+  const entityLink = entityStore.dataSource[dataSourceKey];
+  if (!entityLink) return '';
+
+  const entity = entityStore.getEntityFromLink(entityLink);
+  if (!entity || entity.sys.type === 'Asset') return '';
+
+  const contentType = entity.sys.contentType.sys.id;
 
   const fieldPath = variableMapping?.pathsByContentType?.[contentType]?.path;
 

--- a/packages/experience-builder-sdk/test/__fixtures__/entities.ts
+++ b/packages/experience-builder-sdk/test/__fixtures__/entities.ts
@@ -1,5 +1,7 @@
 import { Asset, AssetFile, Entry } from 'contentful';
 
+export const CONTENT_TYPE_ID = 'testContentType';
+
 export const entityIds = {
   ENTRY1: 'entry1',
   ENTRY2: 'entry2',
@@ -12,7 +14,7 @@ export const entries: Entry[] = [
       type: 'Entry',
       contentType: {
         sys: {
-          id: 'bar',
+          id: CONTENT_TYPE_ID,
           type: 'Link',
           linkType: 'ContentType',
         },
@@ -49,7 +51,7 @@ export const entries: Entry[] = [
       type: 'Entry',
       contentType: {
         sys: {
-          id: 'bar',
+          id: CONTENT_TYPE_ID,
           type: 'Link',
           linkType: 'ContentType',
         },

--- a/packages/experience-builder-sdk/test/__fixtures__/index.ts
+++ b/packages/experience-builder-sdk/test/__fixtures__/index.ts
@@ -1,0 +1,6 @@
+export * from './composition';
+export * from './assembly';
+export * from './entities';
+export * from './breakpoints';
+export * from './componentDefinition';
+export * from './componentTreeNode';

--- a/packages/validators/src/schemas/v2023_09_28/common.ts
+++ b/packages/validators/src/schemas/v2023_09_28/common.ts
@@ -180,7 +180,6 @@ export type ComponentPropertyValue = z.infer<typeof ComponentPropertyValueSchema
 export const PatternPropertySchema = z.object({
   type: z.literal('BoundValue'),
   path: z.string(),
-  contentType: z.string(),
 });
 
 export const PatternPropertiesSchema = z.record(propertyKeySchema, PatternPropertySchema);


### PR DESCRIPTION
## Purpose
We have decided to not store the contentTypeId in the pattern properties so we need to remove it from the schema, otherwise validation of the experience will fail.

## Approach

After removing the field from `patternProperties` I needed to adjust the path resolving logic to get the ContentType ID by looking up the entity in the entityStore and getting its ContentType ID. The tests have been updated accordingly.

<!--
Remember when merging:
- Use "Squash and merge" when merging changes into development.
- Use "Create a merge commit" when releasing changes into next and main.

Three important notes on pull requests:
- In general, you should ask yourself whether this code change will improve or worsen the overall code quality. Any new tech debt will probably never be cleaned up.
- Please remember that newly introduced logic should be validated and protected through testing.
- Take a look at PR guides:
  Google's Code Review Guidelines: https://google.github.io/eng-practices/
  Blockly - Writing a Good Pull Request: https://developers.google.com/blockly/guides/contribute/get-started/write_a_good_pr
-->
