### PR TITLE
fix: text align validation from left right to start end [SPA-3060]

### DIFF
--- a/packages/core/src/definitions/styles.ts
+++ b/packages/core/src/definitions/styles.ts
@@ -266,7 +266,7 @@ export const optionalBuiltInStyles: Partial<DesignVariableMap> = {
       in: [
         {
           value: 'start',
-          displayName: 'Align left',
+          displayName: 'Align start',
         },
         {
           value: 'center',
@@ -274,7 +274,7 @@ export const optionalBuiltInStyles: Partial<DesignVariableMap> = {
         },
         {
           value: 'end',
-          displayName: 'Align right',
+          displayName: 'Align end',
         },
       ],
     },

--- a/packages/core/src/definitions/styles.ts
+++ b/packages/core/src/definitions/styles.ts
@@ -265,7 +265,7 @@ export const optionalBuiltInStyles: Partial<DesignVariableMap> = {
     validations: {
       in: [
         {
-          value: 'left',
+          value: 'start',
           displayName: 'Align left',
         },
         {
@@ -273,7 +273,7 @@ export const optionalBuiltInStyles: Partial<DesignVariableMap> = {
           displayName: 'Align center',
         },
         {
-          value: 'right',
+          value: 'end',
           displayName: 'Align right',
         },
       ],
@@ -282,7 +282,7 @@ export const optionalBuiltInStyles: Partial<DesignVariableMap> = {
     type: 'Text',
     group: 'style',
     description: 'The text alignment of the element',
-    defaultValue: 'left',
+    defaultValue: 'start',
   },
   cfTextTransform: {
     validations: {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -228,7 +228,7 @@ export type StyleProps = {
   cfLineHeight: string;
   cfLetterSpacing: string;
   cfTextColor: string;
-  cfTextAlign: 'left' | 'center' | 'right';
+  cfTextAlign: 'start' | 'center' | 'end';
   cfTextTransform: 'none' | 'capitalize' | 'uppercase' | 'lowercase';
   cfTextBold: boolean;
   cfTextItalic: boolean;


### PR DESCRIPTION
## Purpose
A customer has reported that the cfTextAlign setting is not compatible with Right to Left languages, as it uses left/right instead of start/end. 

Here is the link to the video:

https://www.loom.com/share/66039cd623e243509754a7f94025b080?sid=fd41560d-6657-4fd5-a123-d397f038ae68 

## Approach

We switched to using logical alignment values (start, center, end) to ensure proper text alignment across different writing systems. Unlike left and right, which are fixed, start and end adapt based on the text direction (ltr or rtl). This allows us to support both left-to-right (e.g., English) and right-to-left (e.g., Arabic) languages with a single consistent alignment system, improving internationalization support without hardcoding language-specific rules.