### PR TITLE
[SPA-2496] Improve Initialization Experience

### DIFF
--- a/packages/core/src/components/IframeLoading.tsx
+++ b/packages/core/src/components/IframeLoading.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+export function IframeLoading() {
+  return (
+    <div style={{ width: '100%', paddingTop: '16px' }}>
+      <p style={{ textAlign: 'center' }}>Loading...</p>
+    </div>
+  );
+}

--- a/packages/core/src/components/index.ts
+++ b/packages/core/src/components/index.ts
@@ -1,0 +1,1 @@
+export * from './IframeLoading';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -6,3 +6,4 @@ export * from './enums';
 export * from './fetchers';
 export * from './registries';
 export * from './deep-binding';
+export * from './components';

--- a/packages/experience-builder-sdk/src/blocks/editor/VisualEditorLoader.tsx
+++ b/packages/experience-builder-sdk/src/blocks/editor/VisualEditorLoader.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { EntityStore, VisualEditorMode } from '@contentful/experiences-core';
+import { EntityStore, IframeLoading, VisualEditorMode } from '@contentful/experiences-core';
 import type { Experience } from '@contentful/experiences-core/types';
 
 type VisualEditorLoaderProps = {
@@ -33,7 +33,7 @@ export const VisualEditorLoader: React.FC<VisualEditorLoaderProps> = ({
     }
   }, [visualEditorMode]);
 
-  if (!VisualEditor) return null;
+  if (!VisualEditor) return <IframeLoading />;
 
   return <VisualEditor experience={experience} />;
 };

--- a/packages/experience-builder-sdk/src/blocks/editor/VisualEditorRoot.tsx
+++ b/packages/experience-builder-sdk/src/blocks/editor/VisualEditorRoot.tsx
@@ -1,5 +1,5 @@
 import React, { Suspense } from 'react';
-import { EntityStore, VisualEditorMode } from '@contentful/experiences-core';
+import { EntityStore, IframeLoading, VisualEditorMode } from '@contentful/experiences-core';
 import { ErrorBoundary } from '../../components/ErrorBoundary';
 import { useInitializeVisualEditor } from '../../hooks/useInitializeVisualEditor';
 import type { Experience } from '@contentful/experiences-core/types';
@@ -26,7 +26,7 @@ export const VisualEditorRoot: React.FC<VisualEditorRootProps> = ({
 
   return (
     <ErrorBoundary>
-      <Suspense fallback={<div>Loading...</div>}>
+      <Suspense fallback={<IframeLoading />}>
         <VisualEditorLoader experience={experience} visualEditorMode={visualEditorMode} />
       </Suspense>
     </ErrorBoundary>

--- a/packages/visual-editor/src/components/RootRenderer/RootRenderer.tsx
+++ b/packages/visual-editor/src/components/RootRenderer/RootRenderer.tsx
@@ -9,7 +9,7 @@ import styles from './render.module.css';
 import { useBreakpoints } from '@/hooks/useBreakpoints';
 import { useEditorSubscriber } from '@/hooks/useEditorSubscriber';
 import { DNDProvider } from './DNDProvider';
-import { sendMessage } from '@contentful/experiences-core';
+import { IframeLoading, sendMessage } from '@contentful/experiences-core';
 import { OUTGOING_EVENTS } from '@contentful/experiences-core/constants';
 import { useEditorStore } from '@/store/editor';
 import { Dropzone } from '@components/DraggableBlock/Dropzone';
@@ -30,6 +30,7 @@ export const RootRenderer: React.FC<RootRendererProperties> = ({ onChange }) => 
   const { resolveDesignValue } = useBreakpoints(breakpoints);
   const [containerStyles, setContainerStyles] = useState<CSSProperties>({});
   const tree = useTreeStore((state) => state.tree);
+  const isTreeReady = useTreeStore((state) => state.isReady);
 
   const handleMouseOver = useCallback(() => {
     // Remove hover state set by UI when mouse is over canvas
@@ -116,6 +117,10 @@ export const RootRenderer: React.FC<RootRendererProperties> = ({ onChange }) => 
     handleResizeCanvas();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [containerRef.current]);
+
+  if (!isTreeReady) {
+    return <IframeLoading />;
+  }
 
   return (
     <DNDProvider>

--- a/packages/visual-editor/src/components/VisualEditorRoot.tsx
+++ b/packages/visual-editor/src/components/VisualEditorRoot.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react';
-import { EntityStore, sendMessage } from '@contentful/experiences-core';
+import { EntityStore, IframeLoading, sendMessage } from '@contentful/experiences-core';
 import { RootRenderer } from './RootRenderer/RootRenderer';
 import SimulateDnD from '@/utils/simulateDnD';
 import { OUTGOING_EVENTS } from '@contentful/experiences-core/constants';
@@ -57,7 +57,7 @@ export const VisualEditorRoot = ({ experience }: { experience?: Experience<Entit
     };
   }, [setHoveringZone, setMousePosition]);
 
-  if (!initialized) return null;
+  if (!initialized) return <IframeLoading />;
 
   return <RootRenderer />;
 };

--- a/packages/visual-editor/src/store/tree.ts
+++ b/packages/visual-editor/src/store/tree.ts
@@ -19,6 +19,7 @@ import { ASSEMBLY_NODE_TYPE } from '@contentful/experiences-core/constants';
 import { treeVisit } from '@contentful/experiences-core';
 import { isEqual } from 'lodash-es';
 export interface TreeStore {
+  isReady: boolean;
   tree: ExperienceTree;
   breakpoints: Breakpoint[];
   updateTree: (tree: ExperienceTree) => void;
@@ -43,6 +44,7 @@ export interface TreeStore {
 }
 
 export const useTreeStore = create<TreeStore>((set, get) => ({
+  isReady: false,
   tree: {
     root: {
       children: [],
@@ -89,6 +91,7 @@ export const useTreeStore = create<TreeStore>((set, get) => ({
       tree,
       // Breakpoints must be updated, as we receive completely new tree with possibly new breakpoints
       breakpoints: tree?.root?.data?.breakpoints || [],
+      isReady: true,
     });
   },
   updateTree: (tree) => {
@@ -148,6 +151,7 @@ export const useTreeStore = create<TreeStore>((set, get) => ({
         });
 
         state.breakpoints = tree?.root?.data?.breakpoints || [];
+        state.isReady = true;
       }),
     );
   },


### PR DESCRIPTION
## Purpose

This PR focuses on improving the user experience during the initialization of Studio. 
Ticket: https://contentful.atlassian.net/browse/SPA-2496

## Approach

- Add `isReady` flag to `treeStore` to make sure we know when the tree is actually ready to render
- Extract the existing Loading inline component in SDK into a reusable component
    - IframeLoading component is created inside core package, because it had to be accessed by both SDK and Visual Editor
- Update all of the steps in initialization of Visual Editor with the extracted IframeLoading component, so there are no more flashes of white screen
- Add IframeLoading with `isReady` flag check, so there are no flash of empty canvas state