### PR TITLE
fix: clickable carousel and custom image [SPA-2945]

### DIFF
--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -167,7 +167,7 @@ export const CF_STYLE_ATTRIBUTES = [
   'cfTextUnderline',
 ];
 
-export const EMPTY_CONTAINER_HEIGHT = '80px';
+export const EMPTY_CONTAINER_SIZE = '80px';
 
 export const HYPERLINK_DEFAULT_PATTERN = `/{locale}/{entry.fields.slug}/`;
 

--- a/packages/core/src/utils/styleUtils/stylesUtils.spec.ts
+++ b/packages/core/src/utils/styleUtils/stylesUtils.spec.ts
@@ -1,7 +1,7 @@
 import { ExperienceTreeNode } from '@/types';
 import { calculateNodeDefaultHeight, stringifyCssProperties } from './stylesUtils';
 import { describe, it, expect } from 'vitest';
-import { CONTENTFUL_COMPONENTS, EMPTY_CONTAINER_HEIGHT } from '@/constants';
+import { CONTENTFUL_COMPONENTS, EMPTY_CONTAINER_SIZE } from '@/constants';
 
 describe('stylesUtils', () => {
   describe('calculateNodeDefaultHeight', () => {
@@ -40,7 +40,7 @@ describe('stylesUtils', () => {
         value: 'auto',
       });
 
-      expect(result).toBe(EMPTY_CONTAINER_HEIGHT);
+      expect(result).toBe(EMPTY_CONTAINER_SIZE);
     });
 
     it('should return "100%" when container has a non-container child', () => {

--- a/packages/core/src/utils/styleUtils/stylesUtils.ts
+++ b/packages/core/src/utils/styleUtils/stylesUtils.ts
@@ -6,7 +6,7 @@ import {
   transformGridColumn,
 } from './styleTransformers';
 import { isContentfulStructureComponent, isStructureWithRelativeHeight } from '../components';
-import { EMPTY_CONTAINER_HEIGHT } from '../../constants';
+import { EMPTY_CONTAINER_SIZE } from '../../constants';
 import {
   CSSProperties,
   StyleProps,
@@ -135,7 +135,7 @@ export const addMinHeightForEmptyStructures = (
   ) {
     return {
       ...cssProperties,
-      minHeight: EMPTY_CONTAINER_HEIGHT,
+      minHeight: EMPTY_CONTAINER_SIZE,
     };
   }
   return cssProperties;
@@ -143,7 +143,7 @@ export const addMinHeightForEmptyStructures = (
 
 /**
  * Container/section default behavior:
- * Default height => height: EMPTY_CONTAINER_HEIGHT
+ * Default height => height: EMPTY_CONTAINER_SIZE
  * If a container component has children => height: 'fit-content'
  */
 export const calculateNodeDefaultHeight = ({
@@ -163,5 +163,5 @@ export const calculateNodeDefaultHeight = ({
     return '100%';
   }
 
-  return EMPTY_CONTAINER_HEIGHT;
+  return EMPTY_CONTAINER_SIZE;
 };

--- a/packages/storybook-addon/src/components/StyleSectionComponents/SizeInput/SizeSelector.tsx
+++ b/packages/storybook-addon/src/components/StyleSectionComponents/SizeInput/SizeSelector.tsx
@@ -4,7 +4,7 @@ import { Grid, Select, Text, TextInput } from '@contentful/f36-components';
 import { useVariableState } from '@/hooks/useVariableState';
 import { styles } from './styles';
 import { useCompositionCanvasSubscriber } from '@/context/useCompositionCanvasSubscriber';
-import { EMPTY_CONTAINER_HEIGHT } from '@contentful/experiences-core/constants';
+import { EMPTY_CONTAINER_SIZE } from '@contentful/experiences-core/constants';
 
 const heightVariableName = 'cfHeight';
 const widthVariableName = 'cfWidth';
@@ -30,7 +30,7 @@ const fitSizingOptions = [
 
 const transformValuesBySizingOption = (sizingOption: SizingOptions, value: string) => {
   if (sizingOption === 'fixed') {
-    return EMPTY_CONTAINER_HEIGHT;
+    return EMPTY_CONTAINER_SIZE;
   }
 
   if (sizingOption === 'fit') {

--- a/packages/test-apps/nextjs/src/components/CustomImageComponent.tsx
+++ b/packages/test-apps/nextjs/src/components/CustomImageComponent.tsx
@@ -1,8 +1,8 @@
-export function CustomImageComponent(props: { src: string }) {
+export function CustomImageComponent({ src, ...rest }: { src: string }) {
   return (
-    <>
-      <img src={props.src} style={{ height: '100px', width: '100px' }} />
-      <span>{props.src}</span>
-    </>
+    <div {...rest}>
+      <img src={src} style={{ height: '100px', width: '100px' }} />
+      <span>{src}</span>
+    </div>
   );
 }

--- a/packages/test-apps/react-vite/src/components/CustomImageComponent.tsx
+++ b/packages/test-apps/react-vite/src/components/CustomImageComponent.tsx
@@ -1,8 +1,8 @@
-export function CustomImageComponent(props: { src: string }) {
+export function CustomImageComponent({ src, ...rest }: { src: string }) {
   return (
-    <>
-      <img src={props.src} style={{ height: '100px', width: '100px' }} />
-      <span>{props.src}</span>
-    </>
+    <div {...rest}>
+      <img src={src} style={{ height: '100px', width: '100px' }} />
+      <span>{src}</span>
+    </div>
   );
 }

--- a/packages/visual-editor/src/components/EditorBlock/useComponentProps.ts
+++ b/packages/visual-editor/src/components/EditorBlock/useComponentProps.ts
@@ -10,7 +10,7 @@ import {
   sanitizeNodeProps,
   EntityStoreBase,
 } from '@contentful/experiences-core';
-import { ASSEMBLY_NODE_TYPE, EMPTY_CONTAINER_HEIGHT } from '@contentful/experiences-core/constants';
+import { ASSEMBLY_NODE_TYPE, EMPTY_CONTAINER_SIZE } from '@contentful/experiences-core/constants';
 import type {
   StyleProps,
   PrimitiveValue,
@@ -208,16 +208,26 @@ export const useComponentProps = ({
 
   const cfStyles = useMemo(() => buildCfStyles(props as StyleProps), [props]);
 
+  const shouldRenderEmptySpaceWithMinSize = useMemo(() => {
+    if (node.children.length) return false;
+
+    // Render with minimum height and with in those two scenarios:
+    if (isStructureWithRelativeHeight(node.data.blockId, cfStyles.height)) return true;
+    if (definition?.children) return true;
+
+    return false;
+  }, [cfStyles.height, definition?.children, node.children.length, node.data.blockId]);
+
   // Styles that will be applied to the component element
   const componentStyles = useMemo(
     () => ({
       ...cfStyles,
-      ...(!node.children.length &&
-        isStructureWithRelativeHeight(node.data.blockId, cfStyles.height) && {
-          minHeight: EMPTY_CONTAINER_HEIGHT,
-        }),
+      ...(shouldRenderEmptySpaceWithMinSize && {
+        minHeight: EMPTY_CONTAINER_SIZE,
+        minWidth: EMPTY_CONTAINER_SIZE,
+      }),
     }),
-    [cfStyles, node.children.length, node.data.blockId],
+    [cfStyles, shouldRenderEmptySpaceWithMinSize],
   );
 
   const cfCsrClassName = useEditorModeClassName({


### PR DESCRIPTION
## Purpose

In the new editor, one could not click on an empty carousel or custom image.

## Approach
1. The carousel had no minimum size anymore. I fixed that by adding a rule that every custom component that accepts children get's a minimum height and width of `80px` (like before). This might not work in some specific use cases but it follows the existing behaviour and also it doesn't affect preview/delivery.

2. The custom image in our test apps did not correctly forward the HTML attributes to identify nodes in the DOM. Added that