### PR TITLE
fix: [SPA-3075] send canvas geometry on image load separately

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -558,7 +558,7 @@ type OUTGOING_EVENT_PAYLOADS = {
   };
 };
 
-export type CanvasGeometryUpdateSourceEvent = 'resize' | 'mutation';
+export type CanvasGeometryUpdateSourceEvent = 'resize' | 'mutation' | 'imageLoad';
 
 export type SendMessageParams = <T extends OutgoingEvent>(
   eventType: T,

--- a/packages/visual-editor/src/components/RootRenderer/sendCanvasGeometryUpdatedMessage.ts
+++ b/packages/visual-editor/src/components/RootRenderer/sendCanvasGeometryUpdatedMessage.ts
@@ -20,7 +20,6 @@ export const sendCanvasGeometryUpdatedMessage = async (
   sourceEvent: CanvasGeometryUpdateSourceEvent,
 ) => {
   const nodeToCoordinatesMap: NodeToCoordinatesMap = {};
-  await waitForAllImagesToBeLoaded();
   collectNodeCoordinates(tree.root, nodeToCoordinatesMap);
   sendMessage(OUTGOING_EVENTS.CanvasGeometryUpdated, {
     size: {
@@ -56,28 +55,22 @@ const collectNodeCoordinates = (
   node.children.forEach((child) => collectNodeCoordinates(child, nodeToCoordinatesMap));
 };
 
-const waitForAllImagesToBeLoaded = () => {
-  // If the document contains an image, wait for this image to be loaded before collecting & sending all geometry data.
-  const allImageNodes = document.querySelectorAll('img');
-  return Promise.all(
-    Array.from(allImageNodes).map((imageNode) => {
-      if (imageNode.complete) {
-        return Promise.resolve();
+export function waitForImageToBeLoaded(imageNode: HTMLImageElement) {
+  if (imageNode.complete) {
+    return Promise.resolve();
+  }
+  return new Promise<void>((resolve, reject) => {
+    const handleImageLoad = (event: Event | ErrorEvent) => {
+      imageNode.removeEventListener('load', handleImageLoad);
+      imageNode.removeEventListener('error', handleImageLoad);
+      if (event.type === 'error') {
+        console.warn('Image failed to load:', imageNode);
+        reject();
+      } else {
+        resolve();
       }
-      return new Promise<void>((resolve, reject) => {
-        const handleImageLoad = (event: Event | ErrorEvent) => {
-          imageNode.removeEventListener('load', handleImageLoad);
-          imageNode.removeEventListener('error', handleImageLoad);
-          if (event.type === 'error') {
-            console.warn('Image failed to load:', imageNode);
-            reject();
-          } else {
-            resolve();
-          }
-        };
-        imageNode.addEventListener('load', handleImageLoad);
-        imageNode.addEventListener('error', handleImageLoad);
-      });
-    }),
-  );
-};
+    };
+    imageNode.addEventListener('load', handleImageLoad);
+    imageNode.addEventListener('error', handleImageLoad);
+  });
+}

--- a/packages/visual-editor/src/components/RootRenderer/useCanvasGeometryUpdates.ts
+++ b/packages/visual-editor/src/components/RootRenderer/useCanvasGeometryUpdates.ts
@@ -1,6 +1,9 @@
 import { debounce } from 'lodash-es';
-import { useEffect, useMemo, useRef } from 'react';
-import { sendCanvasGeometryUpdatedMessage } from './sendCanvasGeometryUpdatedMessage';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import {
+  waitForImageToBeLoaded,
+  sendCanvasGeometryUpdatedMessage,
+} from './sendCanvasGeometryUpdatedMessage';
 import {
   CanvasGeometryUpdateSourceEvent,
   ExperienceTree,
@@ -44,6 +47,18 @@ export const useCanvasGeometryUpdates = ({ tree }: UseCanvasGeometryUpdatesParam
     [],
   );
 
+  const debouncedCollectImages = useMemo(
+    () =>
+      debounce(
+        () => {
+          return Array.from(document.querySelectorAll('img'));
+        },
+        300,
+        { leading: true, trailing: true },
+      ),
+    [],
+  );
+
   // Store tree in a ref to avoid the need to deactivate & reactivate the mutation observer
   // when the tree changes. This is important to avoid missing out on some mutation events.
   const treeRef = useRef<ExperienceTree>(tree);
@@ -58,11 +73,21 @@ export const useCanvasGeometryUpdates = ({ tree }: UseCanvasGeometryUpdatesParam
     return () => window.removeEventListener('resize', resizeEventListener);
   }, [debouncedUpdateGeometry]);
 
+  const [{ allImages, loadedImages }, setImages] = useState(() => {
+    const allImages = debouncedCollectImages();
+    const loadedImages = new WeakSet<HTMLImageElement>();
+    return { allImages, loadedImages };
+  });
+
   // Handling DOM mutations
   useEffect(() => {
-    const observer = new MutationObserver(() =>
-      debouncedUpdateGeometry(treeRef.current, 'mutation'),
-    );
+    const observer = new MutationObserver(() => {
+      debouncedUpdateGeometry(treeRef.current, 'mutation');
+
+      // find all images on any DOM change
+      const allImages = debouncedCollectImages();
+      setImages((prevState) => ({ ...prevState, allImages }));
+    });
     // send initial geometry in case the tree is empty
     debouncedUpdateGeometry(treeRef.current, 'mutation');
     observer.observe(document.documentElement, {
@@ -71,5 +96,27 @@ export const useCanvasGeometryUpdates = ({ tree }: UseCanvasGeometryUpdatesParam
       attributes: true,
     });
     return () => observer.disconnect();
-  }, [debouncedUpdateGeometry]);
+  }, [debouncedCollectImages, debouncedUpdateGeometry]);
+
+  // Handling image loading separately,
+  // as each image can load at a different time, some might be hidden or lazy loaded
+  useEffect(() => {
+    let isCurrent = true;
+
+    allImages.forEach(async (imageNode) => {
+      if (loadedImages.has(imageNode)) {
+        return;
+      }
+      // update the geometry after each image is loaded, as it can shift the layout
+      await waitForImageToBeLoaded(imageNode);
+      if (isCurrent) {
+        loadedImages.add(imageNode);
+        debouncedUpdateGeometry(treeRef.current, 'imageLoad');
+      }
+    });
+
+    return () => {
+      isCurrent = false;
+    };
+  }, [allImages, loadedImages, debouncedUpdateGeometry]);
 };


### PR DESCRIPTION
## Purpose

Don't wait for all images to be loaded before sending the canvas geometry, as some images might be never loaded due to lazy loading.

## Approach

1. Keep sending canvas geometry on dom mutation, but without waiting for images
2. Collect all images on dom mutation, as new images can be added asynchronously
3. Wait for each image to be loaded separately to send a new geometry update, as they can shift the layout

## Testing

1. To validate the idea that lazy images prevent sending geometry update I added a lazy image that is not visible
2. Removing the promise that waits for all images makes it send the geometry correctly
3. After the lazy image is loaded (e.g. it's scrolled into view), the handler for this message correctly updates the geometry
