### PR TITLE
fix: increase handshake timeout for v3 switch [SPA-3058]

### DIFF
--- a/packages/experience-builder-sdk/src/hooks/useDetectCanvasMode.tsx
+++ b/packages/experience-builder-sdk/src/hooks/useDetectCanvasMode.tsx
@@ -77,9 +77,13 @@ export const useDetectCanvasMode = ({ isClientSide = false }: useDetectCanvasMod
         sendMessage(OUTGOING_EVENTS.Connected, undefined);
         sendMessage(OUTGOING_EVENTS.SDKFeatures, sdkFeatures);
 
+        // If in iframe, we wait long to avoid setting preview mode accidentally in editor mode
+        // when switching from v2 to v3
+        const handshakeDelay = inIframe() ? 2000 : 100;
+
         // FIXME: This causes a race condition by setting the mode sometimes to NONE when
         // reloading the canvas due to a save event.
-        const handshakeTimeout = setTimeout(handleHandshakeTimeout, 100);
+        const handshakeTimeout = setTimeout(handleHandshakeTimeout, handshakeDelay);
 
         return () => {
           window.removeEventListener('message', onMessage);


### PR DESCRIPTION
When the iframe is rerendered for v3 in the web app, it remounts the whole thing. For _"some reason"_, the "connected" event coming from the SDK is not getting the response "requestEditorMode" and thereby reaches the handshake timeout that changes the mode to "NONE" and thereby makes the SDK fetch the experience.
This in the end leads to an error with the global entity store not being the editor one.