### PR TITLE
fix(core): handle entry fields being already resolved links [SPA-2863] [ZEND-6194]

### DIFF
--- a/packages/core/src/utils/transformers/getResolvedEntryFromLink.ts
+++ b/packages/core/src/utils/transformers/getResolvedEntryFromLink.ts
@@ -14,17 +14,24 @@ export function getResolvedEntryFromLink(
     throw new Error(`Expected an Entry or Asset, but got: ${JSON.stringify(entryOrAsset)}`);
   }
 
-  const value = get<UnresolvedLink<'Entry'>>(entryOrAsset, path.split('/').slice(2, -1));
+  const value = get<UnresolvedLink<'Entry'> | Entry | Asset>(
+    entryOrAsset,
+    path.split('/').slice(2, -1),
+  );
 
-  if (value?.sys.type !== 'Link') {
+  let resolvedEntity: Entry | Asset | undefined;
+
+  if (isAsset(value) || isEntry(value)) {
+    // In some cases, reference fields are already resolved
+    resolvedEntity = value;
+  } else if (value?.sys.type === 'Link') {
+    // Look up the reference in the entity store
+    resolvedEntity = entityStore.getEntityFromLink(value);
+    if (!resolvedEntity) {
+      return;
+    }
+  } else {
     console.warn(`Expected a link to a reference, but got: ${JSON.stringify(value)}`);
-    return;
-  }
-
-  //Look up the reference in the entity store
-  const resolvedEntity = entityStore.getEntityFromLink(value);
-
-  if (!resolvedEntity) {
     return;
   }
 


### PR DESCRIPTION
## Purpose

When using `Link` properties in custom components, the links might not be correctly resolved depending on other `Link` properties in the same experience being populated.

Warning message that showed up in the logs:
```
Expected a link to a reference, but got: { "type":"Entry", ... }
```

## Approach

So the entity store can contain entries with resolved references while `getResolvedEntryFromLink` enforced those to be links until now. I adjusted that method to gracefully accept already resolved references as well.