### PR TITLE
chore: [] send initial canvas geometry

### DIFF
--- a/packages/visual-editor/src/components/RootRenderer/useCanvasGeometryUpdates.ts
+++ b/packages/visual-editor/src/components/RootRenderer/useCanvasGeometryUpdates.ts
@@ -63,6 +63,8 @@ export const useCanvasGeometryUpdates = ({ tree }: UseCanvasGeometryUpdatesParam
     const observer = new MutationObserver(() =>
       debouncedUpdateGeometry(treeRef.current, 'mutation'),
     );
+    // send initial geometry in case the tree is empty
+    debouncedUpdateGeometry(treeRef.current, 'mutation');
     observer.observe(document.documentElement, {
       childList: true,
       subtree: true,


### PR DESCRIPTION
## Purpose

Send initial canvas geometry when the tree is not yet received or is empty, so the web app can render the canvas height properly.

## Approach

Send geometry immediately after creating a mutation observer.