### PR TITLE
refactor: add prebindingDefinitions in pattern schema [SPA-2900]

### DIFF
--- a/packages/core/src/fetchers/attachPrebindingDefaultValueAsDataSource.spec.ts
+++ b/packages/core/src/fetchers/attachPrebindingDefaultValueAsDataSource.spec.ts
@@ -60,22 +60,27 @@ describe('attachPrebindingDefaultValueAsDataSource', () => {
     experience.fields = {
       ...experience.fields,
       componentSettings: {
-        parameterDefinitions: {
-          someField: {
-            defaultSource: {
-              contentTypeId: 'defaultBindingCt',
-              type: 'Entry',
-              link: {
-                sys: {
-                  id: defaultId,
-                  type: 'Link',
-                  linkType: 'Entry',
+        prebindingDefinitions: [
+          {
+            id: 'prebindingId',
+            parameterDefinitions: {
+              someField: {
+                defaultSource: {
+                  contentTypeId: 'defaultBindingCt',
+                  type: 'Entry',
+                  link: {
+                    sys: {
+                      id: defaultId,
+                      type: 'Link',
+                      linkType: 'Entry',
+                    },
+                  },
                 },
+                contentTypes: {},
               },
             },
-            contentTypes: {},
           },
-        },
+        ],
         variableDefinitions: {},
       },
       dataSource: {},
@@ -100,12 +105,17 @@ describe('attachPrebindingDefaultValueAsDataSource', () => {
       fields: {
         ...experience.fields,
         componentSettings: {
-          parameterDefinitions: {
-            someField: {
-              contentTypes: {},
-              defaultSource: undefined,
+          prebindingDefinitions: [
+            {
+              id: 'prebindingId',
+              parameterDefinitions: {
+                someField: {
+                  contentTypes: {},
+                  defaultSource: undefined,
+                },
+              },
             },
-          },
+          ],
           variableDefinitions: {},
         },
         dataSource: {},

--- a/packages/core/src/fetchers/attachPrebindingDefaultValueAsDataSource.ts
+++ b/packages/core/src/fetchers/attachPrebindingDefaultValueAsDataSource.ts
@@ -17,7 +17,8 @@ export const attachPrebindingDefaultValueAsDataSource = (
     return;
   }
 
-  const patternDefs = experienceEntry.fields.componentSettings?.parameterDefinitions ?? {};
+  const patternDefs =
+    experienceEntry.fields.componentSettings?.prebindingDefinitions?.[0].parameterDefinitions ?? {};
   const defaultPrebinding = Object.values(patternDefs).find(
     (def) => def.defaultSource,
   )?.defaultSource;

--- a/packages/experience-builder-sdk/src/utils/prebindingUtils.spec.ts
+++ b/packages/experience-builder-sdk/src/utils/prebindingUtils.spec.ts
@@ -22,14 +22,19 @@ describe('shouldUsePrebinding', () => {
   it('should return true when all conditions are met', () => {
     const componentValueKey = 'testKey';
     const componentSettings = {
-      parameterDefinitions: {
-        testParameterId: {},
-      },
-      variableMappings: {
-        testKey: {
-          parameterId: 'testParameterId',
+      prebindingDefinitions: [
+        {
+          id: 'prebindingDefinition1',
+          parameterDefinitions: {
+            testParameterId: {},
+          },
+          variableMappings: {
+            testKey: {
+              parameterId: 'testParameterId',
+            },
+          },
         },
-      },
+      ],
     } as unknown as ExperienceComponentSettings;
     const parameters = {
       testParameterId: {},
@@ -137,17 +142,22 @@ describe('resolvePrebindingPath', () => {
   it('should return the correct path when all conditions are met', () => {
     const componentValueKey = 'testKey';
     const componentSettings = {
-      parameterDefinitions: {},
       variableDefinitions: {},
-      variableMappings: {
-        testKey: {
-          type: 'ContentTypeMapping',
-          parameterId: 'testParameterId',
-          pathsByContentType: {
-            testContentType: { path: '/fields/testField' },
+      prebindingDefinitions: [
+        {
+          id: 'prebindingDefinition1',
+          parameterDefinitions: {},
+          variableMappings: {
+            testKey: {
+              type: 'ContentTypeMapping',
+              parameterId: 'testParameterId',
+              pathsByContentType: {
+                testContentType: { path: '/fields/testField' },
+              },
+            },
           },
         },
-      },
+      ],
     } as unknown as ExperienceComponentSettings;
     const parameters: Record<string, Parameter> = {
       testParameterId: {
@@ -292,29 +302,34 @@ describe('resolveMaybePrebindingDefaultValuePath', () => {
           ...experienceEntry.fields,
           componentSettings: {
             ...experienceEntry.fields.componentSettings,
-            parameterDefinitions: {
-              testParameterId: {
-                defaultSource: {
-                  contentTypeId: 'testContentType',
-                  type: 'Entry',
-                  link: {
-                    sys: { id: dataSourceKey, type: 'Link', linkType: 'Entry' },
+            prebindingDefinitions: [
+              {
+                id: 'prebindingDefinition1',
+                parameterDefinitions: {
+                  testParameterId: {
+                    defaultSource: {
+                      contentTypeId: 'testContentType',
+                      type: 'Entry',
+                      link: {
+                        sys: { id: dataSourceKey, type: 'Link', linkType: 'Entry' },
+                      },
+                    },
+                    contentTypes: {
+                      testContentType: {},
+                    },
                   },
                 },
-                contentTypes: {
-                  testContentType: {},
+                variableMappings: {
+                  testKey: {
+                    type: 'ContentTypeMapping',
+                    parameterId: 'testParameterId',
+                    pathsByContentType: {
+                      testContentType: { path: '/fields/testField' },
+                    },
+                  },
                 },
               },
-            },
-            variableMappings: {
-              testKey: {
-                type: 'ContentTypeMapping',
-                parameterId: 'testParameterId',
-                pathsByContentType: {
-                  testContentType: { path: '/fields/testField' },
-                },
-              },
-            },
+            ],
             ...componentSettingsOverrides,
           },
         },
@@ -335,7 +350,13 @@ describe('resolveMaybePrebindingDefaultValuePath', () => {
 
   it('should return undefined when variableMapping is missing', () => {
     const modifiedEntityStore = createEntityStoreWithComponentSettings({
-      variableMappings: {},
+      prebindingDefinitions: [
+        {
+          id: 'prebindingId',
+          parameterDefinitions: {},
+          variableMappings: {},
+        },
+      ],
     });
 
     const result = resolveMaybePrebindingDefaultValuePath({
@@ -348,7 +369,13 @@ describe('resolveMaybePrebindingDefaultValuePath', () => {
 
   it('should return undefined when parameterDefinition is missing', () => {
     const modifiedEntityStore = createEntityStoreWithComponentSettings({
-      parameterDefinitions: {},
+      prebindingDefinitions: [
+        {
+          id: 'prebindingId',
+          parameterDefinitions: {},
+          variableMappings: {},
+        },
+      ],
     });
 
     const result = resolveMaybePrebindingDefaultValuePath({
@@ -361,13 +388,18 @@ describe('resolveMaybePrebindingDefaultValuePath', () => {
 
   it('should return undefined when defaultValue is missing', () => {
     const modifiedEntityStore = createEntityStoreWithComponentSettings({
-      parameterDefinitions: {
-        testParameterId: {
-          contentTypes: {
-            testContentType: {},
+      prebindingDefinitions: [
+        {
+          id: 'prebindingDefinition1',
+          parameterDefinitions: {
+            testParameterId: {
+              contentTypes: {
+                testContentType: {},
+              },
+            },
           },
         },
-      },
+      ],
     } as unknown as ExperienceComponentSettings);
 
     const result = resolveMaybePrebindingDefaultValuePath({

--- a/packages/experience-builder-sdk/src/utils/prebindingUtils.ts
+++ b/packages/experience-builder-sdk/src/utils/prebindingUtils.ts
@@ -16,7 +16,8 @@ export const shouldUsePrebinding = ({
   parameters: Record<string, Parameter>;
   variable: ComponentPropertyValue;
 }) => {
-  const { parameterDefinitions, variableMappings } = componentSettings;
+  const { prebindingDefinitions } = componentSettings;
+  const { parameterDefinitions, variableMappings } = prebindingDefinitions?.[0] || {};
 
   const variableMapping = variableMappings?.[componentValueKey];
 
@@ -39,7 +40,10 @@ export const resolvePrebindingPath = ({
   parameters: Record<string, Parameter>;
   entityStore: EntityStore;
 }) => {
-  const variableMapping = componentSettings.variableMappings?.[componentValueKey];
+  const prebindingDefinition = componentSettings.prebindingDefinitions?.[0];
+  if (!prebindingDefinition) return '';
+
+  const variableMapping = prebindingDefinition.variableMappings?.[componentValueKey];
 
   if (!variableMapping) return '';
 
@@ -74,11 +78,15 @@ export const resolveMaybePrebindingDefaultValuePath = ({
   if (!entityStore.experienceEntryFields?.componentSettings) return;
 
   const componentSettings = entityStore.experienceEntryFields.componentSettings;
-  const mapping = componentSettings.variableMappings?.[componentValueKey];
+
+  const prebindingDefinition = componentSettings.prebindingDefinitions?.[0];
+  if (!prebindingDefinition) return '';
+
+  const mapping = prebindingDefinition.variableMappings?.[componentValueKey];
   if (!mapping) return;
 
   const mappingId = mapping.parameterId || '';
-  const prebinding = componentSettings.parameterDefinitions?.[mappingId];
+  const prebinding = prebindingDefinition.parameterDefinitions?.[mappingId];
   if (!prebinding || !prebinding?.defaultSource) return;
 
   const { contentTypeId, link } = prebinding.defaultSource;

--- a/packages/validators/src/schemas/v2023_09_28/pattern.ts
+++ b/packages/validators/src/schemas/v2023_09_28/pattern.ts
@@ -80,13 +80,20 @@ export const ComponentVariablesSchema = z.record(
   ComponentVariableSchema,
 );
 
-const ComponentSettingsSchema = z.object({
-  variableDefinitions: ComponentVariablesSchema,
-  thumbnailId: z.enum(THUMBNAIL_IDS).optional(),
-  category: z.string().max(50, 'Category must contain at most 50 characters').optional(),
+export const PrebindingDefinitionSchema = z.object({
+  id: propertyKeySchema,
   variableMappings: VariableMappingsSchema.optional(),
-  parameterDefinitions: ParameterDefinitionsSchema.optional(),
+  parameterDefinitions: ParameterDefinitionsSchema,
 });
+
+const ComponentSettingsSchema = z
+  .object({
+    variableDefinitions: ComponentVariablesSchema,
+    thumbnailId: z.enum(THUMBNAIL_IDS).optional(),
+    category: z.string().max(50, 'Category must contain at most 50 characters').optional(),
+    prebindingDefinitions: z.array(PrebindingDefinitionSchema).optional(),
+  })
+  .strict();
 
 export const PatternFieldsCMAShapeSchema = z.object({
   componentTree: localeWrapper(ComponentTreeSchema),

--- a/packages/validators/src/schemas/v2023_09_28/pattern.ts
+++ b/packages/validators/src/schemas/v2023_09_28/pattern.ts
@@ -90,8 +90,9 @@ export const ComponentVariablesSchema = z.record(
 export const PrebindingDefinitionSchema = z
   .object({
     id: propertyKeySchema,
-    variableMappings: VariableMappingsSchema.optional(),
     parameterDefinitions: ParameterDefinitionsSchema,
+    variableMappings: VariableMappingsSchema.optional(),
+    allowedVariableOverrides: z.array(z.string()).optional(),
   })
   .strict();
 

--- a/packages/validators/src/schemas/v2023_09_28/pattern.ts
+++ b/packages/validators/src/schemas/v2023_09_28/pattern.ts
@@ -43,8 +43,14 @@ const VariableMappingSchema = z.object({
   pathsByContentType: z.record(z.string(), z.object({ path: z.string() })),
 });
 
-// TODO: finalize schema structure before release
-// https://contentful.atlassian.net/browse/LUMOS-523
+export const PassToNodeSchema = z
+  .object({
+    nodeId: propertyKeySchema,
+    parameterId: propertyKeySchema,
+    prebindingId: propertyKeySchema,
+  })
+  .strict();
+
 const ParameterDefinitionSchema = z.object({
   defaultSource: z
     .strictObject({
@@ -69,6 +75,7 @@ const ParameterDefinitionSchema = z.object({
       }),
     }),
   ),
+  passToNodes: z.array(PassToNodeSchema).optional(),
 });
 
 export const ParameterDefinitionsSchema = z.record(propertyKeySchema, ParameterDefinitionSchema);
@@ -80,20 +87,11 @@ export const ComponentVariablesSchema = z.record(
   ComponentVariableSchema,
 );
 
-export const PassToNodeSchema = z
-  .object({
-    nodeId: propertyKeySchema,
-    parameterId: propertyKeySchema,
-    prebindingId: propertyKeySchema,
-  })
-  .strict();
-
 export const PrebindingDefinitionSchema = z
   .object({
     id: propertyKeySchema,
     variableMappings: VariableMappingsSchema.optional(),
     parameterDefinitions: ParameterDefinitionsSchema,
-    passToNodes: z.array(PassToNodeSchema).optional(),
   })
   .strict();
 
@@ -102,7 +100,7 @@ const ComponentSettingsSchema = z
     variableDefinitions: ComponentVariablesSchema,
     thumbnailId: z.enum(THUMBNAIL_IDS).optional(),
     category: z.string().max(50, 'Category must contain at most 50 characters').optional(),
-    prebindingDefinitions: z.array(PrebindingDefinitionSchema).optional(),
+    prebindingDefinitions: z.array(PrebindingDefinitionSchema).max(1).optional(),
   })
   .strict();
 

--- a/packages/validators/src/schemas/v2023_09_28/pattern.ts
+++ b/packages/validators/src/schemas/v2023_09_28/pattern.ts
@@ -80,11 +80,22 @@ export const ComponentVariablesSchema = z.record(
   ComponentVariableSchema,
 );
 
-export const PrebindingDefinitionSchema = z.object({
-  id: propertyKeySchema,
-  variableMappings: VariableMappingsSchema.optional(),
-  parameterDefinitions: ParameterDefinitionsSchema,
-});
+export const PassToNodeSchema = z
+  .object({
+    nodeId: propertyKeySchema,
+    parameterId: propertyKeySchema,
+    prebindingId: propertyKeySchema,
+  })
+  .strict();
+
+export const PrebindingDefinitionSchema = z
+  .object({
+    id: propertyKeySchema,
+    variableMappings: VariableMappingsSchema.optional(),
+    parameterDefinitions: ParameterDefinitionsSchema,
+    passToNodes: z.array(PassToNodeSchema).optional(),
+  })
+  .strict();
 
 const ComponentSettingsSchema = z
   .object({

--- a/packages/validators/src/test/__fixtures__/v2023_09_28/experiencePattern.ts
+++ b/packages/validators/src/test/__fixtures__/v2023_09_28/experiencePattern.ts
@@ -294,30 +294,35 @@ export const experiencePattern = {
     },
     componentSettings: {
       'en-US': {
-        parameterDefinitions: {
-          '8v3GB67qF5f': {
-            defaultSource: {
-              contentTypeId: 'productFeatureTopic',
-              type: 'Entry',
-              link: {
-                sys: {
-                  id: '2hpuOIh8POJcekFdOLlaDa',
-                  linkType: 'Entry',
-                  type: 'Link',
+        prebindingDefinitions: [
+          {
+            id: 'prebindingDefinition1',
+            parameterDefinitions: {
+              '8v3GB67qF5f': {
+                defaultSource: {
+                  contentTypeId: 'productFeatureTopic',
+                  type: 'Entry',
+                  link: {
+                    sys: {
+                      id: '2hpuOIh8POJcekFdOLlaDa',
+                      linkType: 'Entry',
+                      type: 'Link',
+                    },
+                  },
                 },
-              },
-            },
-            contentTypes: {
-              productFeatureTopic: {
-                sys: {
-                  id: 'productFeatureTopic',
-                  type: 'Link',
-                  linkType: 'ContentType',
+                contentTypes: {
+                  productFeatureTopic: {
+                    sys: {
+                      id: 'productFeatureTopic',
+                      type: 'Link',
+                      linkType: 'ContentType',
+                    },
+                  },
                 },
               },
             },
           },
-        },
+        ],
         variableDefinitions: {
           cfBackgroundImageUrl_AtBrirchNbwfpkWlSfTD6: {
             displayName: 'Background image',

--- a/packages/validators/src/validators/tests/componentSettings.spec.ts
+++ b/packages/validators/src/validators/tests/componentSettings.spec.ts
@@ -174,4 +174,67 @@ describe('componentSettings', () => {
     expect(result.errors).toBeDefined();
     expect(result.errors?.[0].details).toBe('Category must contain at most 50 characters');
   });
+
+  describe('prebindingDefinitions', () => {
+    it('allows to have an optional prebindingDefinitions field', () => {
+      const pattern = {
+        ...experiencePattern,
+        fields: {
+          ...experiencePattern.fields,
+          componentSettings: {
+            [locale]: {
+              variableDefinitions: {},
+              prebindingDefinitions: [],
+            },
+          },
+        },
+      };
+      const result = validateExperienceFields(pattern, schemaVersion);
+      expect(result.success).toBe(true);
+      expect(result.errors).toBeUndefined();
+    });
+
+    it('errors if prebindingDefinitions is not an array', () => {
+      const pattern = {
+        ...experiencePattern,
+        fields: {
+          ...experiencePattern.fields,
+          componentSettings: {
+            [locale]: {
+              variableDefinitions: {},
+              prebindingDefinitions: { id: '1', parameterDefinitions: {} },
+            },
+          },
+        },
+      };
+      const result = validateExperienceFields(pattern, schemaVersion);
+      expect(result.success).toBe(false);
+      expect(result.errors).toBeDefined();
+      expect(result.errors?.[0].details).toBe(
+        'The type of "prebindingDefinitions" is incorrect, expected type: array',
+      );
+    });
+
+    it('errors if prebindingDefinitions is not an array of length 1', () => {
+      const pattern = {
+        ...experiencePattern,
+        fields: {
+          ...experiencePattern.fields,
+          componentSettings: {
+            [locale]: {
+              variableDefinitions: {},
+              prebindingDefinitions: [
+                { id: '1', parameterDefinitions: {} },
+                { id: '2', parameterDefinitions: {} },
+              ],
+            },
+          },
+        },
+      };
+      const result = validateExperienceFields(pattern, schemaVersion);
+      expect(result.success).toBe(false);
+      expect(result.errors).toBeDefined();
+      expect(result.errors?.[0].details).toBe('Array must contain at most 1 element(s)');
+    });
+  });
 });

--- a/packages/validators/src/validators/tests/experienceValidator.spec.ts
+++ b/packages/validators/src/validators/tests/experienceValidator.spec.ts
@@ -24,13 +24,13 @@ describe(`${schemaVersion} version`, () => {
 
   it('should return an error if parameterDefinitions contentTypes do not use a link reference', () => {
     const clonedExperiencePattern = JSON.parse(JSON.stringify(experiencePattern));
-    // @ts-ignore - force type for invalid contentTypes test
-    clonedExperiencePattern.fields.componentSettings['en-US'].parameterDefinitions[
+    clonedExperiencePattern.fields.componentSettings[
+      'en-US'
+    ].prebindingDefinitions[0].parameterDefinitions[
       '8v3GB67qF5f'
     ].contentTypes.productFeatureTopic = {
-      ...clonedExperiencePattern.fields.componentSettings['en-US'].parameterDefinitions[
-        '8v3GB67qF5f'
-      ].contentTypes.productFeatureTopic.sys,
+      ...clonedExperiencePattern.fields.componentSettings['en-US'].prebindingDefinitions[0]
+        .parameterDefinitions['8v3GB67qF5f'].contentTypes.productFeatureTopic.sys,
     };
     const result = validateExperienceFields(clonedExperiencePattern, schemaVersion);
 


### PR DESCRIPTION
## Purpose

Introduce wrapping object for prebinding definitions.

⚠️ This is breaking change for pattern with prebinding enabled, but it's ok since the feature is still in development.

## Approach

* Updated schema to reflect the new format and update all related code references and test fixtures to use the new format.

Before:
```
"componentSettings": {
  "parameterDefinitions": {
    ...
  },
  "variableMappings": {
     ...
  }
}
```

After:
```
"componentSettings": {
  "prebindingDefinitions": [
    {
      "id": "$randomId",
      "parameterDefinitions": {
        ...
      },
      "variableMappings": {
        ...
      }
    }
  ]
}
```

* Added also support for `passToNodes` and `allowedVariableOverrides` in Pattern Schema.
* Made `componentSettings`, `prebindingDefinitions` and `passToNode` objects strict.

<!--
Remember when merging:
- Use "Squash and merge" when merging changes into development.
- Use "Create a merge commit" when releasing changes into next and main.

Three important notes on pull requests:
- In general, you should ask yourself whether this code change will improve or worsen the overall code quality. Any new tech debt will probably never be cleaned up.
- Please remember that newly introduced logic should be validated and protected through testing.
- Take a look at PR guides:
  Google's Code Review Guidelines: https://google.github.io/eng-practices/
  Blockly - Writing a Good Pull Request: https://developers.google.com/blockly/guides/contribute/get-started/write_a_good_pr
-->
