### PR TITLE
feat: [] prepare SDK to delegate pan to the canvas

### DIFF
--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -26,6 +26,7 @@ export const OUTGOING_EVENTS = {
   SDKFeatures: 'sdkFeatures',
   RequestEntities: 'REQUEST_ENTITIES',
   CanvasGeometryUpdated: 'canvasGeometryUpdated',
+  CanvasPan: 'canvasPan',
 } as const;
 
 export const INCOMING_EVENTS = {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -556,6 +556,14 @@ type OUTGOING_EVENT_PAYLOADS = {
     nodes: Record<string, { coordinates: Pick<DOMRect, 'x' | 'y' | 'width' | 'height'> }>;
     sourceEvent: CanvasGeometryUpdateSourceEvent;
   };
+  canvasPan: {
+    ctrlKey: boolean;
+    metaKey: boolean;
+    clientX: number;
+    clientY: number;
+    deltaX: number;
+    deltaY: number;
+  };
 };
 
 export type CanvasGeometryUpdateSourceEvent = 'resize' | 'mutation' | 'imageLoad';

--- a/packages/visual-editor/src/components/RootRenderer/useCanvasGeometryUpdates.ts
+++ b/packages/visual-editor/src/components/RootRenderer/useCanvasGeometryUpdates.ts
@@ -8,6 +8,8 @@ import {
   CanvasGeometryUpdateSourceEvent,
   ExperienceTree,
 } from '@contentful/experiences-core/types';
+import { sendMessage } from '@contentful/experiences-core';
+import { OUTGOING_EVENTS } from '@contentful/experiences-core/constants';
 
 /*
  * Scenarios to consider:
@@ -119,4 +121,21 @@ export const useCanvasGeometryUpdates = ({ tree }: UseCanvasGeometryUpdatesParam
       isCurrent = false;
     };
   }, [allImages, loadedImages, debouncedUpdateGeometry]);
+
+  // Delegate scrolling to the canvas
+  useEffect(() => {
+    const onWheel = (e: WheelEvent) => {
+      e.preventDefault();
+      sendMessage(OUTGOING_EVENTS.CanvasPan, {
+        ctrlKey: e.ctrlKey,
+        metaKey: e.metaKey,
+        clientX: e.clientX,
+        clientY: e.clientY,
+        deltaX: e.deltaX,
+        deltaY: e.deltaY,
+      });
+    };
+    document.addEventListener('wheel', onWheel, { passive: false });
+    return () => document.removeEventListener('wheel', onWheel);
+  }, []);
 };


### PR DESCRIPTION
## Purpose

If the interaction layer of canvas is disabled, the iframe intercepts the wheel event, on which web app relies on to handle pan and zoom.

## Approach

Send the data from wheel event back to the web app so it can handle pan and zoom properly.
