### PR TITLE
fix: fixes bug by replicating coupled cfBackgroundImageUrl to all breakpoints [SPA-2998]

### DIFF
--- a/packages/experience-builder-sdk/src/utils/parseComponentProps.ts
+++ b/packages/experience-builder-sdk/src/utils/parseComponentProps.ts
@@ -98,7 +98,16 @@ export const parseComponentProps = ({
         const propValue = boundValue ?? propDefinition.defaultValue;
 
         if (isSpecialCaseCssProp(propName)) {
-          styleProps[propName] = { [mainBreakpoint.id]: propValue };
+          // styleProps[propName] = { [mainBreakpoint.id]: propValue };
+          // Here we create kind of "fake" style property out of a bound value.
+          // As bound values are breakpoint-universal (they apply to all breakpoints),
+          // but styleProps are breakpoint-specific, we need to ensure that
+          // semantically our "fake" style property will be universall as well,
+          // by expanding it to all the breakpoints. This is important as
+          // styleTransformers.ts#transformBackgroundImageUrl() expects
+          // cfBackgroundImageUrl to be present for all breakpoints
+          // where cfBackgroundImageOptions is present.
+          styleProps[propName] = Object.fromEntries(breakpoints.map((b) => [b.id, propValue]));
         } else {
           contentProps[propName] = propValue;
         }
@@ -121,7 +130,7 @@ export const parseComponentProps = ({
         });
 
         if (isSpecialCaseCssProp(propName)) {
-          styleProps[propName] = { [mainBreakpoint.id]: unboundValue };
+          styleProps[propName] = Object.fromEntries(breakpoints.map((b) => [b.id, unboundValue]));
         } else {
           contentProps[propName] = unboundValue;
         }
@@ -139,7 +148,8 @@ export const parseComponentProps = ({
           }) ?? propDefinition.defaultValue;
 
         if (isSpecialCaseCssProp(propName)) {
-          styleProps[propName] = { [mainBreakpoint.id]: propValue };
+          // TODO: should I fix it here?
+          styleProps[propName] = Object.fromEntries(breakpoints.map((b) => [b.id, propValue]));
         } else {
           contentProps[propName] = propValue;
         }
@@ -201,6 +211,7 @@ export const parseComponentProps = ({
   /* [Data Format] `mediaQuery` is a joined string of all media query CSS code
    * mediaQuery = ".cfstyles-123{margin:42px;}@media(max-width:768px){.cfstyles-456{margin:13px;}}"
    */
+  console.error(`;; `, JSON.stringify(styleProps, null, 2));
   return {
     styleProps,
     mediaQuery,


### PR DESCRIPTION


## Purpose


Ensures that when we create "fake" cfBackgroundImageUrl Design value, it's available for all breakpoints.

## Approach

<!--
Remember when merging:
- Use "Squash and merge" when merging changes into development.
- Use "Create a merge commit" when releasing changes into next and main.

Three important notes on pull requests:
- In general, you should ask yourself whether this code change will improve or worsen the overall code quality. Any new tech debt will probably never be cleaned up.
- Please remember that newly introduced logic should be validated and protected through testing.
- Take a look at PR guides:
  Google's Code Review Guidelines: https://google.github.io/eng-practices/
  Blockly - Writing a Good Pull Request: https://developers.google.com/blockly/guides/contribute/get-started/write_a_good_pr
-->
