### PR TITLE
feat: [] skip hidden nodes

### DIFF
--- a/packages/core/src/utils/domValues.ts
+++ b/packages/core/src/utils/domValues.ts
@@ -14,6 +14,11 @@ export const findOutermostCoordinates = (first: Rect, second: Rect) => {
   };
 };
 
+export const isElementHidden = (rect: DOMRect): boolean => {
+  /** if the rect has no size and position, its element is not rendered in the DOM */
+  return rect.width === 0 && rect.height === 0 && rect.x === 0 && rect.y === 0;
+};
+
 export const getElementCoordinates = (element: Element): DOMRect => {
   const rect = element.getBoundingClientRect();
 

--- a/packages/visual-editor/src/components/RootRenderer/sendCanvasGeometryUpdatedMessage.ts
+++ b/packages/visual-editor/src/components/RootRenderer/sendCanvasGeometryUpdatedMessage.ts
@@ -1,4 +1,4 @@
-import { sendMessage, getElementCoordinates } from '@contentful/experiences-core';
+import { sendMessage, getElementCoordinates, isElementHidden } from '@contentful/experiences-core';
 import { OUTGOING_EVENTS } from '@contentful/experiences-core/constants';
 import {
   CanvasGeometryUpdateSourceEvent,
@@ -39,6 +39,11 @@ const collectNodeCoordinates = (
   const selectedElement = document.querySelector(`[data-cf-node-id="${node.data.id}"]`);
   if (selectedElement) {
     const rect = getElementCoordinates(selectedElement);
+
+    if (isElementHidden(rect)) {
+      return;
+    }
+
     nodeToCoordinatesMap[node.data.id] = {
       coordinates: {
         x: rect.x + window.scrollX,


### PR DESCRIPTION
## Purpose

Don't send the nodes that has nullified bounding client rect values, as it's not rendered in the DOM.

## Approach

Skip the node if its rect values are `0`. 
