### PR TITLE
fix: avoid native missing image indicator cross-browser & show corner radius on placeholder image

### DIFF
--- a/packages/components/src/components/Image/Image.css
+++ b/packages/components/src/components/Image/Image.css
@@ -1,12 +1,13 @@
 div.cf-placeholder-wrapper {
   /* Required for the absolute positioned icon to render in the center */
   position: relative;
+  outline-offset: -2px;
+  outline: 2px solid rgba(var(--cf-color-gray400-rgb), 0.5);
+  overflow: hidden;
 }
 
 img.cf-placeholder-image {
   background-color: var(--cf-color-gray100);
-  outline-offset: -2px;
-  outline: 2px solid rgba(var(--cf-color-gray400-rgb), 0.5);
   width: 100%;
   height: 100%;
 }

--- a/packages/components/src/components/Image/Image.tsx
+++ b/packages/components/src/components/Image/Image.tsx
@@ -12,8 +12,8 @@ export const Image: React.FC<ImageProps> = ({ className = '', src, cfImageAsset,
     return (
       <div className={combineClasses('cf-placeholder-wrapper', className)}>
         <img
-          className={'cf-placeholder-image'}
-          src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAA"
+          className="cf-placeholder-image"
+          src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHdpZHRoPScxJyBoZWlnaHQ9JzEnLz4="
           {...props}
         />
         <svg


### PR DESCRIPTION
## Purpose

This PR aims to solve two issues with images:
- Safari & Firefox showing native missing image indicators on top of our image placeholder
- "Corner radius" property not being reflected in image placeholder when no image is bound / when building a pattern

## Approach

- Replaced existing hard-coded base64 image used in placeholder image with a cross-browser supported base64 string for a 1x1 pixel svg
- Moved placeholder image outline styles to wrapper `div` and applied `overflow: hidden` to ensure the `border-radius` value is visually reflected

## Preview

### Pattern preview with images

#### Safari

| Before | After |
|--------|--------|
| <img width="2718" height="1322" alt="CleanShot 2025-07-29 at 14 20 57@2x" src="https://github.com/user-attachments/assets/c30f6c9d-2e82-4c33-b154-cae2b44fc81c" /> | <img width="2718" height="1322" alt="CleanShot 2025-07-29 at 14 18 31@2x" src="https://github.com/user-attachments/assets/acfec5c8-fbfc-4622-a898-f398c0151313" /> |

#### Firefox

| Before | After |
|--------|--------|
| <img width="2706" height="1460" alt="CleanShot 2025-07-29 at 15 04 46@2x" src="https://github.com/user-attachments/assets/916addaa-a446-4ab2-b4c1-1a6d80789698" /> | <img width="2706" height="1460" alt="CleanShot 2025-07-29 at 15 04 04@2x" src="https://github.com/user-attachments/assets/7937c868-897e-4664-a35e-8a3f442c03be" /> | 

### Editor preview

| Before | After |
|--------|--------|
| <img width="3680" height="1606" alt="CleanShot 2025-07-29 at 14 20 22@2x" src="https://github.com/user-attachments/assets/76c14e9f-57ed-4169-aa66-7959121180ae" /> | <img width="3680" height="1606" alt="CleanShot 2025-07-29 at 14 17 45@2x" src="https://github.com/user-attachments/assets/4473251a-b148-4897-8e1f-7efb812f0b70" /> | 

### Editor experience for updating corner radius

https://github.com/user-attachments/assets/3dd591d3-66df-405a-adae-f6ae930132ac


