### PR TITLE
chore(ci): [SECURITY-936] Enable CodeQL scans for GitHub workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -6,7 +6,7 @@ on:
     branches: [development]
     paths: [".github/workflows/**"]
   pull_request:
-    branches: [main, master]
+    branches: [development]
     paths: [".github/workflows/**"]
 
 jobs:


### PR DESCRIPTION
Enable CodeQL scans for GitHub workflow.

For more details on why we do this, please refer to https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/

After the merge, navigate to the code-scanning findings available under the security tab --> code-scanning