### PR TITLE
fix: remove unnecessary node removal check in getTreeDiff function

### DIFF
--- a/packages/visual-editor/src/utils/getTreeDiff.ts
+++ b/packages/visual-editor/src/utils/getTreeDiff.ts
@@ -159,11 +159,6 @@ function compareNodes({
   });
 
   map.forEach((index, key) => {
-    // If the node count of the entire tree doesn't signify
-    // a node was removed, don't add that as a diff
-    if (!nodeRemoved) {
-      return;
-    }
     // Remaining nodes in the map are removed in the second tree
     differences.push({
       type: TreeAction.REMOVE_NODE,


### PR DESCRIPTION
#### Problem

The visual editor's diffing algorithm, which is responsible for calculating the difference between two versions of the component tree, was failing to correctly identify a "detach" operation. A "detach" operation occurs when a node is removed from the tree, and its children are promoted to take its place. This led to visual inconsistencies and duplicated "ghost" components in the editor, as the detached node was never correctly cleared from the UI.

#### Root Cause Analysis

The root of the issue was a flawed optimization within the `compareNodes` function in `src/utils/getTreeDiff.ts`. The logic contained a check that prevented the creation of a `REMOVE_NODE` action if the total number of children under a given parent node did not decrease.

This created a critical blind spot for the "detach" scenario. Consider the transformation:

**Before:** `Parent` -> `Child` -> `Grandchild`
**After:** `Parent` -> `Grandchild`

From the `Parent` node's perspective, its number of children remains exactly one. The child count does not change (it goes from 1 to 1). This caused the `nodeRemoved` flag within the algorithm to be `false`, and the faulty check `if (!nodeRemoved)` incorrectly skipped the logic that should have identified the original "Child" node as removed.

This explains why the issue was most prominent and reproducible in simple cases but might have seemed to work correctly in more complex scenes. If other components were being deleted from the same parent in the same operation, the child count *would* decrease, the `nodeRemoved` flag would become `true`, and the `REMOVE_NODE` action for the detached node would be created correctly, effectively masking the underlying bug. The failure was specific to operations that preserved the child count of the parent node.

#### The Change

The fix was to remove the conditional `if (!nodeRemoved)` check entirely. The core of the diffing algorithm correctly uses a `Map` to track which nodes from the original tree are still present in the updated tree. Any node ID remaining in the map after the comparison is, by definition, a node that has been removed.

By removing the faulty check, we now trust the `Map` as the single source of truth for detecting removed nodes, regardless of whether the parent's child count changed. This makes the algorithm more robust and capable of handling complex tree transformations like the detach operation reliably.

```typescript
// Corrected logic in src/utils/getTreeDiff.ts

map.forEach((index, key) => {
  // Remaining nodes in the map are removed in the second tree
  differences.push({
    type: TreeAction.REMOVE_NODE,
    indexToRemove: index,
    parentNodeId,
    idToRemove: key,
  });
});
```

#### Risks & Mitigation

*   **Risk**: Low. The removed check was an incorrect optimization that was causing known bugs under specific, reproducible conditions. Its removal restores the intended and more reliable logic of the diffing algorithm.

*   **Mitigation**: The logic is now more direct and less prone to being fooled by complex scenarios. The algorithm's reliance on the `Map` of remaining nodes is a standard and robust method for this kind of comparison. Thorough testing of all component operations (add, delete, reorder, and especially detach) is recommended to ensure no regressions have been introduced.