### PR TITLE
chore: bump SDK to latest v1 version in all example apps [SPA-2943]

### DIFF
--- a/examples/astrojs-ssr/package-lock.json
+++ b/examples/astrojs-ssr/package-lock.json
@@ -11,7 +11,7 @@
         "@astrojs/check": "^0.9.4",
         "@astrojs/node": "^9.0.0",
         "@astrojs/react": "^4.1.1",
-        "@contentful/experiences-sdk-react": "^1.41.0",
+        "@contentful/experiences-sdk-react": "^1.42.3",
         "@types/react": "^19.0.1",
         "@types/react-dom": "^19.0.2",
         "astro": "^5.0.8",
@@ -472,11 +472,12 @@
       }
     },
     "node_modules/@contentful/experiences-components-react": {
-      "version": "1.41.0",
-      "resolved": "https://npm.pkg.github.com/download/@contentful/experiences-components-react/1.41.0/5d4468c8787e8aca33e30c27180bdfc65a4d5b76",
-      "integrity": "sha512-ph/KJeehLfo0+Q4TsfZmsWg96MAgPb3sTBzY7kIZpilA9bRxUzLkJDo3QG6SwaEdKouSz3PF2oytcqvvl99AiA==",
+      "version": "1.42.3",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/experiences-components-react/1.42.3/3a18da1f66206992800ed73eeb66f288f7b6548c",
+      "integrity": "sha512-pA+butufpD3rDS21aXCjqz5RHRtz+vSwLhj9MDEg4nj5xybNGB7ZKE+yphuGI3siIdZtieKnEWrNDm9wb92kpg==",
+      "license": "MIT",
       "dependencies": {
-        "@contentful/experiences-core": "1.41.0",
+        "@contentful/experiences-core": "1.42.3",
         "@contentful/rich-text-react-renderer": "^16.0.1",
         "postcss-import": "^16.0.1",
         "style-inject": "^0.3.0"
@@ -487,11 +488,12 @@
       }
     },
     "node_modules/@contentful/experiences-core": {
-      "version": "1.41.0",
-      "resolved": "https://npm.pkg.github.com/download/@contentful/experiences-core/1.41.0/92eefbe04362884537b1b0800c75d19e1853c84a",
-      "integrity": "sha512-sdPOk4SSDQ/QTaP1eiQbP9Xqr69//ruFfRc3bgn1ZoeWbfdmt1Duq+lhmEVQ8hkdf8hIlhjtVWLeQMpBqjUSQw==",
+      "version": "1.42.3",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/experiences-core/1.42.3/e80498253642fc287dd2cadfbd6461040f44c322",
+      "integrity": "sha512-9yTLdL5MyiKwwkryjRHNRYTwJFy9qVISeBw+ls1iPvwdPHHXv9/663c54Ozrjj9/3Iy5DCcG/uBpzvQQRyf6aQ==",
+      "license": "MIT",
       "dependencies": {
-        "@contentful/experiences-validators": "1.41.0",
+        "@contentful/experiences-validators": "1.42.3",
         "@contentful/rich-text-types": "^17.0.0"
       },
       "peerDependencies": {
@@ -502,6 +504,7 @@
       "version": "17.0.1",
       "resolved": "https://npm.pkg.github.com/download/@contentful/rich-text-types/17.0.1/9b5d8520decc0630756231415e6f4f2d6776b166",
       "integrity": "sha512-T+btHJY9mdLeZ1Sn2GcWLiG93gwBvovBxR73/tjUeIYsosBM3dkOdMRKXzBV9ghcuE1q+QP0TbyxA77hYIF9Jw==",
+      "license": "MIT",
       "dependencies": {
         "is-plain-obj": "^3.0.0"
       },
@@ -521,14 +524,15 @@
       }
     },
     "node_modules/@contentful/experiences-sdk-react": {
-      "version": "1.41.0",
-      "resolved": "https://npm.pkg.github.com/download/@contentful/experiences-sdk-react/1.41.0/a873db09ce3d36fdf83071e8e7a1b843681c9c7a",
-      "integrity": "sha512-MwccWOQfETro3FGhlzCUItyXsBgVlF5pNttsfCKMGf0nyOLYonfBbEnJk8ykrZh+sguAXM9sNIV7wcps+d85hA==",
+      "version": "1.42.3",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/experiences-sdk-react/1.42.3/c705c8b7f8a4899900cab8c760c00388fd8b95a2",
+      "integrity": "sha512-TvRGNhtn+Tc/T3FBlXdB1C9NGVjMzh8Sbq8BpfrVB0qEaEV3AvhTSyduVoFWct+S4VCgk5HiwBirtflOg8q2Fw==",
+      "license": "MIT",
       "dependencies": {
-        "@contentful/experiences-components-react": "1.41.0",
-        "@contentful/experiences-core": "1.41.0",
-        "@contentful/experiences-validators": "1.41.0",
-        "@contentful/experiences-visual-editor-react": "1.41.0",
+        "@contentful/experiences-components-react": "1.42.3",
+        "@contentful/experiences-core": "1.42.3",
+        "@contentful/experiences-validators": "1.42.3",
+        "@contentful/experiences-visual-editor-react": "1.42.3",
         "@contentful/rich-text-types": "^17.0.0",
         "classnames": "^2.3.2",
         "csstype": "^3.1.2",
@@ -566,20 +570,20 @@
       }
     },
     "node_modules/@contentful/experiences-validators": {
-      "version": "1.41.0",
-      "resolved": "https://npm.pkg.github.com/download/@contentful/experiences-validators/1.41.0/4cbceccdf844c7a5d32fd88b8c02f86b4cd93be8",
-      "integrity": "sha512-XCIwkfp/PTsPnCvJf/WINqJfzAbvGyhhknH/WjngiO/Px861twePhxFKthA9qKBTfv3/yNnBHUzQsP2EvICLGQ==",
+      "version": "1.42.3",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/experiences-validators/1.42.3/4ee8118af74d4204ddbafe26f2a9a83a263f7899",
+      "integrity": "sha512-wCqYPbD9mVu6a3iGHqlGay8VJZ6+/7txyAUxeZNAdgm2Tjio1tfG6jz4F7Bi++NJXqWp/K+n/mRXLZcfbUY86g==",
       "dependencies": {
         "zod": "^3.22.4"
       }
     },
     "node_modules/@contentful/experiences-visual-editor-react": {
-      "version": "1.41.0",
-      "resolved": "https://npm.pkg.github.com/download/@contentful/experiences-visual-editor-react/1.41.0/fe33f6098411051d4e8d7da22a3343ce56bbd060",
-      "integrity": "sha512-5un5ifV4CCzl2H/K1mvVjk4n0rx/nsW4zX1q/bAUDVRiVz1F8JYZeimemh323N1kewKUcGCsxGLVsipy3Jy3RA==",
+      "version": "1.42.3",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/experiences-visual-editor-react/1.42.3/b1f2720ce8365741db13db1d9f5ea5cc930ef40f",
+      "integrity": "sha512-tbP1rwY5mcnMZepXzdvT9at+v+vmhq68qlussZW9QefbdQk4QkIY3D8aqJiO5sOclzREV+EGrct+iEQvXjMLSA==",
       "dependencies": {
-        "@contentful/experiences-components-react": "1.41.0",
-        "@contentful/experiences-core": "1.41.0",
+        "@contentful/experiences-components-react": "1.42.3",
+        "@contentful/experiences-core": "1.42.3",
         "@hello-pangea/dnd": "^16.3.0",
         "classnames": "^2.3.2",
         "contentful": "^10.6.14",
@@ -728,6 +732,7 @@
       "version": "16.0.2",
       "resolved": "https://npm.pkg.github.com/download/@contentful/rich-text-react-renderer/16.0.2/8c82c983b31eb9b0506b1bec8e232863e7bcb1c3",
       "integrity": "sha512-rh1leRqndG3RzWQTKOXu7GrLGY2ijlrGkDi+df9sI14aaj6Tl2vCoHwEtmW5kjNS5XBwo+RSR86j1ro9fDTnfw==",
+      "license": "MIT",
       "dependencies": {
         "@contentful/rich-text-types": "^17.0.1"
       },
@@ -743,6 +748,7 @@
       "version": "17.0.1",
       "resolved": "https://npm.pkg.github.com/download/@contentful/rich-text-types/17.0.1/9b5d8520decc0630756231415e6f4f2d6776b166",
       "integrity": "sha512-T+btHJY9mdLeZ1Sn2GcWLiG93gwBvovBxR73/tjUeIYsosBM3dkOdMRKXzBV9ghcuE1q+QP0TbyxA77hYIF9Jw==",
+      "license": "MIT",
       "dependencies": {
         "is-plain-obj": "^3.0.0"
       },

--- a/examples/astrojs-ssr/package.json
+++ b/examples/astrojs-ssr/package.json
@@ -13,7 +13,7 @@
     "@astrojs/check": "^0.9.4",
     "@astrojs/node": "^9.0.0",
     "@astrojs/react": "^4.1.1",
-    "@contentful/experiences-sdk-react": "^1.41.0",
+    "@contentful/experiences-sdk-react": "^1.42.3",
     "@types/react": "^19.0.1",
     "@types/react-dom": "^19.0.2",
     "astro": "^5.0.8",

--- a/examples/gatsby/gatsby-spa/package-lock.json
+++ b/examples/gatsby/gatsby-spa/package-lock.json
@@ -8,7 +8,7 @@
       "name": "gatsby-spa",
       "version": "1.0.0",
       "dependencies": {
-        "@contentful/experiences-sdk-react": "^1.41.0",
+        "@contentful/experiences-sdk-react": "^1.42.3",
         "contentful": "^11.3.2",
         "gatsby": "^5.14.5",
         "react": "^18.2.0",
@@ -1971,11 +1971,12 @@
       }
     },
     "node_modules/@contentful/experiences-components-react": {
-      "version": "1.42.2",
-      "resolved": "https://npm.pkg.github.com/download/@contentful/experiences-components-react/1.42.2/f4b2a33cc70355c32c461cc25e9f00a674fc4223",
-      "integrity": "sha512-AHmfWGpZgPEFuinbOX/A1DXfjk12AlSXZyWRDHRIZSey42GKd4EbeCLL9X3pAFz0CvQhxz4El0n+L/TD9V/XWg==",
+      "version": "1.42.3",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/experiences-components-react/1.42.3/3a18da1f66206992800ed73eeb66f288f7b6548c",
+      "integrity": "sha512-pA+butufpD3rDS21aXCjqz5RHRtz+vSwLhj9MDEg4nj5xybNGB7ZKE+yphuGI3siIdZtieKnEWrNDm9wb92kpg==",
+      "license": "MIT",
       "dependencies": {
-        "@contentful/experiences-core": "1.42.2",
+        "@contentful/experiences-core": "1.42.3",
         "@contentful/rich-text-react-renderer": "^16.0.1",
         "postcss-import": "^16.0.1",
         "style-inject": "^0.3.0"
@@ -1986,11 +1987,12 @@
       }
     },
     "node_modules/@contentful/experiences-core": {
-      "version": "1.42.2",
-      "resolved": "https://npm.pkg.github.com/download/@contentful/experiences-core/1.42.2/42801d6e23bfb5e413c33d96f5cdfb0786373881",
-      "integrity": "sha512-Wqn+TEig1sjVJ8TirWsSBt1WQjHCJEueuCKfA8WMlGRhEmyQ3aH70HURJx9IZa2tGeAPwDrwy3cunDuiDbvXSA==",
+      "version": "1.42.3",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/experiences-core/1.42.3/e80498253642fc287dd2cadfbd6461040f44c322",
+      "integrity": "sha512-9yTLdL5MyiKwwkryjRHNRYTwJFy9qVISeBw+ls1iPvwdPHHXv9/663c54Ozrjj9/3Iy5DCcG/uBpzvQQRyf6aQ==",
+      "license": "MIT",
       "dependencies": {
-        "@contentful/experiences-validators": "1.42.2",
+        "@contentful/experiences-validators": "1.42.3",
         "@contentful/rich-text-types": "^17.0.0"
       },
       "peerDependencies": {
@@ -2001,6 +2003,7 @@
       "version": "17.0.1",
       "resolved": "https://npm.pkg.github.com/download/@contentful/rich-text-types/17.0.1/9b5d8520decc0630756231415e6f4f2d6776b166",
       "integrity": "sha512-T+btHJY9mdLeZ1Sn2GcWLiG93gwBvovBxR73/tjUeIYsosBM3dkOdMRKXzBV9ghcuE1q+QP0TbyxA77hYIF9Jw==",
+      "license": "MIT",
       "dependencies": {
         "is-plain-obj": "^3.0.0"
       },
@@ -2009,14 +2012,15 @@
       }
     },
     "node_modules/@contentful/experiences-sdk-react": {
-      "version": "1.42.2",
-      "resolved": "https://npm.pkg.github.com/download/@contentful/experiences-sdk-react/1.42.2/16c6180665027bb65f0b50b6155e60a18ed69909",
-      "integrity": "sha512-dEWzbTdT6/6rptoyzWSi0S41qFDfiC2taGCVaVM5hQRlVHaCSmuk5LLHo3Wa0yMgIZED097ukwQU9nzUmhG9Xw==",
+      "version": "1.42.3",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/experiences-sdk-react/1.42.3/c705c8b7f8a4899900cab8c760c00388fd8b95a2",
+      "integrity": "sha512-TvRGNhtn+Tc/T3FBlXdB1C9NGVjMzh8Sbq8BpfrVB0qEaEV3AvhTSyduVoFWct+S4VCgk5HiwBirtflOg8q2Fw==",
+      "license": "MIT",
       "dependencies": {
-        "@contentful/experiences-components-react": "1.42.2",
-        "@contentful/experiences-core": "1.42.2",
-        "@contentful/experiences-validators": "1.42.2",
-        "@contentful/experiences-visual-editor-react": "1.42.2",
+        "@contentful/experiences-components-react": "1.42.3",
+        "@contentful/experiences-core": "1.42.3",
+        "@contentful/experiences-validators": "1.42.3",
+        "@contentful/experiences-visual-editor-react": "1.42.3",
         "@contentful/rich-text-types": "^17.0.0",
         "classnames": "^2.3.2",
         "csstype": "^3.1.2",
@@ -2053,20 +2057,20 @@
       }
     },
     "node_modules/@contentful/experiences-validators": {
-      "version": "1.42.2",
-      "resolved": "https://npm.pkg.github.com/download/@contentful/experiences-validators/1.42.2/6866ff76bceb0edaa85493fcf05123387515168e",
-      "integrity": "sha512-R2kc6ucWkHEaI3voObYsLEQCQe3Lcs2mpAw38idDRap+YDxTM5R2NQtx7n5SwG3q/IYVC6pZyYwhGntvPnj4+w==",
+      "version": "1.42.3",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/experiences-validators/1.42.3/4ee8118af74d4204ddbafe26f2a9a83a263f7899",
+      "integrity": "sha512-wCqYPbD9mVu6a3iGHqlGay8VJZ6+/7txyAUxeZNAdgm2Tjio1tfG6jz4F7Bi++NJXqWp/K+n/mRXLZcfbUY86g==",
       "dependencies": {
         "zod": "^3.22.4"
       }
     },
     "node_modules/@contentful/experiences-visual-editor-react": {
-      "version": "1.42.2",
-      "resolved": "https://npm.pkg.github.com/download/@contentful/experiences-visual-editor-react/1.42.2/e0be02959081b114dd3d469dd4e827640238aa3b",
-      "integrity": "sha512-REjcFvr8QR2CVw60/ghnf+M+e1ejsDJX36oYIyWE7D7esiedhQLO7lDS2NRfmJbQFigIMDLQlWA97/iWvady9g==",
+      "version": "1.42.3",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/experiences-visual-editor-react/1.42.3/b1f2720ce8365741db13db1d9f5ea5cc930ef40f",
+      "integrity": "sha512-tbP1rwY5mcnMZepXzdvT9at+v+vmhq68qlussZW9QefbdQk4QkIY3D8aqJiO5sOclzREV+EGrct+iEQvXjMLSA==",
       "dependencies": {
-        "@contentful/experiences-components-react": "1.42.2",
-        "@contentful/experiences-core": "1.42.2",
+        "@contentful/experiences-components-react": "1.42.3",
+        "@contentful/experiences-core": "1.42.3",
         "@hello-pangea/dnd": "^16.3.0",
         "classnames": "^2.3.2",
         "contentful": "^10.6.14",
@@ -2162,6 +2166,7 @@
       "version": "16.0.2",
       "resolved": "https://npm.pkg.github.com/download/@contentful/rich-text-react-renderer/16.0.2/8c82c983b31eb9b0506b1bec8e232863e7bcb1c3",
       "integrity": "sha512-rh1leRqndG3RzWQTKOXu7GrLGY2ijlrGkDi+df9sI14aaj6Tl2vCoHwEtmW5kjNS5XBwo+RSR86j1ro9fDTnfw==",
+      "license": "MIT",
       "dependencies": {
         "@contentful/rich-text-types": "^17.0.1"
       },
@@ -2177,6 +2182,7 @@
       "version": "17.0.1",
       "resolved": "https://npm.pkg.github.com/download/@contentful/rich-text-types/17.0.1/9b5d8520decc0630756231415e6f4f2d6776b166",
       "integrity": "sha512-T+btHJY9mdLeZ1Sn2GcWLiG93gwBvovBxR73/tjUeIYsosBM3dkOdMRKXzBV9ghcuE1q+QP0TbyxA77hYIF9Jw==",
+      "license": "MIT",
       "dependencies": {
         "is-plain-obj": "^3.0.0"
       },
@@ -17505,9 +17511,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.25.67",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.67.tgz",
-      "integrity": "sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw==",
+      "version": "3.25.73",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.73.tgz",
+      "integrity": "sha512-fuIKbQAWQl22Ba5d1quwEETQYjqnpKVyZIWAhbnnHgnDd3a+z4YgEfkI5SZ2xMELnLAXo/Flk2uXgysZNf0uaA==",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -18878,22 +18884,22 @@
       }
     },
     "@contentful/experiences-components-react": {
-      "version": "1.42.2",
-      "resolved": "https://npm.pkg.github.com/download/@contentful/experiences-components-react/1.42.2/f4b2a33cc70355c32c461cc25e9f00a674fc4223",
-      "integrity": "sha512-AHmfWGpZgPEFuinbOX/A1DXfjk12AlSXZyWRDHRIZSey42GKd4EbeCLL9X3pAFz0CvQhxz4El0n+L/TD9V/XWg==",
+      "version": "1.42.3",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/experiences-components-react/1.42.3/3a18da1f66206992800ed73eeb66f288f7b6548c",
+      "integrity": "sha512-pA+butufpD3rDS21aXCjqz5RHRtz+vSwLhj9MDEg4nj5xybNGB7ZKE+yphuGI3siIdZtieKnEWrNDm9wb92kpg==",
       "requires": {
-        "@contentful/experiences-core": "1.42.2",
+        "@contentful/experiences-core": "1.42.3",
         "@contentful/rich-text-react-renderer": "^16.0.1",
         "postcss-import": "^16.0.1",
         "style-inject": "^0.3.0"
       }
     },
     "@contentful/experiences-core": {
-      "version": "1.42.2",
-      "resolved": "https://npm.pkg.github.com/download/@contentful/experiences-core/1.42.2/42801d6e23bfb5e413c33d96f5cdfb0786373881",
-      "integrity": "sha512-Wqn+TEig1sjVJ8TirWsSBt1WQjHCJEueuCKfA8WMlGRhEmyQ3aH70HURJx9IZa2tGeAPwDrwy3cunDuiDbvXSA==",
+      "version": "1.42.3",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/experiences-core/1.42.3/e80498253642fc287dd2cadfbd6461040f44c322",
+      "integrity": "sha512-9yTLdL5MyiKwwkryjRHNRYTwJFy9qVISeBw+ls1iPvwdPHHXv9/663c54Ozrjj9/3Iy5DCcG/uBpzvQQRyf6aQ==",
       "requires": {
-        "@contentful/experiences-validators": "1.42.2",
+        "@contentful/experiences-validators": "1.42.3",
         "@contentful/rich-text-types": "^17.0.0"
       },
       "dependencies": {
@@ -18908,14 +18914,14 @@
       }
     },
     "@contentful/experiences-sdk-react": {
-      "version": "1.42.2",
-      "resolved": "https://npm.pkg.github.com/download/@contentful/experiences-sdk-react/1.42.2/16c6180665027bb65f0b50b6155e60a18ed69909",
-      "integrity": "sha512-dEWzbTdT6/6rptoyzWSi0S41qFDfiC2taGCVaVM5hQRlVHaCSmuk5LLHo3Wa0yMgIZED097ukwQU9nzUmhG9Xw==",
+      "version": "1.42.3",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/experiences-sdk-react/1.42.3/c705c8b7f8a4899900cab8c760c00388fd8b95a2",
+      "integrity": "sha512-TvRGNhtn+Tc/T3FBlXdB1C9NGVjMzh8Sbq8BpfrVB0qEaEV3AvhTSyduVoFWct+S4VCgk5HiwBirtflOg8q2Fw==",
       "requires": {
-        "@contentful/experiences-components-react": "1.42.2",
-        "@contentful/experiences-core": "1.42.2",
-        "@contentful/experiences-validators": "1.42.2",
-        "@contentful/experiences-visual-editor-react": "1.42.2",
+        "@contentful/experiences-components-react": "1.42.3",
+        "@contentful/experiences-core": "1.42.3",
+        "@contentful/experiences-validators": "1.42.3",
+        "@contentful/experiences-visual-editor-react": "1.42.3",
         "@contentful/rich-text-types": "^17.0.0",
         "classnames": "^2.3.2",
         "csstype": "^3.1.2",
@@ -18941,20 +18947,20 @@
       }
     },
     "@contentful/experiences-validators": {
-      "version": "1.42.2",
-      "resolved": "https://npm.pkg.github.com/download/@contentful/experiences-validators/1.42.2/6866ff76bceb0edaa85493fcf05123387515168e",
-      "integrity": "sha512-R2kc6ucWkHEaI3voObYsLEQCQe3Lcs2mpAw38idDRap+YDxTM5R2NQtx7n5SwG3q/IYVC6pZyYwhGntvPnj4+w==",
+      "version": "1.42.3",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/experiences-validators/1.42.3/4ee8118af74d4204ddbafe26f2a9a83a263f7899",
+      "integrity": "sha512-wCqYPbD9mVu6a3iGHqlGay8VJZ6+/7txyAUxeZNAdgm2Tjio1tfG6jz4F7Bi++NJXqWp/K+n/mRXLZcfbUY86g==",
       "requires": {
         "zod": "^3.22.4"
       }
     },
     "@contentful/experiences-visual-editor-react": {
-      "version": "1.42.2",
-      "resolved": "https://npm.pkg.github.com/download/@contentful/experiences-visual-editor-react/1.42.2/e0be02959081b114dd3d469dd4e827640238aa3b",
-      "integrity": "sha512-REjcFvr8QR2CVw60/ghnf+M+e1ejsDJX36oYIyWE7D7esiedhQLO7lDS2NRfmJbQFigIMDLQlWA97/iWvady9g==",
+      "version": "1.42.3",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/experiences-visual-editor-react/1.42.3/b1f2720ce8365741db13db1d9f5ea5cc930ef40f",
+      "integrity": "sha512-tbP1rwY5mcnMZepXzdvT9at+v+vmhq68qlussZW9QefbdQk4QkIY3D8aqJiO5sOclzREV+EGrct+iEQvXjMLSA==",
       "requires": {
-        "@contentful/experiences-components-react": "1.42.2",
-        "@contentful/experiences-core": "1.42.2",
+        "@contentful/experiences-components-react": "1.42.3",
+        "@contentful/experiences-core": "1.42.3",
         "@hello-pangea/dnd": "^16.3.0",
         "classnames": "^2.3.2",
         "contentful": "^10.6.14",
@@ -29882,9 +29888,9 @@
       }
     },
     "zod": {
-      "version": "3.25.67",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.67.tgz",
-      "integrity": "sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw=="
+      "version": "3.25.73",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.73.tgz",
+      "integrity": "sha512-fuIKbQAWQl22Ba5d1quwEETQYjqnpKVyZIWAhbnnHgnDd3a+z4YgEfkI5SZ2xMELnLAXo/Flk2uXgysZNf0uaA=="
     },
     "zustand": {
       "version": "4.5.7",

--- a/examples/gatsby/gatsby-spa/package.json
+++ b/examples/gatsby/gatsby-spa/package.json
@@ -16,7 +16,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@contentful/experiences-sdk-react": "^1.41.0",
+    "@contentful/experiences-sdk-react": "^1.42.3",
     "contentful": "^11.3.2",
     "gatsby": "^5.14.5",
     "react": "^18.2.0",

--- a/examples/gatsby/gatsby-ssg/package-lock.json
+++ b/examples/gatsby/gatsby-ssg/package-lock.json
@@ -8,7 +8,7 @@
       "name": "gatsby-ssg",
       "version": "1.0.0",
       "dependencies": {
-        "@contentful/experiences-sdk-react": "^1.41.0",
+        "@contentful/experiences-sdk-react": "^1.42.3",
         "contentful": "^11.4.3",
         "gatsby": "^5.14.5",
         "react": "^18.2.0",
@@ -1978,11 +1978,12 @@
       }
     },
     "node_modules/@contentful/experiences-components-react": {
-      "version": "1.42.2",
-      "resolved": "https://npm.pkg.github.com/download/@contentful/experiences-components-react/1.42.2/f4b2a33cc70355c32c461cc25e9f00a674fc4223",
-      "integrity": "sha512-AHmfWGpZgPEFuinbOX/A1DXfjk12AlSXZyWRDHRIZSey42GKd4EbeCLL9X3pAFz0CvQhxz4El0n+L/TD9V/XWg==",
+      "version": "1.42.3",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/experiences-components-react/1.42.3/3a18da1f66206992800ed73eeb66f288f7b6548c",
+      "integrity": "sha512-pA+butufpD3rDS21aXCjqz5RHRtz+vSwLhj9MDEg4nj5xybNGB7ZKE+yphuGI3siIdZtieKnEWrNDm9wb92kpg==",
+      "license": "MIT",
       "dependencies": {
-        "@contentful/experiences-core": "1.42.2",
+        "@contentful/experiences-core": "1.42.3",
         "@contentful/rich-text-react-renderer": "^16.0.1",
         "postcss-import": "^16.0.1",
         "style-inject": "^0.3.0"
@@ -1993,11 +1994,12 @@
       }
     },
     "node_modules/@contentful/experiences-core": {
-      "version": "1.42.2",
-      "resolved": "https://npm.pkg.github.com/download/@contentful/experiences-core/1.42.2/42801d6e23bfb5e413c33d96f5cdfb0786373881",
-      "integrity": "sha512-Wqn+TEig1sjVJ8TirWsSBt1WQjHCJEueuCKfA8WMlGRhEmyQ3aH70HURJx9IZa2tGeAPwDrwy3cunDuiDbvXSA==",
+      "version": "1.42.3",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/experiences-core/1.42.3/e80498253642fc287dd2cadfbd6461040f44c322",
+      "integrity": "sha512-9yTLdL5MyiKwwkryjRHNRYTwJFy9qVISeBw+ls1iPvwdPHHXv9/663c54Ozrjj9/3Iy5DCcG/uBpzvQQRyf6aQ==",
+      "license": "MIT",
       "dependencies": {
-        "@contentful/experiences-validators": "1.42.2",
+        "@contentful/experiences-validators": "1.42.3",
         "@contentful/rich-text-types": "^17.0.0"
       },
       "peerDependencies": {
@@ -2005,14 +2007,15 @@
       }
     },
     "node_modules/@contentful/experiences-sdk-react": {
-      "version": "1.42.2",
-      "resolved": "https://npm.pkg.github.com/download/@contentful/experiences-sdk-react/1.42.2/16c6180665027bb65f0b50b6155e60a18ed69909",
-      "integrity": "sha512-dEWzbTdT6/6rptoyzWSi0S41qFDfiC2taGCVaVM5hQRlVHaCSmuk5LLHo3Wa0yMgIZED097ukwQU9nzUmhG9Xw==",
+      "version": "1.42.3",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/experiences-sdk-react/1.42.3/c705c8b7f8a4899900cab8c760c00388fd8b95a2",
+      "integrity": "sha512-TvRGNhtn+Tc/T3FBlXdB1C9NGVjMzh8Sbq8BpfrVB0qEaEV3AvhTSyduVoFWct+S4VCgk5HiwBirtflOg8q2Fw==",
+      "license": "MIT",
       "dependencies": {
-        "@contentful/experiences-components-react": "1.42.2",
-        "@contentful/experiences-core": "1.42.2",
-        "@contentful/experiences-validators": "1.42.2",
-        "@contentful/experiences-visual-editor-react": "1.42.2",
+        "@contentful/experiences-components-react": "1.42.3",
+        "@contentful/experiences-core": "1.42.3",
+        "@contentful/experiences-validators": "1.42.3",
+        "@contentful/experiences-visual-editor-react": "1.42.3",
         "@contentful/rich-text-types": "^17.0.0",
         "classnames": "^2.3.2",
         "csstype": "^3.1.2",
@@ -2038,20 +2041,20 @@
       }
     },
     "node_modules/@contentful/experiences-validators": {
-      "version": "1.42.2",
-      "resolved": "https://npm.pkg.github.com/download/@contentful/experiences-validators/1.42.2/6866ff76bceb0edaa85493fcf05123387515168e",
-      "integrity": "sha512-R2kc6ucWkHEaI3voObYsLEQCQe3Lcs2mpAw38idDRap+YDxTM5R2NQtx7n5SwG3q/IYVC6pZyYwhGntvPnj4+w==",
+      "version": "1.42.3",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/experiences-validators/1.42.3/4ee8118af74d4204ddbafe26f2a9a83a263f7899",
+      "integrity": "sha512-wCqYPbD9mVu6a3iGHqlGay8VJZ6+/7txyAUxeZNAdgm2Tjio1tfG6jz4F7Bi++NJXqWp/K+n/mRXLZcfbUY86g==",
       "dependencies": {
         "zod": "^3.22.4"
       }
     },
     "node_modules/@contentful/experiences-visual-editor-react": {
-      "version": "1.42.2",
-      "resolved": "https://npm.pkg.github.com/download/@contentful/experiences-visual-editor-react/1.42.2/e0be02959081b114dd3d469dd4e827640238aa3b",
-      "integrity": "sha512-REjcFvr8QR2CVw60/ghnf+M+e1ejsDJX36oYIyWE7D7esiedhQLO7lDS2NRfmJbQFigIMDLQlWA97/iWvady9g==",
+      "version": "1.42.3",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/experiences-visual-editor-react/1.42.3/b1f2720ce8365741db13db1d9f5ea5cc930ef40f",
+      "integrity": "sha512-tbP1rwY5mcnMZepXzdvT9at+v+vmhq68qlussZW9QefbdQk4QkIY3D8aqJiO5sOclzREV+EGrct+iEQvXjMLSA==",
       "dependencies": {
-        "@contentful/experiences-components-react": "1.42.2",
-        "@contentful/experiences-core": "1.42.2",
+        "@contentful/experiences-components-react": "1.42.3",
+        "@contentful/experiences-core": "1.42.3",
         "@hello-pangea/dnd": "^16.3.0",
         "classnames": "^2.3.2",
         "contentful": "^10.6.14",
@@ -2072,6 +2075,7 @@
       "version": "16.8.5",
       "resolved": "https://npm.pkg.github.com/download/@contentful/rich-text-types/16.8.5/832c8b428612f5181908bc1033c6ef9f48f1ce83",
       "integrity": "sha512-q18RJuJCOuYveGiCIjE5xLCQc5lZ3L2Qgxrlg/H2YEobDFqdtmklazRi1XwEWaK3tMg6yVXBzKKkQfLB4qW14A==",
+      "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
       }
@@ -2155,6 +2159,7 @@
       "version": "16.0.2",
       "resolved": "https://npm.pkg.github.com/download/@contentful/rich-text-react-renderer/16.0.2/8c82c983b31eb9b0506b1bec8e232863e7bcb1c3",
       "integrity": "sha512-rh1leRqndG3RzWQTKOXu7GrLGY2ijlrGkDi+df9sI14aaj6Tl2vCoHwEtmW5kjNS5XBwo+RSR86j1ro9fDTnfw==",
+      "license": "MIT",
       "dependencies": {
         "@contentful/rich-text-types": "^17.0.1"
       },
@@ -2170,6 +2175,7 @@
       "version": "17.0.1",
       "resolved": "https://npm.pkg.github.com/download/@contentful/rich-text-types/17.0.1/9b5d8520decc0630756231415e6f4f2d6776b166",
       "integrity": "sha512-T+btHJY9mdLeZ1Sn2GcWLiG93gwBvovBxR73/tjUeIYsosBM3dkOdMRKXzBV9ghcuE1q+QP0TbyxA77hYIF9Jw==",
+      "license": "MIT",
       "dependencies": {
         "is-plain-obj": "^3.0.0"
       },
@@ -16712,9 +16718,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.25.67",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.67.tgz",
-      "integrity": "sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw==",
+      "version": "3.25.73",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.73.tgz",
+      "integrity": "sha512-fuIKbQAWQl22Ba5d1quwEETQYjqnpKVyZIWAhbnnHgnDd3a+z4YgEfkI5SZ2xMELnLAXo/Flk2uXgysZNf0uaA==",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -18076,34 +18082,34 @@
       }
     },
     "@contentful/experiences-components-react": {
-      "version": "1.42.2",
-      "resolved": "https://npm.pkg.github.com/download/@contentful/experiences-components-react/1.42.2/f4b2a33cc70355c32c461cc25e9f00a674fc4223",
-      "integrity": "sha512-AHmfWGpZgPEFuinbOX/A1DXfjk12AlSXZyWRDHRIZSey42GKd4EbeCLL9X3pAFz0CvQhxz4El0n+L/TD9V/XWg==",
+      "version": "1.42.3",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/experiences-components-react/1.42.3/3a18da1f66206992800ed73eeb66f288f7b6548c",
+      "integrity": "sha512-pA+butufpD3rDS21aXCjqz5RHRtz+vSwLhj9MDEg4nj5xybNGB7ZKE+yphuGI3siIdZtieKnEWrNDm9wb92kpg==",
       "requires": {
-        "@contentful/experiences-core": "1.42.2",
+        "@contentful/experiences-core": "1.42.3",
         "@contentful/rich-text-react-renderer": "^16.0.1",
         "postcss-import": "^16.0.1",
         "style-inject": "^0.3.0"
       }
     },
     "@contentful/experiences-core": {
-      "version": "1.42.2",
-      "resolved": "https://npm.pkg.github.com/download/@contentful/experiences-core/1.42.2/42801d6e23bfb5e413c33d96f5cdfb0786373881",
-      "integrity": "sha512-Wqn+TEig1sjVJ8TirWsSBt1WQjHCJEueuCKfA8WMlGRhEmyQ3aH70HURJx9IZa2tGeAPwDrwy3cunDuiDbvXSA==",
+      "version": "1.42.3",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/experiences-core/1.42.3/e80498253642fc287dd2cadfbd6461040f44c322",
+      "integrity": "sha512-9yTLdL5MyiKwwkryjRHNRYTwJFy9qVISeBw+ls1iPvwdPHHXv9/663c54Ozrjj9/3Iy5DCcG/uBpzvQQRyf6aQ==",
       "requires": {
-        "@contentful/experiences-validators": "1.42.2",
+        "@contentful/experiences-validators": "1.42.3",
         "@contentful/rich-text-types": "^17.0.0"
       }
     },
     "@contentful/experiences-sdk-react": {
-      "version": "1.42.2",
-      "resolved": "https://npm.pkg.github.com/download/@contentful/experiences-sdk-react/1.42.2/16c6180665027bb65f0b50b6155e60a18ed69909",
-      "integrity": "sha512-dEWzbTdT6/6rptoyzWSi0S41qFDfiC2taGCVaVM5hQRlVHaCSmuk5LLHo3Wa0yMgIZED097ukwQU9nzUmhG9Xw==",
+      "version": "1.42.3",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/experiences-sdk-react/1.42.3/c705c8b7f8a4899900cab8c760c00388fd8b95a2",
+      "integrity": "sha512-TvRGNhtn+Tc/T3FBlXdB1C9NGVjMzh8Sbq8BpfrVB0qEaEV3AvhTSyduVoFWct+S4VCgk5HiwBirtflOg8q2Fw==",
       "requires": {
-        "@contentful/experiences-components-react": "1.42.2",
-        "@contentful/experiences-core": "1.42.2",
-        "@contentful/experiences-validators": "1.42.2",
-        "@contentful/experiences-visual-editor-react": "1.42.2",
+        "@contentful/experiences-components-react": "1.42.3",
+        "@contentful/experiences-core": "1.42.3",
+        "@contentful/experiences-validators": "1.42.3",
+        "@contentful/experiences-visual-editor-react": "1.42.3",
         "@contentful/rich-text-types": "^17.0.0",
         "classnames": "^2.3.2",
         "csstype": "^3.1.2",
@@ -18121,20 +18127,20 @@
       }
     },
     "@contentful/experiences-validators": {
-      "version": "1.42.2",
-      "resolved": "https://npm.pkg.github.com/download/@contentful/experiences-validators/1.42.2/6866ff76bceb0edaa85493fcf05123387515168e",
-      "integrity": "sha512-R2kc6ucWkHEaI3voObYsLEQCQe3Lcs2mpAw38idDRap+YDxTM5R2NQtx7n5SwG3q/IYVC6pZyYwhGntvPnj4+w==",
+      "version": "1.42.3",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/experiences-validators/1.42.3/4ee8118af74d4204ddbafe26f2a9a83a263f7899",
+      "integrity": "sha512-wCqYPbD9mVu6a3iGHqlGay8VJZ6+/7txyAUxeZNAdgm2Tjio1tfG6jz4F7Bi++NJXqWp/K+n/mRXLZcfbUY86g==",
       "requires": {
         "zod": "^3.22.4"
       }
     },
     "@contentful/experiences-visual-editor-react": {
-      "version": "1.42.2",
-      "resolved": "https://npm.pkg.github.com/download/@contentful/experiences-visual-editor-react/1.42.2/e0be02959081b114dd3d469dd4e827640238aa3b",
-      "integrity": "sha512-REjcFvr8QR2CVw60/ghnf+M+e1ejsDJX36oYIyWE7D7esiedhQLO7lDS2NRfmJbQFigIMDLQlWA97/iWvady9g==",
+      "version": "1.42.3",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/experiences-visual-editor-react/1.42.3/b1f2720ce8365741db13db1d9f5ea5cc930ef40f",
+      "integrity": "sha512-tbP1rwY5mcnMZepXzdvT9at+v+vmhq68qlussZW9QefbdQk4QkIY3D8aqJiO5sOclzREV+EGrct+iEQvXjMLSA==",
       "requires": {
-        "@contentful/experiences-components-react": "1.42.2",
-        "@contentful/experiences-core": "1.42.2",
+        "@contentful/experiences-components-react": "1.42.3",
+        "@contentful/experiences-core": "1.42.3",
         "@hello-pangea/dnd": "^16.3.0",
         "classnames": "^2.3.2",
         "contentful": "^10.6.14",
@@ -28476,9 +28482,9 @@
       }
     },
     "zod": {
-      "version": "3.25.67",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.67.tgz",
-      "integrity": "sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw=="
+      "version": "3.25.73",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.73.tgz",
+      "integrity": "sha512-fuIKbQAWQl22Ba5d1quwEETQYjqnpKVyZIWAhbnnHgnDd3a+z4YgEfkI5SZ2xMELnLAXo/Flk2uXgysZNf0uaA=="
     },
     "zustand": {
       "version": "4.5.7",

--- a/examples/gatsby/gatsby-ssg/package.json
+++ b/examples/gatsby/gatsby-ssg/package.json
@@ -16,7 +16,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@contentful/experiences-sdk-react": "^1.41.0",
+    "@contentful/experiences-sdk-react": "^1.42.3",
     "contentful": "^11.4.3",
     "gatsby": "^5.14.5",
     "react": "^18.2.0",

--- a/examples/next-app-router/package-lock.json
+++ b/examples/next-app-router/package-lock.json
@@ -8,7 +8,7 @@
       "name": "next-app-router",
       "version": "0.1.0",
       "dependencies": {
-        "@contentful/experiences-sdk-react": "^1.41.0",
+        "@contentful/experiences-sdk-react": "^1.42.3",
         "contentful": "^11.3.2",
         "next": "15.2.3",
         "next-i18n-router": "^5.5.0",
@@ -56,11 +56,12 @@
       }
     },
     "node_modules/@contentful/experiences-components-react": {
-      "version": "1.42.2",
-      "resolved": "https://npm.pkg.github.com/download/@contentful/experiences-components-react/1.42.2/f4b2a33cc70355c32c461cc25e9f00a674fc4223",
-      "integrity": "sha512-AHmfWGpZgPEFuinbOX/A1DXfjk12AlSXZyWRDHRIZSey42GKd4EbeCLL9X3pAFz0CvQhxz4El0n+L/TD9V/XWg==",
+      "version": "1.42.3",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/experiences-components-react/1.42.3/3a18da1f66206992800ed73eeb66f288f7b6548c",
+      "integrity": "sha512-pA+butufpD3rDS21aXCjqz5RHRtz+vSwLhj9MDEg4nj5xybNGB7ZKE+yphuGI3siIdZtieKnEWrNDm9wb92kpg==",
+      "license": "MIT",
       "dependencies": {
-        "@contentful/experiences-core": "1.42.2",
+        "@contentful/experiences-core": "1.42.3",
         "@contentful/rich-text-react-renderer": "^16.0.1",
         "postcss-import": "^16.0.1",
         "style-inject": "^0.3.0"
@@ -87,11 +88,12 @@
       }
     },
     "node_modules/@contentful/experiences-core": {
-      "version": "1.42.2",
-      "resolved": "https://npm.pkg.github.com/download/@contentful/experiences-core/1.42.2/42801d6e23bfb5e413c33d96f5cdfb0786373881",
-      "integrity": "sha512-Wqn+TEig1sjVJ8TirWsSBt1WQjHCJEueuCKfA8WMlGRhEmyQ3aH70HURJx9IZa2tGeAPwDrwy3cunDuiDbvXSA==",
+      "version": "1.42.3",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/experiences-core/1.42.3/e80498253642fc287dd2cadfbd6461040f44c322",
+      "integrity": "sha512-9yTLdL5MyiKwwkryjRHNRYTwJFy9qVISeBw+ls1iPvwdPHHXv9/663c54Ozrjj9/3Iy5DCcG/uBpzvQQRyf6aQ==",
+      "license": "MIT",
       "dependencies": {
-        "@contentful/experiences-validators": "1.42.2",
+        "@contentful/experiences-validators": "1.42.3",
         "@contentful/rich-text-types": "^17.0.0"
       },
       "peerDependencies": {
@@ -102,6 +104,7 @@
       "version": "17.0.1",
       "resolved": "https://npm.pkg.github.com/download/@contentful/rich-text-types/17.0.1/9b5d8520decc0630756231415e6f4f2d6776b166",
       "integrity": "sha512-T+btHJY9mdLeZ1Sn2GcWLiG93gwBvovBxR73/tjUeIYsosBM3dkOdMRKXzBV9ghcuE1q+QP0TbyxA77hYIF9Jw==",
+      "license": "MIT",
       "dependencies": {
         "is-plain-obj": "^3.0.0"
       },
@@ -110,14 +113,15 @@
       }
     },
     "node_modules/@contentful/experiences-sdk-react": {
-      "version": "1.42.2",
-      "resolved": "https://npm.pkg.github.com/download/@contentful/experiences-sdk-react/1.42.2/16c6180665027bb65f0b50b6155e60a18ed69909",
-      "integrity": "sha512-dEWzbTdT6/6rptoyzWSi0S41qFDfiC2taGCVaVM5hQRlVHaCSmuk5LLHo3Wa0yMgIZED097ukwQU9nzUmhG9Xw==",
+      "version": "1.42.3",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/experiences-sdk-react/1.42.3/c705c8b7f8a4899900cab8c760c00388fd8b95a2",
+      "integrity": "sha512-TvRGNhtn+Tc/T3FBlXdB1C9NGVjMzh8Sbq8BpfrVB0qEaEV3AvhTSyduVoFWct+S4VCgk5HiwBirtflOg8q2Fw==",
+      "license": "MIT",
       "dependencies": {
-        "@contentful/experiences-components-react": "1.42.2",
-        "@contentful/experiences-core": "1.42.2",
-        "@contentful/experiences-validators": "1.42.2",
-        "@contentful/experiences-visual-editor-react": "1.42.2",
+        "@contentful/experiences-components-react": "1.42.3",
+        "@contentful/experiences-core": "1.42.3",
+        "@contentful/experiences-validators": "1.42.3",
+        "@contentful/experiences-visual-editor-react": "1.42.3",
         "@contentful/rich-text-types": "^17.0.0",
         "classnames": "^2.3.2",
         "csstype": "^3.1.2",
@@ -144,20 +148,20 @@
       }
     },
     "node_modules/@contentful/experiences-validators": {
-      "version": "1.42.2",
-      "resolved": "https://npm.pkg.github.com/download/@contentful/experiences-validators/1.42.2/6866ff76bceb0edaa85493fcf05123387515168e",
-      "integrity": "sha512-R2kc6ucWkHEaI3voObYsLEQCQe3Lcs2mpAw38idDRap+YDxTM5R2NQtx7n5SwG3q/IYVC6pZyYwhGntvPnj4+w==",
+      "version": "1.42.3",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/experiences-validators/1.42.3/4ee8118af74d4204ddbafe26f2a9a83a263f7899",
+      "integrity": "sha512-wCqYPbD9mVu6a3iGHqlGay8VJZ6+/7txyAUxeZNAdgm2Tjio1tfG6jz4F7Bi++NJXqWp/K+n/mRXLZcfbUY86g==",
       "dependencies": {
         "zod": "^3.22.4"
       }
     },
     "node_modules/@contentful/experiences-visual-editor-react": {
-      "version": "1.42.2",
-      "resolved": "https://npm.pkg.github.com/download/@contentful/experiences-visual-editor-react/1.42.2/e0be02959081b114dd3d469dd4e827640238aa3b",
-      "integrity": "sha512-REjcFvr8QR2CVw60/ghnf+M+e1ejsDJX36oYIyWE7D7esiedhQLO7lDS2NRfmJbQFigIMDLQlWA97/iWvady9g==",
+      "version": "1.42.3",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/experiences-visual-editor-react/1.42.3/b1f2720ce8365741db13db1d9f5ea5cc930ef40f",
+      "integrity": "sha512-tbP1rwY5mcnMZepXzdvT9at+v+vmhq68qlussZW9QefbdQk4QkIY3D8aqJiO5sOclzREV+EGrct+iEQvXjMLSA==",
       "dependencies": {
-        "@contentful/experiences-components-react": "1.42.2",
-        "@contentful/experiences-core": "1.42.2",
+        "@contentful/experiences-components-react": "1.42.3",
+        "@contentful/experiences-core": "1.42.3",
         "@hello-pangea/dnd": "^16.3.0",
         "classnames": "^2.3.2",
         "contentful": "^10.6.14",
@@ -301,6 +305,7 @@
       "version": "16.0.2",
       "resolved": "https://npm.pkg.github.com/download/@contentful/rich-text-react-renderer/16.0.2/8c82c983b31eb9b0506b1bec8e232863e7bcb1c3",
       "integrity": "sha512-rh1leRqndG3RzWQTKOXu7GrLGY2ijlrGkDi+df9sI14aaj6Tl2vCoHwEtmW5kjNS5XBwo+RSR86j1ro9fDTnfw==",
+      "license": "MIT",
       "dependencies": {
         "@contentful/rich-text-types": "^17.0.1"
       },
@@ -316,6 +321,7 @@
       "version": "17.0.1",
       "resolved": "https://npm.pkg.github.com/download/@contentful/rich-text-types/17.0.1/9b5d8520decc0630756231415e6f4f2d6776b166",
       "integrity": "sha512-T+btHJY9mdLeZ1Sn2GcWLiG93gwBvovBxR73/tjUeIYsosBM3dkOdMRKXzBV9ghcuE1q+QP0TbyxA77hYIF9Jw==",
+      "license": "MIT",
       "dependencies": {
         "is-plain-obj": "^3.0.0"
       },
@@ -6236,9 +6242,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.25.67",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.67.tgz",
-      "integrity": "sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw==",
+      "version": "3.25.72",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.72.tgz",
+      "integrity": "sha512-Cl+fe4dNL4XumOBNBsr0lHfA80PQiZXHI4xEMTEr8gt6aGz92t3lBA32e71j9+JeF/VAYvdfBnuwJs+BMx/BrA==",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/examples/next-app-router/package.json
+++ b/examples/next-app-router/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@contentful/experiences-sdk-react": "^1.41.0",
+    "@contentful/experiences-sdk-react": "^1.42.3",
     "contentful": "^11.3.2",
     "next": "15.2.3",
     "next-i18n-router": "^5.5.0",

--- a/examples/next-pages-router/package-lock.json
+++ b/examples/next-pages-router/package-lock.json
@@ -8,7 +8,7 @@
       "name": "next-pages-router",
       "version": "0.1.0",
       "dependencies": {
-        "@contentful/experiences-sdk-react": "^1.41.0",
+        "@contentful/experiences-sdk-react": "^1.42.3",
         "contentful": "^11.3.2",
         "next": "15.2.4",
         "react": "19.0.0",
@@ -55,11 +55,12 @@
       }
     },
     "node_modules/@contentful/experiences-components-react": {
-      "version": "1.42.2",
-      "resolved": "https://npm.pkg.github.com/download/@contentful/experiences-components-react/1.42.2/f4b2a33cc70355c32c461cc25e9f00a674fc4223",
-      "integrity": "sha512-AHmfWGpZgPEFuinbOX/A1DXfjk12AlSXZyWRDHRIZSey42GKd4EbeCLL9X3pAFz0CvQhxz4El0n+L/TD9V/XWg==",
+      "version": "1.42.3",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/experiences-components-react/1.42.3/3a18da1f66206992800ed73eeb66f288f7b6548c",
+      "integrity": "sha512-pA+butufpD3rDS21aXCjqz5RHRtz+vSwLhj9MDEg4nj5xybNGB7ZKE+yphuGI3siIdZtieKnEWrNDm9wb92kpg==",
+      "license": "MIT",
       "dependencies": {
-        "@contentful/experiences-core": "1.42.2",
+        "@contentful/experiences-core": "1.42.3",
         "@contentful/rich-text-react-renderer": "^16.0.1",
         "postcss-import": "^16.0.1",
         "style-inject": "^0.3.0"
@@ -86,11 +87,12 @@
       }
     },
     "node_modules/@contentful/experiences-core": {
-      "version": "1.42.2",
-      "resolved": "https://npm.pkg.github.com/download/@contentful/experiences-core/1.42.2/42801d6e23bfb5e413c33d96f5cdfb0786373881",
-      "integrity": "sha512-Wqn+TEig1sjVJ8TirWsSBt1WQjHCJEueuCKfA8WMlGRhEmyQ3aH70HURJx9IZa2tGeAPwDrwy3cunDuiDbvXSA==",
+      "version": "1.42.3",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/experiences-core/1.42.3/e80498253642fc287dd2cadfbd6461040f44c322",
+      "integrity": "sha512-9yTLdL5MyiKwwkryjRHNRYTwJFy9qVISeBw+ls1iPvwdPHHXv9/663c54Ozrjj9/3Iy5DCcG/uBpzvQQRyf6aQ==",
+      "license": "MIT",
       "dependencies": {
-        "@contentful/experiences-validators": "1.42.2",
+        "@contentful/experiences-validators": "1.42.3",
         "@contentful/rich-text-types": "^17.0.0"
       },
       "peerDependencies": {
@@ -101,6 +103,7 @@
       "version": "17.0.1",
       "resolved": "https://npm.pkg.github.com/download/@contentful/rich-text-types/17.0.1/9b5d8520decc0630756231415e6f4f2d6776b166",
       "integrity": "sha512-T+btHJY9mdLeZ1Sn2GcWLiG93gwBvovBxR73/tjUeIYsosBM3dkOdMRKXzBV9ghcuE1q+QP0TbyxA77hYIF9Jw==",
+      "license": "MIT",
       "dependencies": {
         "is-plain-obj": "^3.0.0"
       },
@@ -109,14 +112,15 @@
       }
     },
     "node_modules/@contentful/experiences-sdk-react": {
-      "version": "1.42.2",
-      "resolved": "https://npm.pkg.github.com/download/@contentful/experiences-sdk-react/1.42.2/16c6180665027bb65f0b50b6155e60a18ed69909",
-      "integrity": "sha512-dEWzbTdT6/6rptoyzWSi0S41qFDfiC2taGCVaVM5hQRlVHaCSmuk5LLHo3Wa0yMgIZED097ukwQU9nzUmhG9Xw==",
+      "version": "1.42.3",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/experiences-sdk-react/1.42.3/c705c8b7f8a4899900cab8c760c00388fd8b95a2",
+      "integrity": "sha512-TvRGNhtn+Tc/T3FBlXdB1C9NGVjMzh8Sbq8BpfrVB0qEaEV3AvhTSyduVoFWct+S4VCgk5HiwBirtflOg8q2Fw==",
+      "license": "MIT",
       "dependencies": {
-        "@contentful/experiences-components-react": "1.42.2",
-        "@contentful/experiences-core": "1.42.2",
-        "@contentful/experiences-validators": "1.42.2",
-        "@contentful/experiences-visual-editor-react": "1.42.2",
+        "@contentful/experiences-components-react": "1.42.3",
+        "@contentful/experiences-core": "1.42.3",
+        "@contentful/experiences-validators": "1.42.3",
+        "@contentful/experiences-visual-editor-react": "1.42.3",
         "@contentful/rich-text-types": "^17.0.0",
         "classnames": "^2.3.2",
         "csstype": "^3.1.2",
@@ -143,20 +147,20 @@
       }
     },
     "node_modules/@contentful/experiences-validators": {
-      "version": "1.42.2",
-      "resolved": "https://npm.pkg.github.com/download/@contentful/experiences-validators/1.42.2/6866ff76bceb0edaa85493fcf05123387515168e",
-      "integrity": "sha512-R2kc6ucWkHEaI3voObYsLEQCQe3Lcs2mpAw38idDRap+YDxTM5R2NQtx7n5SwG3q/IYVC6pZyYwhGntvPnj4+w==",
+      "version": "1.42.3",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/experiences-validators/1.42.3/4ee8118af74d4204ddbafe26f2a9a83a263f7899",
+      "integrity": "sha512-wCqYPbD9mVu6a3iGHqlGay8VJZ6+/7txyAUxeZNAdgm2Tjio1tfG6jz4F7Bi++NJXqWp/K+n/mRXLZcfbUY86g==",
       "dependencies": {
         "zod": "^3.22.4"
       }
     },
     "node_modules/@contentful/experiences-visual-editor-react": {
-      "version": "1.42.2",
-      "resolved": "https://npm.pkg.github.com/download/@contentful/experiences-visual-editor-react/1.42.2/e0be02959081b114dd3d469dd4e827640238aa3b",
-      "integrity": "sha512-REjcFvr8QR2CVw60/ghnf+M+e1ejsDJX36oYIyWE7D7esiedhQLO7lDS2NRfmJbQFigIMDLQlWA97/iWvady9g==",
+      "version": "1.42.3",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/experiences-visual-editor-react/1.42.3/b1f2720ce8365741db13db1d9f5ea5cc930ef40f",
+      "integrity": "sha512-tbP1rwY5mcnMZepXzdvT9at+v+vmhq68qlussZW9QefbdQk4QkIY3D8aqJiO5sOclzREV+EGrct+iEQvXjMLSA==",
       "dependencies": {
-        "@contentful/experiences-components-react": "1.42.2",
-        "@contentful/experiences-core": "1.42.2",
+        "@contentful/experiences-components-react": "1.42.3",
+        "@contentful/experiences-core": "1.42.3",
         "@hello-pangea/dnd": "^16.3.0",
         "classnames": "^2.3.2",
         "contentful": "^10.6.14",
@@ -300,6 +304,7 @@
       "version": "16.0.2",
       "resolved": "https://npm.pkg.github.com/download/@contentful/rich-text-react-renderer/16.0.2/8c82c983b31eb9b0506b1bec8e232863e7bcb1c3",
       "integrity": "sha512-rh1leRqndG3RzWQTKOXu7GrLGY2ijlrGkDi+df9sI14aaj6Tl2vCoHwEtmW5kjNS5XBwo+RSR86j1ro9fDTnfw==",
+      "license": "MIT",
       "dependencies": {
         "@contentful/rich-text-types": "^17.0.1"
       },
@@ -315,6 +320,7 @@
       "version": "17.0.1",
       "resolved": "https://npm.pkg.github.com/download/@contentful/rich-text-types/17.0.1/9b5d8520decc0630756231415e6f4f2d6776b166",
       "integrity": "sha512-T+btHJY9mdLeZ1Sn2GcWLiG93gwBvovBxR73/tjUeIYsosBM3dkOdMRKXzBV9ghcuE1q+QP0TbyxA77hYIF9Jw==",
+      "license": "MIT",
       "dependencies": {
         "is-plain-obj": "^3.0.0"
       },
@@ -6207,9 +6213,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.25.67",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.67.tgz",
-      "integrity": "sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw==",
+      "version": "3.25.73",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.73.tgz",
+      "integrity": "sha512-fuIKbQAWQl22Ba5d1quwEETQYjqnpKVyZIWAhbnnHgnDd3a+z4YgEfkI5SZ2xMELnLAXo/Flk2uXgysZNf0uaA==",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/examples/next-pages-router/package.json
+++ b/examples/next-pages-router/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@contentful/experiences-sdk-react": "^1.41.0",
+    "@contentful/experiences-sdk-react": "^1.42.3",
     "contentful": "^11.3.2",
     "next": "15.2.4",
     "react": "19.0.0",


### PR DESCRIPTION
## Purpose

Bump SDK version to latest v1 version in all example apps.

Tested both in editor mode and delivery with a medium complexity experience and didn't see any issues.

https://contentful.atlassian.net/browse/SPA-2943

## Approach

<!--
Remember when merging:
- Use "Squash and merge" when merging changes into development.
- Use "Create a merge commit" when releasing changes into next and main.

Three important notes on pull requests:
- In general, you should ask yourself whether this code change will improve or worsen the overall code quality. Any new tech debt will probably never be cleaned up.
- Please remember that newly introduced logic should be validated and protected through testing.
- Take a look at PR guides:
  Google's Code Review Guidelines: https://google.github.io/eng-practices/
  Blockly - Writing a Good Pull Request: https://developers.google.com/blockly/guides/contribute/get-started/write_a_good_pr
-->
