### PR TITLE
rename patternPropertyDefinitions, patternPropertyDefinitionId, and patternProperties [SPA-2844]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2507,6 +2507,7 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {

--- a/packages/core/src/fetchers/attachPrebindingDefaultValueAsDataSource.spec.ts
+++ b/packages/core/src/fetchers/attachPrebindingDefaultValueAsDataSource.spec.ts
@@ -14,11 +14,45 @@ describe('attachPrebindingDefaultValueAsDataSource', () => {
   });
 
   it('should return early if not a pattern', () => {
-    const experience = {} as unknown as ExperienceEntry;
+    const getterStub = vi.fn();
+    const experience = {
+      get fields() {
+        getterStub();
+        return {
+          componentSettings: {
+            parameterDefinitions: {},
+            variableDefinitions: {},
+          },
+          dataSource: {},
+        };
+      },
+    } as unknown as ExperienceEntry;
 
     mockCheckIsAssemblyEntry.mockReturnValue(false);
 
-    expect(attachPrebindingDefaultValueAsDataSource(experience)).toBeUndefined();
+    attachPrebindingDefaultValueAsDataSource(experience);
+    expect(getterStub).not.toHaveBeenCalled();
+  });
+
+  it('should not return early if a pattern', () => {
+    const getterStub = vi.fn();
+    const experience = {
+      get fields() {
+        getterStub();
+        return {
+          componentSettings: {
+            parameterDefinitions: {},
+            variableDefinitions: {},
+          },
+          dataSource: {},
+        };
+      },
+    } as unknown as ExperienceEntry;
+
+    mockCheckIsAssemblyEntry.mockReturnValue(true);
+
+    attachPrebindingDefaultValueAsDataSource(experience);
+    expect(getterStub).toHaveBeenCalled();
   });
 
   it('should attach default prebinding value to dataSource', () => {
@@ -26,7 +60,7 @@ describe('attachPrebindingDefaultValueAsDataSource', () => {
     experience.fields = {
       ...experience.fields,
       componentSettings: {
-        patternPropertyDefinitions: {
+        parameterDefinitions: {
           someField: {
             defaultValue: {
               defaultBinding: {
@@ -64,7 +98,7 @@ describe('attachPrebindingDefaultValueAsDataSource', () => {
       fields: {
         ...experience.fields,
         componentSettings: {
-          patternPropertyDefinitions: {
+          parameterDefinitions: {
             someField: {
               contentTypes: {},
               defaultValue: undefined,

--- a/packages/core/src/fetchers/attachPrebindingDefaultValueAsDataSource.ts
+++ b/packages/core/src/fetchers/attachPrebindingDefaultValueAsDataSource.ts
@@ -17,7 +17,7 @@ export const attachPrebindingDefaultValueAsDataSource = (
     return;
   }
 
-  const patternDefs = experienceEntry.fields.componentSettings?.patternPropertyDefinitions ?? {};
+  const patternDefs = experienceEntry.fields.componentSettings?.parameterDefinitions ?? {};
   const defaultPrebinding = Object.values(patternDefs).find(
     (def) => def.defaultValue,
   )?.defaultValue;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -182,7 +182,7 @@ export type ExperienceTreeNode = {
     dataSource: ExperienceDataSource;
     unboundValues: ExperienceUnboundValues;
     breakpoints: Breakpoint[];
-    patternProperties?: Record<string, PatternProperty>;
+    parameters?: Record<string, PatternProperty>;
     pattern?: {
       id: string;
       nodeId: string;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -35,7 +35,7 @@ export type {
   ComponentValue,
   ComponentDefinitionPropertyType as ComponentDefinitionVariableType,
   PatternProperty,
-  PatternPropertyDefinition,
+  ParameterDefinition,
   VariableMapping,
 } from '@contentful/experiences-validators';
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -16,7 +16,7 @@ import type {
   ExperienceComponentTree,
   ComponentDefinitionPropertyType,
   BindingSourceTypeEnum,
-  PatternProperty,
+  Parameter,
 } from '@contentful/experiences-validators';
 export type {
   ExperienceDataSource,
@@ -34,7 +34,7 @@ export type {
   NoValue,
   ComponentValue,
   ComponentDefinitionPropertyType as ComponentDefinitionVariableType,
-  PatternProperty,
+  Parameter,
   ParameterDefinition,
   VariableMapping,
 } from '@contentful/experiences-validators';
@@ -182,7 +182,7 @@ export type ExperienceTreeNode = {
     dataSource: ExperienceDataSource;
     unboundValues: ExperienceUnboundValues;
     breakpoints: Breakpoint[];
-    parameters?: Record<string, PatternProperty>;
+    parameters?: Record<string, Parameter>;
     pattern?: {
       id: string;
       nodeId: string;

--- a/packages/experience-builder-sdk/src/blocks/preview/CompositionBlock.tsx
+++ b/packages/experience-builder-sdk/src/blocks/preview/CompositionBlock.tsx
@@ -16,7 +16,7 @@ import {
 import type {
   ComponentTreeNode,
   DesignValue,
-  PatternProperty,
+  Parameter,
   PrimitiveValue,
   ResolveDesignValueType,
   StyleProps,
@@ -48,7 +48,7 @@ type CompositionBlockProps = {
    * when storing & accessing cfSsrClassName.
    */
   patternRootNodeIdsChain?: string;
-  wrappingPatternProperties?: Record<string, PatternProperty>;
+  wrappingParameters?: Record<string, Parameter>;
 };
 
 export const CompositionBlock = ({
@@ -59,7 +59,7 @@ export const CompositionBlock = ({
   resolveDesignValue,
   getPatternChildNodeClassName,
   wrappingPatternIds: parentWrappingPatternIds = new Set(),
-  wrappingPatternProperties: parentWrappingPatternProperties = {},
+  wrappingParameters: parentWrappingParameters = {},
   patternRootNodeIdsChain: parentPatternRootNodeIdsChain = '',
 }: CompositionBlockProps) => {
   const isPatternNode = useMemo(() => {
@@ -86,19 +86,13 @@ export const CompositionBlock = ({
       return resolvePattern({
         node: rawNode,
         entityStore,
-        parentPatternProperties: parentWrappingPatternProperties,
+        parentParameters: parentWrappingParameters,
         patternRootNodeIdsChain,
       });
     } else {
       return rawNode;
     }
-  }, [
-    entityStore,
-    isPatternNode,
-    rawNode,
-    parentWrappingPatternProperties,
-    patternRootNodeIdsChain,
-  ]);
+  }, [entityStore, isPatternNode, rawNode, parentWrappingParameters, patternRootNodeIdsChain]);
 
   const wrappingPatternIds = useMemo(() => {
     if (isPatternNode) {
@@ -110,12 +104,12 @@ export const CompositionBlock = ({
   // Merge the pattern properties of the current node with the parent's pattern properties
   // to ensure nested patterns receive relevant pattern properties that were bubbled up
   // during assembly serialization.
-  const wrappingPatternProperties = useMemo(() => {
+  const wrappingParameters = useMemo(() => {
     if (isPatternNode) {
-      return { ...parentWrappingPatternProperties, ...(rawNode.parameters || {}) };
+      return { ...parentWrappingParameters, ...(rawNode.parameters || {}) };
     }
-    return parentWrappingPatternProperties;
-  }, [isPatternNode, rawNode, parentWrappingPatternProperties]);
+    return parentWrappingParameters;
+  }, [isPatternNode, rawNode, parentWrappingParameters]);
 
   const componentRegistration = useMemo(() => {
     const registration = getComponentRegistration(node.definitionId as string);
@@ -230,7 +224,7 @@ export const CompositionBlock = ({
               entityStore={entityStore}
               resolveDesignValue={resolveDesignValue}
               wrappingPatternIds={wrappingPatternIds}
-              wrappingPatternProperties={wrappingPatternProperties}
+              wrappingParameters={wrappingParameters}
               patternRootNodeIdsChain={patternRootNodeIdsChain}
             />
           );
@@ -266,7 +260,7 @@ export const CompositionBlock = ({
     hyperlinkPattern,
     locale,
     wrappingPatternIds,
-    wrappingPatternProperties,
+    wrappingParameters,
     patternRootNodeIdsChain,
   ]);
 
@@ -313,7 +307,7 @@ export const CompositionBlock = ({
               entityStore={entityStore}
               resolveDesignValue={resolveDesignValue}
               wrappingPatternIds={wrappingPatternIds}
-              wrappingPatternProperties={wrappingPatternProperties}
+              wrappingParameters={wrappingParameters}
               patternRootNodeIdsChain={patternRootNodeIdsChain}
             />
           );

--- a/packages/experience-builder-sdk/src/blocks/preview/CompositionBlock.tsx
+++ b/packages/experience-builder-sdk/src/blocks/preview/CompositionBlock.tsx
@@ -1,5 +1,6 @@
 import React, { ReactNode, useMemo } from 'react';
 import type { UnresolvedLink } from 'contentful';
+import { Entry } from 'contentful';
 import {
   checkIsAssemblyEntry,
   checkIsAssemblyNode,
@@ -30,7 +31,6 @@ import {
 } from '@contentful/experiences-components-react';
 import { resolvePattern } from '../../core/preview/assemblyUtils';
 import { resolveMaybePrebindingDefaultValuePath } from '../../utils/prebindingUtils';
-import { Entry } from 'contentful';
 import PreviewUnboundImage from './PreviewUnboundImage';
 import { parseComponentProps } from '../../utils/parseComponentProps';
 
@@ -75,7 +75,7 @@ export const CompositionBlock = ({
 
   const patternRootNodeIdsChain = useMemo(() => {
     if (isPatternNode) {
-      // Pattern nodes are chained without a separator (following the format for prebinding/patternProperties)
+      // Pattern nodes are chained without a separator (following the format for prebinding/parameters)
       return `${parentPatternRootNodeIdsChain}${rawNode.id}`;
     }
     return parentPatternRootNodeIdsChain;
@@ -112,7 +112,7 @@ export const CompositionBlock = ({
   // during assembly serialization.
   const wrappingPatternProperties = useMemo(() => {
     if (isPatternNode) {
-      return { ...parentWrappingPatternProperties, ...(rawNode.patternProperties || {}) };
+      return { ...parentWrappingPatternProperties, ...(rawNode.parameters || {}) };
     }
     return parentWrappingPatternProperties;
   }, [isPatternNode, rawNode, parentWrappingPatternProperties]);
@@ -170,7 +170,7 @@ export const CompositionBlock = ({
       resolveBoundValue: ({ binding, propertyName, dataType }) => {
         const [, uuid] = binding.path.split('/');
         const boundEntityLink = entityStore.dataSource[uuid] as UnresolvedLink<'Entry' | 'Asset'>;
-        const boundValue = transformBoundContentValue(
+        return transformBoundContentValue(
           node.variables,
           entityStore,
           boundEntityLink,
@@ -179,22 +179,18 @@ export const CompositionBlock = ({
           dataType,
           binding.path,
         );
-
-        return boundValue;
       },
       resolveHyperlinkValue: ({ linkTargetKey }) => {
         const boundEntity = entityStore.dataSource[linkTargetKey];
         const hyperlinkEntry = entityStore.getEntryOrAsset(boundEntity, linkTargetKey);
 
-        const value = resolveHyperlinkPattern(
+        return resolveHyperlinkPattern(
           componentRegistration.definition.hyperlinkPattern ||
             hyperlinkPattern ||
             HYPERLINK_DEFAULT_PATTERN,
           hyperlinkEntry as Entry,
           locale,
         );
-
-        return value;
       },
       resolveUnboundValue: ({ mappingKey, defaultValue }) => {
         return entityStore.unboundValues[mappingKey]?.value ?? defaultValue;

--- a/packages/experience-builder-sdk/src/core/preview/assemblyUtils.spec.ts
+++ b/packages/experience-builder-sdk/src/core/preview/assemblyUtils.spec.ts
@@ -27,7 +27,7 @@ describe('resolvePattern', () => {
     const result = resolvePattern({
       node: containerNode,
       entityStore,
-      parentPatternProperties: {},
+      parentParameters: {},
       patternRootNodeIdsChain: '',
     });
 
@@ -50,7 +50,7 @@ describe('resolvePattern', () => {
     const result = resolvePattern({
       node: assemblyNode,
       entityStore,
-      parentPatternProperties: {},
+      parentParameters: {},
       patternRootNodeIdsChain: '',
     });
 
@@ -85,7 +85,7 @@ describe('resolvePattern', () => {
       const result = resolvePattern({
         node: assemblyNode,
         entityStore,
-        parentPatternProperties: {},
+        parentParameters: {},
         patternRootNodeIdsChain: '',
       });
 
@@ -102,16 +102,15 @@ describe('resolvePattern', () => {
     });
 
     it('should return an assembly node with parent parameters', () => {
-      const patternPropertyId = md5('assembly-id') + PATTERN_PROPERTY_DIVIDER + 'patternPropertyId';
-      const patternPropertyId2 =
-        md5('assembly-id') + PATTERN_PROPERTY_DIVIDER + 'patternPropertyId2';
+      const parameterId = md5('assembly-id') + PATTERN_PROPERTY_DIVIDER + 'parameterId';
+      const parameterId2 = md5('assembly-id') + PATTERN_PROPERTY_DIVIDER + 'parameterId2';
       const assemblyNode: ComponentTreeNode = {
         definitionId: 'assembly-id',
         id: 'assembly-id',
         variables: {},
         children: [],
         parameters: {
-          [patternPropertyId]: {
+          [parameterId]: {
             path: '/1230948',
             type: 'BoundValue',
           },
@@ -122,8 +121,8 @@ describe('resolvePattern', () => {
         node: assemblyNode,
         entityStore,
         patternRootNodeIdsChain: 'assembly-id',
-        parentPatternProperties: {
-          [patternPropertyId2]: {
+        parentParameters: {
+          [parameterId2]: {
             path: '/4091203i9',
             type: 'BoundValue',
           },
@@ -131,11 +130,11 @@ describe('resolvePattern', () => {
       });
 
       expect(result.parameters).toEqual({
-        ['patternPropertyId']: {
+        ['parameterId']: {
           path: '/1230948',
           type: 'BoundValue',
         },
-        ['patternPropertyId2']: {
+        ['parameterId2']: {
           path: '/4091203i9',
           type: 'BoundValue',
         },
@@ -157,7 +156,7 @@ describe('resolvePattern', () => {
       const result = resolvePattern({
         node: assemblyNode,
         entityStore,
-        parentPatternProperties: {},
+        parentParameters: {},
         patternRootNodeIdsChain: '',
       });
 
@@ -177,7 +176,7 @@ describe('resolvePattern', () => {
       const result = resolvePattern({
         node: assemblyNode,
         entityStore,
-        parentPatternProperties: {},
+        parentParameters: {},
         patternRootNodeIdsChain: '',
       });
 

--- a/packages/experience-builder-sdk/src/core/preview/assemblyUtils.spec.ts
+++ b/packages/experience-builder-sdk/src/core/preview/assemblyUtils.spec.ts
@@ -1,11 +1,11 @@
 import type { Entry } from 'contentful';
 import md5 from 'md5';
-import { experienceEntry } from '../../../test/__fixtures__/composition';
+import { experienceEntry } from '../../../test/__fixtures__';
 import {
   assemblyGeneratedDesignVariableName,
   createAssemblyEntry,
-} from '../../../test/__fixtures__/assembly';
-import { assets, entries } from '../../../test/__fixtures__/entities';
+} from '../../../test/__fixtures__';
+import { assets, entries } from '../../../test/__fixtures__';
 import {
   CONTENTFUL_COMPONENTS,
   PATTERN_PROPERTY_DIVIDER,
@@ -101,7 +101,7 @@ describe('resolvePattern', () => {
       });
     });
 
-    it('should return an assembly node with parent patternProperties', () => {
+    it('should return an assembly node with parent parameters', () => {
       const patternPropertyId = md5('assembly-id') + PATTERN_PROPERTY_DIVIDER + 'patternPropertyId';
       const patternPropertyId2 =
         md5('assembly-id') + PATTERN_PROPERTY_DIVIDER + 'patternPropertyId2';
@@ -110,7 +110,7 @@ describe('resolvePattern', () => {
         id: 'assembly-id',
         variables: {},
         children: [],
-        patternProperties: {
+        parameters: {
           [patternPropertyId]: {
             path: '/1230948',
             type: 'BoundValue',
@@ -130,7 +130,7 @@ describe('resolvePattern', () => {
         },
       });
 
-      expect(result.patternProperties).toEqual({
+      expect(result.parameters).toEqual({
         ['patternPropertyId']: {
           path: '/1230948',
           type: 'BoundValue',

--- a/packages/experience-builder-sdk/src/core/preview/assemblyUtils.ts
+++ b/packages/experience-builder-sdk/src/core/preview/assemblyUtils.ts
@@ -5,7 +5,7 @@ import type {
   ComponentTreeNode,
   DesignValue,
   ExperienceComponentSettings,
-  PatternProperty,
+  Parameter,
 } from '@contentful/experiences-core/types';
 import { resolvePrebindingPath, shouldUsePrebinding } from '../../utils/prebindingUtils';
 import { PATTERN_PROPERTY_DIVIDER } from '@contentful/experiences-core/constants';
@@ -22,7 +22,7 @@ export const deserializePatternNode = ({
   node: ComponentTreeNode;
   componentInstanceVariables: ComponentTreeNode['variables'];
   componentSettings: ExperienceComponentSettings;
-  parameters: Record<string, PatternProperty>;
+  parameters: Record<string, Parameter>;
   entityStore: EntityStore;
 }): ComponentTreeNode => {
   const variables: Record<string, ComponentPropertyValue> = {};
@@ -113,13 +113,13 @@ export const deserializePatternNode = ({
 
 export const resolvePattern = ({
   node,
-  parentPatternProperties,
+  parentParameters,
   patternRootNodeIdsChain,
   entityStore,
 }: {
   node: ComponentTreeNode;
   entityStore: EntityStore;
-  parentPatternProperties: Record<string, PatternProperty>;
+  parentParameters: Record<string, Parameter>;
   patternRootNodeIdsChain: string;
 }) => {
   const componentId = node.definitionId as string;
@@ -131,20 +131,20 @@ export const resolvePattern = ({
     return node;
   }
 
-  const parameters: Record<string, PatternProperty> = {};
+  const parameters: Record<string, Parameter> = {};
 
-  const allPatternProperties = {
-    ...parentPatternProperties,
+  const allParameters = {
+    ...parentParameters,
     ...(node.parameters || {}),
   };
 
-  for (const [patternPropertyKey, patternProperty] of Object.entries(allPatternProperties)) {
+  for (const [parameterKey, parameter] of Object.entries(allParameters)) {
     /**
      * Bubbled up pattern properties are a concatenation of the node id
      * and the pattern property definition id. We need to split them so
      * that the node only uses the pattern property definition id.
      */
-    const [hashKey, parameterDefinitionId] = patternPropertyKey.split(PATTERN_PROPERTY_DIVIDER);
+    const [hashKey, parameterDefinitionId] = parameterKey.split(PATTERN_PROPERTY_DIVIDER);
 
     const hashedNodeChain = md5(patternRootNodeIdsChain || '');
 
@@ -152,7 +152,7 @@ export const resolvePattern = ({
 
     if (!isMatchingNode) continue;
 
-    parameters[parameterDefinitionId] = patternProperty;
+    parameters[parameterDefinitionId] = parameter;
   }
 
   const componentFields = assembly.fields;

--- a/packages/experience-builder-sdk/src/core/preview/assemblyUtils.ts
+++ b/packages/experience-builder-sdk/src/core/preview/assemblyUtils.ts
@@ -16,13 +16,13 @@ export const deserializePatternNode = ({
   node,
   componentInstanceVariables,
   componentSettings,
-  patternProperties,
+  parameters,
   entityStore,
 }: {
   node: ComponentTreeNode;
   componentInstanceVariables: ComponentTreeNode['variables'];
   componentSettings: ExperienceComponentSettings;
-  patternProperties: Record<string, PatternProperty>;
+  parameters: Record<string, PatternProperty>;
   entityStore: EntityStore;
 }): ComponentTreeNode => {
   const variables: Record<string, ComponentPropertyValue> = {};
@@ -38,13 +38,13 @@ export const deserializePatternNode = ({
       const usePrebinding = shouldUsePrebinding({
         componentSettings,
         componentValueKey,
-        patternProperties,
+        parameters: parameters,
         variable: instanceProperty,
       });
       const path = resolvePrebindingPath({
         componentSettings,
         componentValueKey,
-        patternProperties,
+        parameters: parameters,
         entityStore,
       });
 
@@ -95,7 +95,7 @@ export const deserializePatternNode = ({
       node: child,
       componentInstanceVariables,
       componentSettings,
-      patternProperties,
+      parameters,
       entityStore,
     }),
   );
@@ -107,7 +107,7 @@ export const deserializePatternNode = ({
     children,
     slotId: node.slotId,
     displayName: node.displayName,
-    patternProperties: node.patternProperties,
+    parameters: node.parameters,
   };
 };
 
@@ -131,11 +131,11 @@ export const resolvePattern = ({
     return node;
   }
 
-  const patternProperties: Record<string, PatternProperty> = {};
+  const parameters: Record<string, PatternProperty> = {};
 
   const allPatternProperties = {
     ...parentPatternProperties,
-    ...(node.patternProperties || {}),
+    ...(node.parameters || {}),
   };
 
   for (const [patternPropertyKey, patternProperty] of Object.entries(allPatternProperties)) {
@@ -144,8 +144,7 @@ export const resolvePattern = ({
      * and the pattern property definition id. We need to split them so
      * that the node only uses the pattern property definition id.
      */
-    const [hashKey, patternPropertyDefinitionId] =
-      patternPropertyKey.split(PATTERN_PROPERTY_DIVIDER);
+    const [hashKey, parameterDefinitionId] = patternPropertyKey.split(PATTERN_PROPERTY_DIVIDER);
 
     const hashedNodeChain = md5(patternRootNodeIdsChain || '');
 
@@ -153,7 +152,7 @@ export const resolvePattern = ({
 
     if (!isMatchingNode) continue;
 
-    patternProperties[patternPropertyDefinitionId] = patternProperty;
+    parameters[parameterDefinitionId] = patternProperty;
   }
 
   const componentFields = assembly.fields;
@@ -164,11 +163,11 @@ export const resolvePattern = ({
       id: node.id,
       variables: node.variables,
       children: componentFields.componentTree.children,
-      patternProperties,
+      parameters: parameters,
     },
     componentInstanceVariables: node.variables,
     componentSettings: componentFields.componentSettings!,
-    patternProperties,
+    parameters: parameters,
     entityStore,
   });
 

--- a/packages/experience-builder-sdk/src/core/preview/assemblyUtils.ts
+++ b/packages/experience-builder-sdk/src/core/preview/assemblyUtils.ts
@@ -144,7 +144,7 @@ export const resolvePattern = ({
      * and the pattern property definition id. We need to split them so
      * that the node only uses the pattern property definition id.
      */
-    const [hashKey, parameterDefinitionId] = parameterKey.split(PATTERN_PROPERTY_DIVIDER);
+    const [hashKey, parameterId] = parameterKey.split(PATTERN_PROPERTY_DIVIDER);
 
     const hashedNodeChain = md5(patternRootNodeIdsChain || '');
 
@@ -152,7 +152,7 @@ export const resolvePattern = ({
 
     if (!isMatchingNode) continue;
 
-    parameters[parameterDefinitionId] = parameter;
+    parameters[parameterId] = parameter;
   }
 
   const componentFields = assembly.fields;

--- a/packages/experience-builder-sdk/src/utils/prebindingUtils.spec.ts
+++ b/packages/experience-builder-sdk/src/utils/prebindingUtils.spec.ts
@@ -22,17 +22,17 @@ describe('shouldUsePrebinding', () => {
   it('should return true when all conditions are met', () => {
     const componentValueKey = 'testKey';
     const componentSettings = {
-      patternPropertyDefinitions: {
-        testPatternPropertyDefinitionId: {},
+      parameterDefinitions: {
+        testParameterDefinitionId: {},
       },
       variableMappings: {
         testKey: {
-          patternPropertyDefinitionId: 'testPatternPropertyDefinitionId',
+          parameterDefinitionId: 'testParameterDefinitionId',
         },
       },
     } as unknown as ExperienceComponentSettings;
-    const patternProperties = {
-      testPatternPropertyDefinitionId: {},
+    const parameters = {
+      testParameterDefinitionId: {},
     } as unknown as Record<string, PatternProperty>;
     const variable = {
       type: 'NoValue',
@@ -41,7 +41,7 @@ describe('shouldUsePrebinding', () => {
     const result = shouldUsePrebinding({
       componentValueKey,
       componentSettings,
-      patternProperties,
+      parameters: parameters,
       variable,
     });
 
@@ -51,15 +51,15 @@ describe('shouldUsePrebinding', () => {
   it('should return false when patternPropertyDefinition is missing', () => {
     const componentValueKey = 'testKey';
     const componentSettings = {
-      patternPropertyDefinitions: {},
+      parameterDefinitions: {},
       variableMappings: {
         testKey: {
-          patternPropertyDefinitionId: 'testPatternPropertyDefinitionId',
+          parameterDefinitionId: 'testParameterDefinitionId',
         },
       },
     } as unknown as ExperienceComponentSettings;
-    const patternProperties: Record<string, PatternProperty> = {
-      testPatternPropertyDefinitionId: {},
+    const parameters: Record<string, PatternProperty> = {
+      testParameterDefinitionId: {},
     } as unknown as Record<string, PatternProperty>;
     const variable = {
       type: 'NoValue',
@@ -68,7 +68,7 @@ describe('shouldUsePrebinding', () => {
     const result = shouldUsePrebinding({
       componentValueKey,
       componentSettings,
-      patternProperties,
+      parameters,
       variable,
     });
 
@@ -78,16 +78,16 @@ describe('shouldUsePrebinding', () => {
   it('should return false when patternProperty is missing', () => {
     const componentValueKey = 'testKey';
     const componentSettings: ExperienceComponentSettings = {
-      patternPropertyDefinitions: {
-        testPatternPropertyDefinitionId: {},
+      parameterDefinitions: {
+        testParameterDefinitionId: {},
       },
       variableMappings: {
         testKey: {
-          patternPropertyDefinitionId: 'testPatternPropertyDefinitionId',
+          parameterDefinitionId: 'testParameterDefinitionId',
         },
       },
     } as unknown as ExperienceComponentSettings;
-    const patternProperties: Record<string, PatternProperty> = {};
+    const parameters: Record<string, PatternProperty> = {};
     const variable = {
       type: 'NoValue',
     } as unknown as ComponentPropertyValue;
@@ -95,7 +95,7 @@ describe('shouldUsePrebinding', () => {
     const result = shouldUsePrebinding({
       componentValueKey,
       componentSettings,
-      patternProperties,
+      parameters,
       variable,
     });
 
@@ -105,13 +105,13 @@ describe('shouldUsePrebinding', () => {
   it('should return false when variableMapping is missing', () => {
     const componentValueKey = 'testKey';
     const componentSettings = {
-      patternPropertyDefinitions: {
-        testPatternPropertyDefinitionId: {},
+      parameterDefinitions: {
+        testParameterDefinitionId: {},
       },
       variableMappings: {},
     } as unknown as ExperienceComponentSettings;
-    const patternProperties: Record<string, PatternProperty> = {
-      testPatternPropertyDefinitionId: {
+    const parameters: Record<string, PatternProperty> = {
+      testParameterDefinitionId: {
         path: '/entries/testEntry',
         type: 'BoundValue',
       },
@@ -123,7 +123,7 @@ describe('shouldUsePrebinding', () => {
     const result = shouldUsePrebinding({
       componentValueKey,
       componentSettings,
-      patternProperties,
+      parameters: parameters,
       variable,
     });
 
@@ -137,20 +137,20 @@ describe('resolvePrebindingPath', () => {
   it('should return the correct path when all conditions are met', () => {
     const componentValueKey = 'testKey';
     const componentSettings = {
-      patternPropertyDefinitions: {},
+      parameterDefinitions: {},
       variableDefinitions: {},
       variableMappings: {
         testKey: {
           type: 'ContentTypeMapping',
-          patternPropertyDefinitionId: 'testPatternPropertyDefinitionId',
+          parameterDefinitionId: 'testParameterDefinitionId',
           pathsByContentType: {
             testContentType: { path: '/fields/testField' },
           },
         },
       },
     } as unknown as ExperienceComponentSettings;
-    const patternProperties: Record<string, PatternProperty> = {
-      testPatternPropertyDefinitionId: {
+    const parameters: Record<string, PatternProperty> = {
+      testParameterDefinitionId: {
         path: `/${dataSourceKey}`,
         type: 'BoundValue',
       },
@@ -159,7 +159,7 @@ describe('resolvePrebindingPath', () => {
     const result = resolvePrebindingPath({
       componentValueKey,
       componentSettings,
-      patternProperties,
+      parameters: parameters,
       entityStore,
     });
 
@@ -171,33 +171,33 @@ describe('resolvePrebindingPath', () => {
     const componentSettings: ExperienceComponentSettings = {
       variableMappings: {},
     } as unknown as ExperienceComponentSettings;
-    const patternProperties: Record<string, PatternProperty> = {};
+    const parameters: Record<string, PatternProperty> = {};
 
     const result = resolvePrebindingPath({
       componentValueKey,
       componentSettings,
-      patternProperties,
+      parameters: parameters,
       entityStore,
     });
 
     expect(result).toBe('');
   });
 
-  it('should return an empty string when patternProperties is missing', () => {
+  it('should return an empty string when parameters is missing', () => {
     const componentValueKey = 'testKey';
     const componentSettings: ExperienceComponentSettings = {
       variableMappings: {
         testKey: {
-          patternPropertyDefinitionId: 'testPatternPropertyDefinitionId',
+          parameterDefinitionId: 'testParameterDefinitionId',
         },
       },
     } as unknown as ExperienceComponentSettings;
-    const patternProperties: Record<string, PatternProperty> = {};
+    const parameters: Record<string, PatternProperty> = {};
 
     const result = resolvePrebindingPath({
       componentValueKey,
       componentSettings,
-      patternProperties,
+      parameters: parameters,
       entityStore,
     });
 
@@ -209,18 +209,18 @@ describe('resolvePrebindingPath', () => {
     const componentSettings: ExperienceComponentSettings = {
       variableMappings: {
         testKey: {
-          patternPropertyDefinitionId: 'testPatternPropertyDefinitionId',
+          parameterDefinitionId: 'testParameterDefinitionId',
         },
       },
     } as unknown as ExperienceComponentSettings;
-    const patternProperties: Record<string, PatternProperty> = {
-      testPatternPropertyDefinitionId: { path: `/${dataSourceKey}` },
+    const parameters: Record<string, PatternProperty> = {
+      testParameterDefinitionId: { path: `/${dataSourceKey}` },
     } as unknown as Record<string, PatternProperty>;
 
     const result = resolvePrebindingPath({
       componentValueKey,
       componentSettings,
-      patternProperties,
+      parameters: parameters,
       entityStore,
     });
 
@@ -232,19 +232,19 @@ describe('resolvePrebindingPath', () => {
     const componentSettings: ExperienceComponentSettings = {
       variableMappings: {
         testKey: {
-          patternPropertyDefinitionId: 'testPatternPropertyDefinitionId',
+          parameterDefinitionId: 'testParameterDefinitionId',
           pathsByContentType: {},
         },
       },
     } as unknown as ExperienceComponentSettings;
-    const patternProperties: Record<string, PatternProperty> = {
-      testPatternPropertyDefinitionId: { path: `/${dataSourceKey}` },
+    const parameters: Record<string, PatternProperty> = {
+      testParameterDefinitionId: { path: `/${dataSourceKey}` },
     } as unknown as Record<string, PatternProperty>;
 
     const result = resolvePrebindingPath({
       componentValueKey,
       componentSettings,
-      patternProperties,
+      parameters: parameters,
       entityStore,
     });
 
@@ -257,21 +257,21 @@ describe('resolvePrebindingPath', () => {
     const componentSettings: ExperienceComponentSettings = {
       variableMappings: {
         testKey: {
-          patternPropertyDefinitionId: 'testPatternPropertyDefinitionId',
+          parameterDefinitionId: 'testParameterDefinitionId',
           pathsByContentType: {
             testContentType: { path: '/fields/testField' },
           },
         },
       },
     } as unknown as ExperienceComponentSettings;
-    const patternProperties: Record<string, PatternProperty> = {
-      testPatternPropertyDefinitionId: { path: `/${dataSourceKey}` },
+    const parameters: Record<string, PatternProperty> = {
+      testParameterDefinitionId: { path: `/${dataSourceKey}` },
     } as unknown as Record<string, PatternProperty>;
 
     const result = resolvePrebindingPath({
       componentValueKey,
       componentSettings,
-      patternProperties,
+      parameters: parameters,
       entityStore,
     });
 
@@ -292,8 +292,8 @@ describe('resolveMaybePrebindingDefaultValuePath', () => {
           ...experienceEntry.fields,
           componentSettings: {
             ...experienceEntry.fields.componentSettings,
-            patternPropertyDefinitions: {
-              testPatternPropertyDefinitionId: {
+            parameterDefinitions: {
+              testParameterDefinitionId: {
                 defaultValue: {
                   testContentType: {
                     sys: { id: dataSourceKey, type: 'Link', linkType: 'Entry' },
@@ -307,7 +307,7 @@ describe('resolveMaybePrebindingDefaultValuePath', () => {
             variableMappings: {
               testKey: {
                 type: 'ContentTypeMapping',
-                patternPropertyDefinitionId: 'testPatternPropertyDefinitionId',
+                parameterDefinitionId: 'testParameterDefinitionId',
                 pathsByContentType: {
                   testContentType: { path: '/fields/testField' },
                 },
@@ -346,7 +346,7 @@ describe('resolveMaybePrebindingDefaultValuePath', () => {
 
   it('should return undefined when patternPropertyDefinition is missing', () => {
     const modifiedEntityStore = createEntityStoreWithComponentSettings({
-      patternPropertyDefinitions: {},
+      parameterDefinitions: {},
     });
 
     const result = resolveMaybePrebindingDefaultValuePath({
@@ -359,8 +359,8 @@ describe('resolveMaybePrebindingDefaultValuePath', () => {
 
   it('should return undefined when defaultValue is missing', () => {
     const modifiedEntityStore = createEntityStoreWithComponentSettings({
-      patternPropertyDefinitions: {
-        testPatternPropertyDefinitionId: {
+      parameterDefinitions: {
+        testParameterDefinitionId: {
           contentTypes: {
             testContentType: {},
           },

--- a/packages/experience-builder-sdk/src/utils/prebindingUtils.spec.ts
+++ b/packages/experience-builder-sdk/src/utils/prebindingUtils.spec.ts
@@ -8,7 +8,7 @@ import {
 import {
   ComponentPropertyValue,
   ExperienceComponentSettings,
-  PatternProperty,
+  Parameter,
 } from '@contentful/experiences-validators';
 import { ExperienceEntry } from '@contentful/experiences-core/types';
 
@@ -33,7 +33,7 @@ describe('shouldUsePrebinding', () => {
     } as unknown as ExperienceComponentSettings;
     const parameters = {
       testParameterDefinitionId: {},
-    } as unknown as Record<string, PatternProperty>;
+    } as unknown as Record<string, Parameter>;
     const variable = {
       type: 'NoValue',
     } as unknown as ComponentPropertyValue;
@@ -48,7 +48,7 @@ describe('shouldUsePrebinding', () => {
     expect(result).toBe(true);
   });
 
-  it('should return false when patternPropertyDefinition is missing', () => {
+  it('should return false when parameterDefinition is missing', () => {
     const componentValueKey = 'testKey';
     const componentSettings = {
       parameterDefinitions: {},
@@ -58,9 +58,9 @@ describe('shouldUsePrebinding', () => {
         },
       },
     } as unknown as ExperienceComponentSettings;
-    const parameters: Record<string, PatternProperty> = {
+    const parameters: Record<string, Parameter> = {
       testParameterDefinitionId: {},
-    } as unknown as Record<string, PatternProperty>;
+    } as unknown as Record<string, Parameter>;
     const variable = {
       type: 'NoValue',
     } as unknown as ComponentPropertyValue;
@@ -75,7 +75,7 @@ describe('shouldUsePrebinding', () => {
     expect(result).toBe(false);
   });
 
-  it('should return false when patternProperty is missing', () => {
+  it('should return false when parameter is missing', () => {
     const componentValueKey = 'testKey';
     const componentSettings: ExperienceComponentSettings = {
       parameterDefinitions: {
@@ -87,7 +87,7 @@ describe('shouldUsePrebinding', () => {
         },
       },
     } as unknown as ExperienceComponentSettings;
-    const parameters: Record<string, PatternProperty> = {};
+    const parameters: Record<string, Parameter> = {};
     const variable = {
       type: 'NoValue',
     } as unknown as ComponentPropertyValue;
@@ -110,7 +110,7 @@ describe('shouldUsePrebinding', () => {
       },
       variableMappings: {},
     } as unknown as ExperienceComponentSettings;
-    const parameters: Record<string, PatternProperty> = {
+    const parameters: Record<string, Parameter> = {
       testParameterDefinitionId: {
         path: '/entries/testEntry',
         type: 'BoundValue',
@@ -149,7 +149,7 @@ describe('resolvePrebindingPath', () => {
         },
       },
     } as unknown as ExperienceComponentSettings;
-    const parameters: Record<string, PatternProperty> = {
+    const parameters: Record<string, Parameter> = {
       testParameterDefinitionId: {
         path: `/${dataSourceKey}`,
         type: 'BoundValue',
@@ -171,7 +171,7 @@ describe('resolvePrebindingPath', () => {
     const componentSettings: ExperienceComponentSettings = {
       variableMappings: {},
     } as unknown as ExperienceComponentSettings;
-    const parameters: Record<string, PatternProperty> = {};
+    const parameters: Record<string, Parameter> = {};
 
     const result = resolvePrebindingPath({
       componentValueKey,
@@ -192,7 +192,7 @@ describe('resolvePrebindingPath', () => {
         },
       },
     } as unknown as ExperienceComponentSettings;
-    const parameters: Record<string, PatternProperty> = {};
+    const parameters: Record<string, Parameter> = {};
 
     const result = resolvePrebindingPath({
       componentValueKey,
@@ -213,9 +213,9 @@ describe('resolvePrebindingPath', () => {
         },
       },
     } as unknown as ExperienceComponentSettings;
-    const parameters: Record<string, PatternProperty> = {
+    const parameters: Record<string, Parameter> = {
       testParameterDefinitionId: { path: `/${dataSourceKey}` },
-    } as unknown as Record<string, PatternProperty>;
+    } as unknown as Record<string, Parameter>;
 
     const result = resolvePrebindingPath({
       componentValueKey,
@@ -237,9 +237,9 @@ describe('resolvePrebindingPath', () => {
         },
       },
     } as unknown as ExperienceComponentSettings;
-    const parameters: Record<string, PatternProperty> = {
+    const parameters: Record<string, Parameter> = {
       testParameterDefinitionId: { path: `/${dataSourceKey}` },
-    } as unknown as Record<string, PatternProperty>;
+    } as unknown as Record<string, Parameter>;
 
     const result = resolvePrebindingPath({
       componentValueKey,
@@ -264,9 +264,9 @@ describe('resolvePrebindingPath', () => {
         },
       },
     } as unknown as ExperienceComponentSettings;
-    const parameters: Record<string, PatternProperty> = {
+    const parameters: Record<string, Parameter> = {
       testParameterDefinitionId: { path: `/${dataSourceKey}` },
-    } as unknown as Record<string, PatternProperty>;
+    } as unknown as Record<string, Parameter>;
 
     const result = resolvePrebindingPath({
       componentValueKey,
@@ -344,7 +344,7 @@ describe('resolveMaybePrebindingDefaultValuePath', () => {
     expect(result).toBeUndefined();
   });
 
-  it('should return undefined when patternPropertyDefinition is missing', () => {
+  it('should return undefined when parameterDefinition is missing', () => {
     const modifiedEntityStore = createEntityStoreWithComponentSettings({
       parameterDefinitions: {},
     });

--- a/packages/experience-builder-sdk/src/utils/prebindingUtils.spec.ts
+++ b/packages/experience-builder-sdk/src/utils/prebindingUtils.spec.ts
@@ -23,16 +23,16 @@ describe('shouldUsePrebinding', () => {
     const componentValueKey = 'testKey';
     const componentSettings = {
       parameterDefinitions: {
-        testParameterDefinitionId: {},
+        testParameterId: {},
       },
       variableMappings: {
         testKey: {
-          parameterDefinitionId: 'testParameterDefinitionId',
+          parameterId: 'testParameterId',
         },
       },
     } as unknown as ExperienceComponentSettings;
     const parameters = {
-      testParameterDefinitionId: {},
+      testParameterId: {},
     } as unknown as Record<string, Parameter>;
     const variable = {
       type: 'NoValue',
@@ -54,12 +54,12 @@ describe('shouldUsePrebinding', () => {
       parameterDefinitions: {},
       variableMappings: {
         testKey: {
-          parameterDefinitionId: 'testParameterDefinitionId',
+          parameterId: 'testParameterId',
         },
       },
     } as unknown as ExperienceComponentSettings;
     const parameters: Record<string, Parameter> = {
-      testParameterDefinitionId: {},
+      testParameterId: {},
     } as unknown as Record<string, Parameter>;
     const variable = {
       type: 'NoValue',
@@ -79,11 +79,11 @@ describe('shouldUsePrebinding', () => {
     const componentValueKey = 'testKey';
     const componentSettings: ExperienceComponentSettings = {
       parameterDefinitions: {
-        testParameterDefinitionId: {},
+        testParameterId: {},
       },
       variableMappings: {
         testKey: {
-          parameterDefinitionId: 'testParameterDefinitionId',
+          parameterId: 'testParameterId',
         },
       },
     } as unknown as ExperienceComponentSettings;
@@ -106,12 +106,12 @@ describe('shouldUsePrebinding', () => {
     const componentValueKey = 'testKey';
     const componentSettings = {
       parameterDefinitions: {
-        testParameterDefinitionId: {},
+        testParameterId: {},
       },
       variableMappings: {},
     } as unknown as ExperienceComponentSettings;
     const parameters: Record<string, Parameter> = {
-      testParameterDefinitionId: {
+      testParameterId: {
         path: '/entries/testEntry',
         type: 'BoundValue',
       },
@@ -142,7 +142,7 @@ describe('resolvePrebindingPath', () => {
       variableMappings: {
         testKey: {
           type: 'ContentTypeMapping',
-          parameterDefinitionId: 'testParameterDefinitionId',
+          parameterId: 'testParameterId',
           pathsByContentType: {
             testContentType: { path: '/fields/testField' },
           },
@@ -150,7 +150,7 @@ describe('resolvePrebindingPath', () => {
       },
     } as unknown as ExperienceComponentSettings;
     const parameters: Record<string, Parameter> = {
-      testParameterDefinitionId: {
+      testParameterId: {
         path: `/${dataSourceKey}`,
         type: 'BoundValue',
       },
@@ -188,7 +188,7 @@ describe('resolvePrebindingPath', () => {
     const componentSettings: ExperienceComponentSettings = {
       variableMappings: {
         testKey: {
-          parameterDefinitionId: 'testParameterDefinitionId',
+          parameterId: 'testParameterId',
         },
       },
     } as unknown as ExperienceComponentSettings;
@@ -209,12 +209,12 @@ describe('resolvePrebindingPath', () => {
     const componentSettings: ExperienceComponentSettings = {
       variableMappings: {
         testKey: {
-          parameterDefinitionId: 'testParameterDefinitionId',
+          parameterId: 'testParameterId',
         },
       },
     } as unknown as ExperienceComponentSettings;
     const parameters: Record<string, Parameter> = {
-      testParameterDefinitionId: { path: `/${dataSourceKey}` },
+      testParameterId: { path: `/${dataSourceKey}` },
     } as unknown as Record<string, Parameter>;
 
     const result = resolvePrebindingPath({
@@ -232,13 +232,13 @@ describe('resolvePrebindingPath', () => {
     const componentSettings: ExperienceComponentSettings = {
       variableMappings: {
         testKey: {
-          parameterDefinitionId: 'testParameterDefinitionId',
+          parameterId: 'testParameterId',
           pathsByContentType: {},
         },
       },
     } as unknown as ExperienceComponentSettings;
     const parameters: Record<string, Parameter> = {
-      testParameterDefinitionId: { path: `/${dataSourceKey}` },
+      testParameterId: { path: `/${dataSourceKey}` },
     } as unknown as Record<string, Parameter>;
 
     const result = resolvePrebindingPath({
@@ -257,7 +257,7 @@ describe('resolvePrebindingPath', () => {
     const componentSettings: ExperienceComponentSettings = {
       variableMappings: {
         testKey: {
-          parameterDefinitionId: 'testParameterDefinitionId',
+          parameterId: 'testParameterId',
           pathsByContentType: {
             testContentType: { path: '/fields/testField' },
           },
@@ -265,7 +265,7 @@ describe('resolvePrebindingPath', () => {
       },
     } as unknown as ExperienceComponentSettings;
     const parameters: Record<string, Parameter> = {
-      testParameterDefinitionId: { path: `/${dataSourceKey}` },
+      testParameterId: { path: `/${dataSourceKey}` },
     } as unknown as Record<string, Parameter>;
 
     const result = resolvePrebindingPath({
@@ -293,7 +293,7 @@ describe('resolveMaybePrebindingDefaultValuePath', () => {
           componentSettings: {
             ...experienceEntry.fields.componentSettings,
             parameterDefinitions: {
-              testParameterDefinitionId: {
+              testParameterId: {
                 defaultValue: {
                   testContentType: {
                     sys: { id: dataSourceKey, type: 'Link', linkType: 'Entry' },
@@ -307,7 +307,7 @@ describe('resolveMaybePrebindingDefaultValuePath', () => {
             variableMappings: {
               testKey: {
                 type: 'ContentTypeMapping',
-                parameterDefinitionId: 'testParameterDefinitionId',
+                parameterId: 'testParameterId',
                 pathsByContentType: {
                   testContentType: { path: '/fields/testField' },
                 },
@@ -360,7 +360,7 @@ describe('resolveMaybePrebindingDefaultValuePath', () => {
   it('should return undefined when defaultValue is missing', () => {
     const modifiedEntityStore = createEntityStoreWithComponentSettings({
       parameterDefinitions: {
-        testParameterDefinitionId: {
+        testParameterId: {
           contentTypes: {
             testContentType: {},
           },

--- a/packages/experience-builder-sdk/src/utils/prebindingUtils.ts
+++ b/packages/experience-builder-sdk/src/utils/prebindingUtils.ts
@@ -8,21 +8,21 @@ import {
 export const shouldUsePrebinding = ({
   componentValueKey,
   componentSettings,
-  patternProperties,
+  parameters,
   variable,
 }: {
   componentValueKey: string;
   componentSettings: ExperienceComponentSettings;
-  patternProperties: Record<string, PatternProperty>;
+  parameters: Record<string, PatternProperty>;
   variable: ComponentPropertyValue;
 }) => {
-  const { patternPropertyDefinitions, variableMappings } = componentSettings;
+  const { parameterDefinitions, variableMappings } = componentSettings;
 
   const variableMapping = variableMappings?.[componentValueKey];
 
   const patternPropertyDefinition =
-    patternPropertyDefinitions?.[variableMapping?.patternPropertyDefinitionId || ''];
-  const patternProperty = patternProperties?.[variableMapping?.patternPropertyDefinitionId || ''];
+    parameterDefinitions?.[variableMapping?.parameterDefinitionId || ''];
+  const patternProperty = parameters?.[variableMapping?.parameterDefinitionId || ''];
 
   const isValidForPrebinding =
     !!patternPropertyDefinition && !!patternProperty && !!variableMapping;
@@ -33,19 +33,19 @@ export const shouldUsePrebinding = ({
 export const resolvePrebindingPath = ({
   componentValueKey,
   componentSettings,
-  patternProperties,
+  parameters,
   entityStore,
 }: {
   componentValueKey: string;
   componentSettings: ExperienceComponentSettings;
-  patternProperties: Record<string, PatternProperty>;
+  parameters: Record<string, PatternProperty>;
   entityStore: EntityStore;
 }) => {
   const variableMapping = componentSettings.variableMappings?.[componentValueKey];
 
   if (!variableMapping) return '';
 
-  const patternProperty = patternProperties?.[variableMapping.patternPropertyDefinitionId];
+  const patternProperty = parameters?.[variableMapping.parameterDefinitionId];
 
   if (!patternProperty) return '';
 
@@ -79,8 +79,8 @@ export const resolveMaybePrebindingDefaultValuePath = ({
   const prebinding = componentSettings.variableMappings?.[componentValueKey];
   if (!prebinding) return;
 
-  const mappingId = prebinding.patternPropertyDefinitionId || '';
-  const mapping = componentSettings.patternPropertyDefinitions?.[mappingId];
+  const mappingId = prebinding.parameterDefinitionId || '';
+  const mapping = componentSettings.parameterDefinitions?.[mappingId];
   if (!mapping || !mapping?.defaultValue) return;
 
   const [[contentTypeId, defaultEntryLink]] = Object.entries(mapping.defaultValue);
@@ -89,7 +89,7 @@ export const resolveMaybePrebindingDefaultValuePath = ({
       componentValueKey,
       entityStore,
       componentSettings,
-      patternProperties: {
+      parameters: {
         [mappingId]: {
           path: `/${defaultEntryLink.sys.id}`,
           type: 'BoundValue',

--- a/packages/experience-builder-sdk/src/utils/prebindingUtils.ts
+++ b/packages/experience-builder-sdk/src/utils/prebindingUtils.ts
@@ -20,8 +20,8 @@ export const shouldUsePrebinding = ({
 
   const variableMapping = variableMappings?.[componentValueKey];
 
-  const parameterDefinition = parameterDefinitions?.[variableMapping?.parameterDefinitionId || ''];
-  const parameter = parameters?.[variableMapping?.parameterDefinitionId || ''];
+  const parameterDefinition = parameterDefinitions?.[variableMapping?.parameterId || ''];
+  const parameter = parameters?.[variableMapping?.parameterId || ''];
 
   const isValidForPrebinding = !!parameterDefinition && !!parameter && !!variableMapping;
 
@@ -43,7 +43,7 @@ export const resolvePrebindingPath = ({
 
   if (!variableMapping) return '';
 
-  const parameter = parameters?.[variableMapping.parameterDefinitionId];
+  const parameter = parameters?.[variableMapping.parameterId];
 
   if (!parameter) return '';
 
@@ -77,7 +77,7 @@ export const resolveMaybePrebindingDefaultValuePath = ({
   const prebinding = componentSettings.variableMappings?.[componentValueKey];
   if (!prebinding) return;
 
-  const mappingId = prebinding.parameterDefinitionId || '';
+  const mappingId = prebinding.parameterId || '';
   const mapping = componentSettings.parameterDefinitions?.[mappingId];
   if (!mapping || !mapping?.defaultValue) return;
 

--- a/packages/experience-builder-sdk/src/utils/prebindingUtils.ts
+++ b/packages/experience-builder-sdk/src/utils/prebindingUtils.ts
@@ -2,7 +2,7 @@ import { EntityStore } from '@contentful/experiences-core';
 import {
   ComponentPropertyValue,
   ExperienceComponentSettings,
-  PatternProperty,
+  Parameter,
 } from '@contentful/experiences-validators';
 
 export const shouldUsePrebinding = ({
@@ -13,19 +13,17 @@ export const shouldUsePrebinding = ({
 }: {
   componentValueKey: string;
   componentSettings: ExperienceComponentSettings;
-  parameters: Record<string, PatternProperty>;
+  parameters: Record<string, Parameter>;
   variable: ComponentPropertyValue;
 }) => {
   const { parameterDefinitions, variableMappings } = componentSettings;
 
   const variableMapping = variableMappings?.[componentValueKey];
 
-  const patternPropertyDefinition =
-    parameterDefinitions?.[variableMapping?.parameterDefinitionId || ''];
-  const patternProperty = parameters?.[variableMapping?.parameterDefinitionId || ''];
+  const parameterDefinition = parameterDefinitions?.[variableMapping?.parameterDefinitionId || ''];
+  const parameter = parameters?.[variableMapping?.parameterDefinitionId || ''];
 
-  const isValidForPrebinding =
-    !!patternPropertyDefinition && !!patternProperty && !!variableMapping;
+  const isValidForPrebinding = !!parameterDefinition && !!parameter && !!variableMapping;
 
   return isValidForPrebinding && variable?.type === 'NoValue';
 };
@@ -38,18 +36,18 @@ export const resolvePrebindingPath = ({
 }: {
   componentValueKey: string;
   componentSettings: ExperienceComponentSettings;
-  parameters: Record<string, PatternProperty>;
+  parameters: Record<string, Parameter>;
   entityStore: EntityStore;
 }) => {
   const variableMapping = componentSettings.variableMappings?.[componentValueKey];
 
   if (!variableMapping) return '';
 
-  const patternProperty = parameters?.[variableMapping.parameterDefinitionId];
+  const parameter = parameters?.[variableMapping.parameterDefinitionId];
 
-  if (!patternProperty) return '';
+  if (!parameter) return '';
 
-  const dataSourceKey = patternProperty.path.split('/')[1];
+  const dataSourceKey = parameter.path.split('/')[1];
 
   const entityLink = entityStore.dataSource[dataSourceKey];
   if (!entityLink) return '';
@@ -63,7 +61,7 @@ export const resolvePrebindingPath = ({
 
   if (!fieldPath) return '';
 
-  return patternProperty.path + fieldPath;
+  return parameter.path + fieldPath;
 };
 
 export const resolveMaybePrebindingDefaultValuePath = ({

--- a/packages/validators/src/schemas/index.ts
+++ b/packages/validators/src/schemas/index.ts
@@ -4,7 +4,7 @@ export {
 } from './v2023_09_28/experience';
 export {
   PatternFieldsCMAShapeSchema as PatternSchema_2023_09_28,
-  type PatternPropertyDefinition,
+  type ParameterDefinition,
   VariableMapping,
 } from './v2023_09_28/pattern';
 export { ComponentDefinitionSchema } from './componentDefinition';

--- a/packages/validators/src/schemas/latest.ts
+++ b/packages/validators/src/schemas/latest.ts
@@ -2,7 +2,7 @@ export * from './v2023_09_28/experience';
 export { PatternFields } from './v2023_09_28/pattern';
 export { ComponentPropertyValueSchema } from '@/schemas/v2023_09_28/common';
 export { ComponentPropertyValue } from '@/schemas/v2023_09_28/common';
-export { PatternPropertySchema } from '@/schemas/v2023_09_28/common';
+export { ParameterSchema } from '@/schemas/v2023_09_28/common';
 export { ParametersSchema } from '@/schemas/v2023_09_28/common';
 export { BreakpointSchema } from '@/schemas/v2023_09_28/common';
 export { ComponentTreeNode } from '@/schemas/v2023_09_28/common';

--- a/packages/validators/src/schemas/latest.ts
+++ b/packages/validators/src/schemas/latest.ts
@@ -3,7 +3,7 @@ export { PatternFields } from './v2023_09_28/pattern';
 export { ComponentPropertyValueSchema } from '@/schemas/v2023_09_28/common';
 export { ComponentPropertyValue } from '@/schemas/v2023_09_28/common';
 export { PatternPropertySchema } from '@/schemas/v2023_09_28/common';
-export { PatternPropertiesSchema } from '@/schemas/v2023_09_28/common';
+export { ParametersSchema } from '@/schemas/v2023_09_28/common';
 export { BreakpointSchema } from '@/schemas/v2023_09_28/common';
 export { ComponentTreeNode } from '@/schemas/v2023_09_28/common';
 export { ComponentVariableSchema } from '@/schemas/v2023_09_28/common';

--- a/packages/validators/src/schemas/v2023_09_28/common.ts
+++ b/packages/validators/src/schemas/v2023_09_28/common.ts
@@ -177,12 +177,12 @@ export type ComponentPropertyValue = z.infer<typeof ComponentPropertyValueSchema
 
 // TODO: finalize schema structure before release
 // https://contentful.atlassian.net/browse/LUMOS-523
-export const PatternPropertySchema = z.object({
+export const ParameterSchema = z.object({
   type: z.literal('BoundValue'),
   path: z.string(),
 });
 
-export const ParametersSchema = z.record(propertyKeySchema, PatternPropertySchema);
+export const ParametersSchema = z.record(propertyKeySchema, ParameterSchema);
 
 export const BreakpointSchema = z
   .object({

--- a/packages/validators/src/schemas/v2023_09_28/common.ts
+++ b/packages/validators/src/schemas/v2023_09_28/common.ts
@@ -182,7 +182,7 @@ export const PatternPropertySchema = z.object({
   path: z.string(),
 });
 
-export const PatternPropertiesSchema = z.record(propertyKeySchema, PatternPropertySchema);
+export const ParametersSchema = z.record(propertyKeySchema, PatternPropertySchema);
 
 export const BreakpointSchema = z
   .object({
@@ -201,7 +201,7 @@ const BaseComponentTreeNodeSchema = z.object({
   displayName: z.string().optional(),
   slotId: z.string().optional(),
   variables: z.record(propertyKeySchema, ComponentPropertyValueSchema),
-  patternProperties: PatternPropertiesSchema.optional(),
+  parameters: ParametersSchema.optional(),
 });
 
 export type ComponentTreeNode = z.infer<typeof BaseComponentTreeNodeSchema> & {

--- a/packages/validators/src/schemas/v2023_09_28/experience.ts
+++ b/packages/validators/src/schemas/v2023_09_28/experience.ts
@@ -11,7 +11,7 @@ import {
   HyperlinkValueSchema,
   localeWrapper,
   NoValueSchema,
-  PatternPropertySchema,
+  ParameterSchema,
   PrimitiveValueSchema,
   UnboundValueSchema,
   UnboundValuesSchema,
@@ -41,5 +41,5 @@ export type UnboundValue = z.infer<typeof UnboundValueSchema>;
 export type HyperlinkValue = z.infer<typeof HyperlinkValueSchema>;
 export type ComponentValue = z.infer<typeof ComponentValueSchema>;
 export type BindingSourceTypeEnum = z.infer<typeof BindingSourceTypeEnumSchema>;
-export type PatternProperty = z.infer<typeof PatternPropertySchema>;
+export type Parameter = z.infer<typeof ParameterSchema>;
 export { breakpointsRefinement };

--- a/packages/validators/src/schemas/v2023_09_28/pattern.ts
+++ b/packages/validators/src/schemas/v2023_09_28/pattern.ts
@@ -96,6 +96,6 @@ export const PatternFieldsCMAShapeSchema = z.object({
 });
 
 export type PatternFields = z.infer<typeof PatternFieldsCMAShapeSchema>;
-export type PatternPropertyDefinition = z.infer<typeof ParameterDefinitionSchema>;
+export type ParameterDefinition = z.infer<typeof ParameterDefinitionSchema>;
 export type VariableMapping = z.infer<typeof VariableMappingSchema>;
 export type PatternComponentSettings = z.infer<typeof ComponentSettingsSchema>;

--- a/packages/validators/src/schemas/v2023_09_28/pattern.ts
+++ b/packages/validators/src/schemas/v2023_09_28/pattern.ts
@@ -38,14 +38,14 @@ export const THUMBNAIL_IDS = [
 // TODO: finalize schema structure before release
 // https://contentful.atlassian.net/browse/LUMOS-523
 const VariableMappingSchema = z.object({
-  patternPropertyDefinitionId: propertyKeySchema,
+  parameterDefinitionId: propertyKeySchema,
   type: z.literal('ContentTypeMapping'),
   pathsByContentType: z.record(z.string(), z.object({ path: z.string() })),
 });
 
 // TODO: finalize schema structure before release
 // https://contentful.atlassian.net/browse/LUMOS-523
-const PatternPropertyDefinitionSchema = z.object({
+const ParameterDefinitionSchema = z.object({
   defaultValue: z
     .record(
       z.string(),
@@ -70,10 +70,7 @@ const PatternPropertyDefinitionSchema = z.object({
   ),
 });
 
-export const PatternPropertyDefinitionsSchema = z.record(
-  propertyKeySchema,
-  PatternPropertyDefinitionSchema,
-);
+export const ParameterDefinitionsSchema = z.record(propertyKeySchema, ParameterDefinitionSchema);
 
 const VariableMappingsSchema = z.record(propertyKeySchema, VariableMappingSchema);
 
@@ -87,7 +84,7 @@ const ComponentSettingsSchema = z.object({
   thumbnailId: z.enum(THUMBNAIL_IDS).optional(),
   category: z.string().max(50, 'Category must contain at most 50 characters').optional(),
   variableMappings: VariableMappingsSchema.optional(),
-  patternPropertyDefinitions: PatternPropertyDefinitionsSchema.optional(),
+  parameterDefinitions: ParameterDefinitionsSchema.optional(),
 });
 
 export const PatternFieldsCMAShapeSchema = z.object({
@@ -99,6 +96,6 @@ export const PatternFieldsCMAShapeSchema = z.object({
 });
 
 export type PatternFields = z.infer<typeof PatternFieldsCMAShapeSchema>;
-export type PatternPropertyDefinition = z.infer<typeof PatternPropertyDefinitionSchema>;
+export type PatternPropertyDefinition = z.infer<typeof ParameterDefinitionSchema>;
 export type VariableMapping = z.infer<typeof VariableMappingSchema>;
 export type PatternComponentSettings = z.infer<typeof ComponentSettingsSchema>;

--- a/packages/validators/src/schemas/v2023_09_28/pattern.ts
+++ b/packages/validators/src/schemas/v2023_09_28/pattern.ts
@@ -38,7 +38,7 @@ export const THUMBNAIL_IDS = [
 // TODO: finalize schema structure before release
 // https://contentful.atlassian.net/browse/LUMOS-523
 const VariableMappingSchema = z.object({
-  parameterDefinitionId: propertyKeySchema,
+  parameterId: propertyKeySchema,
   type: z.literal('ContentTypeMapping'),
   pathsByContentType: z.record(z.string(), z.object({ path: z.string() })),
 });

--- a/packages/validators/src/test/__fixtures__/v2023_09_28/experiencePattern.ts
+++ b/packages/validators/src/test/__fixtures__/v2023_09_28/experiencePattern.ts
@@ -294,7 +294,7 @@ export const experiencePattern = {
     },
     componentSettings: {
       'en-US': {
-        patternPropertyDefinitions: {
+        parameterDefinitions: {
           '8v3GB67qF5f': {
             defaultValue: {
               productFeatureTopic: {

--- a/packages/validators/src/types.ts
+++ b/packages/validators/src/types.ts
@@ -16,7 +16,7 @@ export type {
   BoundValue,
   ComponentValue,
   PatternFields,
-  PatternProperty,
+  Parameter,
 } from './schemas/latest';
 export type { ComponentDefinitionPropertyType } from './schemas/componentDefinition';
 export type { SchemaVersions } from './schemas/schemaVersions';

--- a/packages/validators/src/validators/tests/experienceValidator.spec.ts
+++ b/packages/validators/src/validators/tests/experienceValidator.spec.ts
@@ -22,13 +22,13 @@ describe(`${schemaVersion} version`, () => {
     expect(error?.details).toBe(`The property "${field}" is required here`);
   });
 
-  it('should return an error if patternPropertyDefinitions contentTypes do not use a link reference', () => {
+  it('should return an error if parameterDefinitions contentTypes do not use a link reference', () => {
     const clonedExperiencePattern = JSON.parse(JSON.stringify(experiencePattern));
     // @ts-ignore - force type for invalid contentTypes test
-    clonedExperiencePattern.fields.componentSettings['en-US'].patternPropertyDefinitions[
+    clonedExperiencePattern.fields.componentSettings['en-US'].parameterDefinitions[
       '8v3GB67qF5f'
     ].contentTypes.productFeatureTopic = {
-      ...clonedExperiencePattern.fields.componentSettings['en-US'].patternPropertyDefinitions[
+      ...clonedExperiencePattern.fields.componentSettings['en-US'].parameterDefinitions[
         '8v3GB67qF5f'
       ].contentTypes.productFeatureTopic.sys,
     };

--- a/packages/validators/src/validators/tests/experienceValidator.spec.ts
+++ b/packages/validators/src/validators/tests/experienceValidator.spec.ts
@@ -1,6 +1,6 @@
 import { experience, experiencePattern } from '@/test/__fixtures__/v2023_09_28';
 import { describe, it, expect } from 'vitest';
-import { validateExperienceFields } from '../validateExperienceFields';
+import { validateExperienceFields } from '@/validators';
 import * as validatePattern from '@/validators/validatePatternFields';
 import { vi } from 'vitest';
 


### PR DESCRIPTION
## Purpose
Rename some pattern properties

patternPropertyDefinitions → parameterDefinitions
patternPropertyDefinitionId → parameterDefinitionId
patternProperties → parameters

Ticket: https://contentful.atlassian.net/browse/SPA-2844
