### PR TITLE
fix(visual-editor): render cfVisibility in CSS for CSR apps [SPA-2956]

### DIFF
--- a/packages/visual-editor/src/components/EditorBlock/useComponentProps.ts
+++ b/packages/visual-editor/src/components/EditorBlock/useComponentProps.ts
@@ -9,6 +9,7 @@ import {
   isStructureWithRelativeHeight,
   sanitizeNodeProps,
   EntityStoreBase,
+  transformVisibility,
 } from '@contentful/experiences-core';
 import { ASSEMBLY_NODE_TYPE, EMPTY_CONTAINER_SIZE } from '@contentful/experiences-core/constants';
 import type {
@@ -206,7 +207,15 @@ export const useComponentProps = ({
     findNodeById,
   ]);
 
-  const cfStyles = useMemo(() => buildCfStyles(props as StyleProps), [props]);
+  const cfStyles = useMemo(
+    () => ({
+      ...buildCfStyles(props as StyleProps),
+      // The visibility needs to be transformed separately as it requires
+      // a special handling for preview & SSR rendering (not here though).
+      ...transformVisibility(props.cfVisibility),
+    }),
+    [props],
+  );
 
   const shouldRenderEmptySpaceWithMinSize = useMemo(() => {
     if (node.children.length) return false;


### PR DESCRIPTION
## Purpose

As part of #1158, we had to change the way we render `cfVisibility` to not override custom display values for visible nodes.
Due to a faulty merge conflict resolution, the visibility was not rendered at all in editor mode for v3.

## Approach

Turn this prop also in CSS - we have to do it explicitly but at least, it's only one function call.