### PR TITLE
feat: allow mobile-first breakpoint definitions [SPA-3041]

### DIFF
--- a/packages/core/src/__fixtures__/breakpoints.ts
+++ b/packages/core/src/__fixtures__/breakpoints.ts
@@ -1,6 +1,15 @@
 import { Breakpoint } from '@/types';
 
-export const createBreakpoints = (): Breakpoint[] => [
+export const createBreakpoints = (
+  strategy: 'desktop-first' | 'mobile-first' = 'desktop-first',
+): Breakpoint[] => {
+  if (strategy === 'desktop-first') {
+    return createDesktopFirstBreakpoints();
+  }
+  return createMobileFirstBreakpoints();
+};
+
+export const createDesktopFirstBreakpoints = (): Breakpoint[] => [
   {
     id: 'desktop',
     query: '*',
@@ -18,5 +27,26 @@ export const createBreakpoints = (): Breakpoint[] => [
     query: '<576px',
     displayName: 'Mobile',
     previewSize: '390px',
+  },
+];
+
+export const createMobileFirstBreakpoints = (): Breakpoint[] => [
+  {
+    id: 'mobile',
+    query: '*',
+    displayName: 'All sizes',
+    previewSize: '390px',
+  },
+  {
+    id: 'tablet',
+    query: '>576px',
+    displayName: 'Tablet',
+    previewSize: '820px',
+  },
+  {
+    id: 'desktop',
+    query: '>992px',
+    displayName: 'Desktop',
+    previewSize: '993px',
   },
 ];

--- a/packages/core/src/registries/breakpointsRegistry.spec.ts
+++ b/packages/core/src/registries/breakpointsRegistry.spec.ts
@@ -45,22 +45,23 @@ describe('runBreakpointsValidation', () => {
         previewSize: '100%',
       },
       {
+        id: 'test-mobile',
+        query: '<576px',
+        displayName: 'Mobile',
+        previewSize: '390px',
+      },
+      {
         id: 'test-tablet',
         query: '<982px',
         displayName: 'Tablet',
         previewSize: '820px',
       },
-      {
-        id: 'test-mobile',
-        query: '<1000px',
-        displayName: 'Mobile',
-        previewSize: '390px',
-      },
     ]);
 
     const errors = [
       {
-        details: 'Breakpoints should be ordered from largest to smallest pixel value',
+        details:
+          'When using a desktop-first strategy, all breakpoints must have strictly decreasing pixel values',
         name: 'custom',
         path: [],
       },
@@ -71,7 +72,7 @@ describe('runBreakpointsValidation', () => {
     expect(() => registry.runBreakpointsValidation()).toThrow(error);
   });
 
-  it('does not throw an error if no breakpoint definition is invalid', () => {
+  it('does not throw an error when providing valid desktop-first breakpoint definitions', () => {
     registry.defineBreakpoints([
       {
         id: 'test-desktop',
@@ -90,6 +91,31 @@ describe('runBreakpointsValidation', () => {
         query: '<576px',
         displayName: 'Mobile',
         previewSize: '390px',
+      },
+    ]);
+
+    expect(() => registry.runBreakpointsValidation()).not.toThrow();
+  });
+
+  it('does not throw an error when providing valid mobile-first breakpoint definitions', () => {
+    registry.defineBreakpoints([
+      {
+        id: 'test-mobile',
+        query: '*',
+        displayName: 'Mobile',
+        previewSize: '390px',
+      },
+      {
+        id: 'test-tablet',
+        query: '>576px',
+        displayName: 'Tablet',
+        previewSize: '820px',
+      },
+      {
+        id: 'test-desktop',
+        query: '>982px',
+        displayName: 'All Sizes',
+        previewSize: '100%',
       },
     ]);
 

--- a/packages/core/src/utils/breakpoints.spec.ts
+++ b/packages/core/src/utils/breakpoints.spec.ts
@@ -1,6 +1,11 @@
 import { createBreakpoints } from '@/__fixtures__/breakpoints';
 import { designTokensFixture } from '@/__fixtures__/designTokens';
-import { getActiveBreakpointIndex, getValueForBreakpoint, mediaQueryMatcher } from './breakpoints';
+import {
+  detectBreakpointStrategy,
+  getActiveBreakpointIndex,
+  getValueForBreakpoint,
+  mediaQueryMatcher,
+} from './breakpoints';
 import { describe, it, expect } from 'vitest';
 import { defineDesignTokens } from '../registries';
 
@@ -335,5 +340,25 @@ describe('mediaQueryMatcher', () => {
     expect(matchers[0].signal.matches).toBe(false);
     expect(matchers[1].signal.matches).toBe(false);
     expect(initialMatches).toEqual({ tablet: false, mobile: false });
+  });
+});
+
+describe('detectBreakpointStrategy', () => {
+  it('should return the correct strategy for desktop-first breakpoints', () => {
+    const breakpoints = createBreakpoints('desktop-first');
+    const strategy = detectBreakpointStrategy(breakpoints);
+    expect(strategy).toEqual('desktop-first');
+  });
+
+  it('should return the correct strategy for mobile-first breakpoints', () => {
+    const breakpoints = createBreakpoints('mobile-first');
+    const strategy = detectBreakpointStrategy(breakpoints);
+    expect(strategy).toEqual('mobile-first');
+  });
+
+  it('should return no strategy when there is only one wildcard breakpoint', () => {
+    const breakpoints = createBreakpoints('desktop-first').slice(0, 1);
+    const strategy = detectBreakpointStrategy(breakpoints);
+    expect(strategy).toEqual(undefined);
   });
 });

--- a/packages/core/src/utils/breakpoints.spec.ts
+++ b/packages/core/src/utils/breakpoints.spec.ts
@@ -1,7 +1,7 @@
 import { createBreakpoints } from '@/__fixtures__/breakpoints';
 import { designTokensFixture } from '@/__fixtures__/designTokens';
 import {
-  detectBreakpointStrategy,
+  detectBreakpointsStrategy,
   getActiveBreakpointIndex,
   getValueForBreakpoint,
   mediaQueryMatcher,
@@ -343,22 +343,22 @@ describe('mediaQueryMatcher', () => {
   });
 });
 
-describe('detectBreakpointStrategy', () => {
+describe('detectBreakpointsStrategy', () => {
   it('should return the correct strategy for desktop-first breakpoints', () => {
     const breakpoints = createBreakpoints('desktop-first');
-    const strategy = detectBreakpointStrategy(breakpoints);
+    const strategy = detectBreakpointsStrategy(breakpoints);
     expect(strategy).toEqual('desktop-first');
   });
 
   it('should return the correct strategy for mobile-first breakpoints', () => {
     const breakpoints = createBreakpoints('mobile-first');
-    const strategy = detectBreakpointStrategy(breakpoints);
+    const strategy = detectBreakpointsStrategy(breakpoints);
     expect(strategy).toEqual('mobile-first');
   });
 
   it('should return no strategy when there is only one wildcard breakpoint', () => {
     const breakpoints = createBreakpoints('desktop-first').slice(0, 1);
-    const strategy = detectBreakpointStrategy(breakpoints);
+    const strategy = detectBreakpointsStrategy(breakpoints);
     expect(strategy).toEqual(undefined);
   });
 });

--- a/packages/core/src/utils/breakpoints.ts
+++ b/packages/core/src/utils/breakpoints.ts
@@ -180,11 +180,11 @@ export function mergeDesignValuesByBreakpoint(
   };
 }
 
-export const BREAKPOINT_STRATEGY_DESKTOP_FIRST = 'desktop-first';
-export const BREAKPOINT_STRATEGY_MOBILE_FIRST = 'mobile-first';
-export type BreakpointStrategy =
-  | typeof BREAKPOINT_STRATEGY_DESKTOP_FIRST
-  | typeof BREAKPOINT_STRATEGY_MOBILE_FIRST
+export const BREAKPOINTS_STRATEGY_DESKTOP_FIRST = 'desktop-first';
+export const BREAKPOINTS_STRATEGY_MOBILE_FIRST = 'mobile-first';
+export type BreakpointsStrategy =
+  | typeof BREAKPOINTS_STRATEGY_DESKTOP_FIRST
+  | typeof BREAKPOINTS_STRATEGY_MOBILE_FIRST
   | undefined;
 
 /**
@@ -193,19 +193,19 @@ export type BreakpointStrategy =
  * @param breakpoints The array of breakpoints to analyze.
  * @returns The detected breakpoint strategy or undefined if not determinable.
  */
-export const detectBreakpointStrategy = (breakpoints: Breakpoint[]): BreakpointStrategy => {
+export const detectBreakpointsStrategy = (breakpoints: Breakpoint[]): BreakpointsStrategy => {
   if (breakpoints.length < 2) {
     return undefined;
   }
 
   const hasMobileFirst = breakpoints.slice(1).every((bp) => bp.query.startsWith('>'));
   if (hasMobileFirst) {
-    return BREAKPOINT_STRATEGY_MOBILE_FIRST;
+    return BREAKPOINTS_STRATEGY_MOBILE_FIRST;
   }
 
   const hasDesktopFirst = breakpoints.slice(1).every((bp) => bp.query.startsWith('<'));
   if (hasDesktopFirst) {
-    return BREAKPOINT_STRATEGY_DESKTOP_FIRST;
+    return BREAKPOINTS_STRATEGY_DESKTOP_FIRST;
   }
 
   return undefined;

--- a/packages/core/src/utils/breakpoints.ts
+++ b/packages/core/src/utils/breakpoints.ts
@@ -23,7 +23,7 @@ const findLast = <T>(
   array: Array<T>,
   predicate: Parameters<Array<T>['find']>[0],
 ): T | undefined => {
-  return array.reverse().find(predicate);
+  return [...array].reverse().find(predicate);
 };
 
 // Initialise media query matchers. This won't include the always matching fallback breakpoint.

--- a/packages/validators/src/schemas/v2023_09_28/common.ts
+++ b/packages/validators/src/schemas/v2023_09_28/common.ts
@@ -83,8 +83,8 @@ export const breakpointsRefinement = (value: Breakpoint[], ctx: z.RefinementCtx)
   }
 
   // Return early if there's only one generic breakpoint
-  const hasNoBreakpointStrategy = value.length === 1;
-  if (hasNoBreakpointStrategy) {
+  const hasNoBreakpointsStrategy = value.length === 1;
+  if (hasNoBreakpointsStrategy) {
     return;
   }
 

--- a/packages/validators/src/schemas/v2023_09_28/common.ts
+++ b/packages/validators/src/schemas/v2023_09_28/common.ts
@@ -79,6 +79,7 @@ export const breakpointsRefinement = (value: Breakpoint[], ctx: z.RefinementCtx)
       code: z.ZodIssueCode.custom,
       message: `The first breakpoint should include the following attributes: { "query": "*" }`,
     });
+    return;
   }
 
   // Return early if there's only one generic breakpoint
@@ -95,6 +96,7 @@ export const breakpointsRefinement = (value: Breakpoint[], ctx: z.RefinementCtx)
       code: z.ZodIssueCode.custom,
       message: `Breakpoint IDs must be unique`,
     });
+    return;
   }
 
   // Skip the first one which is guaranteed to be a wildcard query

--- a/packages/validators/src/schemas/v2023_09_28/common.ts
+++ b/packages/validators/src/schemas/v2023_09_28/common.ts
@@ -81,12 +81,15 @@ export const breakpointsRefinement = (value: Breakpoint[], ctx: z.RefinementCtx)
     });
   }
 
-  const hasDuplicateIds = value.some((currentBreakpoint, currentBreakpointIndex) => {
-    // check if the current breakpoint id is found in the rest of the array
-    const breakpointIndex = value.findIndex((breakpoint) => breakpoint.id === currentBreakpoint.id);
-    return breakpointIndex !== currentBreakpointIndex;
-  });
+  // Return early if there's only one generic breakpoint
+  const hasNoBreakpointStrategy = value.length === 1;
+  if (hasNoBreakpointStrategy) {
+    return;
+  }
 
+  // Check if any breakpoint id occurs twice
+  const ids = value.map((breakpoint) => breakpoint.id);
+  const hasDuplicateIds = new Set(ids).size !== ids.length;
   if (hasDuplicateIds) {
     ctx.addIssue({
       code: z.ZodIssueCode.custom,
@@ -94,27 +97,59 @@ export const breakpointsRefinement = (value: Breakpoint[], ctx: z.RefinementCtx)
     });
   }
 
-  // Extract the queries boundary by removing the special characters around it
-  const queries = value.map((bp) =>
-    bp.query === '*' ? bp.query : parseInt(bp.query.replace(/px|<|>/, '')),
-  );
+  // Skip the first one which is guaranteed to be a wildcard query
+  const nonBaseBreakpoints = value.slice(1);
+  const isMobileFirstStrategy = nonBaseBreakpoints[0].query.startsWith('>');
+  const isDesktopFirstStrategy = nonBaseBreakpoints[0].query.startsWith('<');
 
-  // sort updates queries array in place so we need to create a copy
-  const originalQueries = [...queries];
-  queries.sort((q1, q2) => {
-    if (q1 === '*') {
-      return -1;
+  if (isMobileFirstStrategy) {
+    const areOperatorsEqual = nonBaseBreakpoints.every(({ query }) => query.startsWith('>'));
+    if (!areOperatorsEqual) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `Breakpoint queries must be in the format ">[size]px" for mobile-first strategy`,
+      });
     }
-    if (q2 === '*') {
-      return 1;
-    }
-    return q1 > q2 ? -1 : 1;
-  });
 
-  if (originalQueries.join('') !== queries.join('')) {
+    // Extract the queries boundary by removing the special characters around it
+    const queries = nonBaseBreakpoints.map((bp) => parseInt(bp.query.replace(/px|<|>/, '')));
+
+    // Starting with the third breakpoint, check that every query is higher than the one above
+    const isIncreasing = queries.every(
+      (value, index, array) => index === 0 || value > array[index - 1],
+    );
+    if (!isIncreasing) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `When using a mobile-first strategy, all breakpoints must have strictly increasing pixel values`,
+      });
+    }
+  } else if (isDesktopFirstStrategy) {
+    const areOperatorsEqual = nonBaseBreakpoints.every(({ query }) => query.startsWith('<'));
+    if (!areOperatorsEqual) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `Breakpoint queries must be in the format "<[size]px" for desktop-first strategy`,
+      });
+    }
+
+    // Extract the queries boundary by removing the special characters around it
+    const queries = nonBaseBreakpoints.map((bp) => parseInt(bp.query.replace(/px|<|>/, '')));
+
+    // Starting with the third breakpoint, check that every query is lower than the one above
+    const isDecreasing = queries.every(
+      (value, index, array) => index === 0 || value < array[index - 1],
+    );
+    if (!isDecreasing) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `When using a desktop-first strategy, all breakpoints must have strictly decreasing pixel values`,
+      });
+    }
+  } else if (!isMobileFirstStrategy && !isDesktopFirstStrategy) {
     ctx.addIssue({
       code: z.ZodIssueCode.custom,
-      message: `Breakpoints should be ordered from largest to smallest pixel value`,
+      message: `You may only use a mobile-first or desktop-first strategy for breakpoints using '<' or '>' queries`,
     });
   }
 };
@@ -187,7 +222,7 @@ export const ParametersSchema = z.record(propertyKeySchema, ParameterSchema);
 export const BreakpointSchema = z
   .object({
     id: propertyKeySchema,
-    query: z.string().regex(/^\*$|^<[0-9*]+px$/),
+    query: z.string().regex(/^\*$|^[<>][0-9*]+px$/),
     previewSize: z.string(),
     displayName: z.string(),
     displayIcon: z.enum(['desktop', 'tablet', 'mobile']).optional(),

--- a/packages/validators/src/validators/tests/componentTree.spec.ts
+++ b/packages/validators/src/validators/tests/componentTree.spec.ts
@@ -123,11 +123,6 @@ describe('componentTree', () => {
           name: 'custom',
           path: ['componentTree', 'en-US', 'breakpoints'],
         },
-        {
-          details: 'Breakpoints should be ordered from largest to smallest pixel value',
-          name: 'custom',
-          path: ['componentTree', 'en-US', 'breakpoints'],
-        },
       ];
       expect(result.success).toBe(false);
       expect(result.errors).toEqual(expectedErrors);
@@ -155,7 +150,33 @@ describe('componentTree', () => {
       expect(result.success).toBe(false);
       expect(error?.name).toBe('custom');
       expect(error?.details).toBe(
-        'Breakpoints should be ordered from largest to smallest pixel value',
+        'When using a desktop-first strategy, all breakpoints must have strictly decreasing pixel values',
+      );
+    });
+
+    it(`fails if breakpoints are not ordered from smallest to largest`, () => {
+      const breakpoints = [
+        { id: 'mobile', query: '*', previewSize: 'small', displayName: 'Mobile' },
+        { id: 'desktop', query: '>1024px', previewSize: 'large', displayName: 'Desktop' },
+        { id: 'tablet', query: '>768px', previewSize: 'medium', displayName: 'Tablet' },
+      ];
+      const componentTree = experience.fields.componentTree[locale];
+      const updatedExperience = {
+        ...experience,
+        fields: {
+          ...experience.fields,
+          componentTree: { [locale]: { ...componentTree, breakpoints } },
+        },
+      };
+      const result = validateExperienceFields(updatedExperience, schemaVersion);
+
+      expect(result.success).toBe(false);
+      const error = result.errors?.[0];
+
+      expect(result.success).toBe(false);
+      expect(error?.name).toBe('custom');
+      expect(error?.details).toBe(
+        'When using a mobile-first strategy, all breakpoints must have strictly increasing pixel values',
       );
     });
 

--- a/packages/validators/src/validators/tests/validateBreakpointDefinitions.spec.ts
+++ b/packages/validators/src/validators/tests/validateBreakpointDefinitions.spec.ts
@@ -2,27 +2,6 @@ import { describe, it, expect } from 'vitest';
 import { validateBreakpointsDefinition } from '../validateBreakpointDefinitions';
 
 describe(validateBreakpointsDefinition, () => {
-  it('should validate that query is "<" px value', () => {
-    const breakpoints = [
-      {
-        id: 'test-desktop',
-        query: '*',
-        displayName: 'All Sizes',
-        previewSize: '100%',
-      },
-      {
-        id: 'test-tablet',
-        query: '>982px',
-        displayName: 'Tablet',
-        previewSize: '820px',
-      },
-    ];
-    const result = validateBreakpointsDefinition(breakpoints);
-
-    expect(result.success).toBe(false);
-    expect(result.errors).toBeDefined();
-  });
-
   it('should validate that first breakpoint has a wild card query', () => {
     const breakpoints = [
       {
@@ -79,38 +58,6 @@ describe(validateBreakpointsDefinition, () => {
     expect(error?.details).toBe('Breakpoint IDs must be unique');
   });
 
-  it('should validate that breakpoint queries are ordered from largest to smallest', () => {
-    const breakpoints = [
-      {
-        id: 'test-desktop',
-        query: '*',
-        displayName: 'All Sizes',
-        previewSize: '100%',
-      },
-      {
-        id: 'test-tablet',
-        query: '<982px',
-        displayName: 'Tablet',
-        previewSize: '820px',
-      },
-      {
-        id: 'test-mobile',
-        query: '<1000px',
-        displayName: 'Tablet',
-        previewSize: '820px',
-      },
-    ];
-    const result = validateBreakpointsDefinition(breakpoints);
-
-    expect(result.success).toBe(false);
-    expect(result.errors).toBeDefined();
-    const error = result.errors?.[0];
-
-    expect(error?.details).toBe(
-      'Breakpoints should be ordered from largest to smallest pixel value',
-    );
-  });
-
   it('should validate that fields in breakpoint object', () => {
     const breakpoints = [
       {
@@ -136,5 +83,185 @@ describe(validateBreakpointsDefinition, () => {
     const error = result.errors?.[0];
 
     expect(error?.details).toBe('The property "wrongFieldAdded" is not expected');
+  });
+
+  it('only allows the first breakpoint to use a wildcard query', () => {
+    const breakpoints = [
+      {
+        id: 'test-mobile',
+        query: '*',
+        displayName: 'Mobile',
+        previewSize: '375px',
+      },
+      {
+        id: 'test-tablet',
+        query: '*',
+        displayName: 'Tablet',
+        previewSize: '820px',
+      },
+    ];
+    const result = validateBreakpointsDefinition(breakpoints);
+
+    expect(result.success).toBe(false);
+    expect(result.errors).toBeDefined();
+    const error = result.errors?.[0];
+
+    expect(error?.details).toBe(
+      "You may only use a mobile-first or desktop-first strategy for breakpoints using '<' or '>' queries",
+    );
+  });
+
+  describe('when using a mobile-first strategy', () => {
+    const mobileBreakpoint = {
+      id: 'test-mobile',
+      query: '*',
+      displayName: 'Mobile',
+      previewSize: '375px',
+    };
+
+    const tabletBreakpoint = {
+      id: 'test-tablet',
+      query: '>768px',
+      displayName: 'Tablet',
+      previewSize: '820px',
+    };
+
+    const desktopBreakpoint = {
+      id: 'test-desktop',
+      query: '>1024px',
+      displayName: 'Desktop',
+      previewSize: '1280px',
+    };
+
+    it('should accept that all breakpoints have a ">" query after the first one', () => {
+      const breakpoints = [mobileBreakpoint, tabletBreakpoint, desktopBreakpoint];
+      const result = validateBreakpointsDefinition(breakpoints);
+
+      expect(result.success).toBe(true);
+    });
+
+    it('should deny breakpoints with "<" query', () => {
+      const breakpoints = [
+        mobileBreakpoint,
+        tabletBreakpoint,
+        { ...desktopBreakpoint, query: '<1024px' },
+      ];
+      const result = validateBreakpointsDefinition(breakpoints);
+
+      expect(result.success).toBe(false);
+      expect(result.errors).toBeDefined();
+      const error = result.errors?.[0];
+
+      expect(error?.details).toBe(
+        'Breakpoint queries must be in the format ">[size]px" for mobile-first strategy',
+      );
+    });
+
+    it('only allows the first breakpoint to use a wildcard query', () => {
+      const breakpoints = [
+        mobileBreakpoint,
+        tabletBreakpoint,
+        { ...desktopBreakpoint, query: '*' },
+      ];
+      const result = validateBreakpointsDefinition(breakpoints);
+
+      expect(result.success).toBe(false);
+      expect(result.errors).toBeDefined();
+      const error = result.errors?.[0];
+
+      expect(error?.details).toBe(
+        'Breakpoint queries must be in the format ">[size]px" for mobile-first strategy',
+      );
+    });
+
+    it('should deny breakpoint queries not being ordered from smallest to largest', () => {
+      const breakpoints = [mobileBreakpoint, desktopBreakpoint, tabletBreakpoint];
+      const result = validateBreakpointsDefinition(breakpoints);
+
+      expect(result.success).toBe(false);
+      expect(result.errors).toBeDefined();
+      const error = result.errors?.[0];
+
+      expect(error?.details).toBe(
+        'When using a mobile-first strategy, all breakpoints must have strictly increasing pixel values',
+      );
+    });
+  });
+
+  describe('when using a desktop-first strategy', () => {
+    const desktopBreakpoint = {
+      id: 'test-desktop',
+      query: '*',
+      displayName: 'Desktop',
+      previewSize: '1280px',
+    };
+
+    const tabletBreakpoint = {
+      id: 'test-tablet',
+      query: '<1024px',
+      displayName: 'Tablet',
+      previewSize: '820px',
+    };
+
+    const mobileBreakpoint = {
+      id: 'test-mobile',
+      query: '<768px',
+      displayName: 'Mobile',
+      previewSize: '375px',
+    };
+
+    it('should accept that all breakpoints have a "<" query after the first one', () => {
+      const breakpoints = [desktopBreakpoint, tabletBreakpoint, mobileBreakpoint];
+      const result = validateBreakpointsDefinition(breakpoints);
+
+      expect(result.success).toBe(true);
+    });
+
+    it('should deny breakpoints with ">" query', () => {
+      const breakpoints = [
+        desktopBreakpoint,
+        tabletBreakpoint,
+        { ...mobileBreakpoint, query: '>1024px' },
+      ];
+      const result = validateBreakpointsDefinition(breakpoints);
+
+      expect(result.success).toBe(false);
+      expect(result.errors).toBeDefined();
+      const error = result.errors?.[0];
+
+      expect(error?.details).toBe(
+        'Breakpoint queries must be in the format "<[size]px" for desktop-first strategy',
+      );
+    });
+
+    it('only allows the first breakpoint to use a wildcard query', () => {
+      const breakpoints = [
+        desktopBreakpoint,
+        tabletBreakpoint,
+        { ...mobileBreakpoint, query: '*' },
+      ];
+      const result = validateBreakpointsDefinition(breakpoints);
+
+      expect(result.success).toBe(false);
+      expect(result.errors).toBeDefined();
+      const error = result.errors?.[0];
+
+      expect(error?.details).toBe(
+        'Breakpoint queries must be in the format "<[size]px" for desktop-first strategy',
+      );
+    });
+
+    it('should deny breakpoint queries not being ordered from largest to smallest', () => {
+      const breakpoints = [desktopBreakpoint, mobileBreakpoint, tabletBreakpoint];
+      const result = validateBreakpointsDefinition(breakpoints);
+
+      expect(result.success).toBe(false);
+      expect(result.errors).toBeDefined();
+      const error = result.errors?.[0];
+
+      expect(error?.details).toBe(
+        'When using a desktop-first strategy, all breakpoints must have strictly decreasing pixel values',
+      );
+    });
   });
 });


### PR DESCRIPTION
## Purpose

To enable our customers build mobile-first websites, the validation is updated to allow using a "mobile-first" strategy, meaning that you can define a list of breakpoint definitions with strictly increasing queries.

Example
```
defineBreakpoints([
  {
    id: 'test-mobile',
    query: '*',
    displayName: 'All Sizes',
    displayIcon: 'mobile',
    previewSize: '350px',
  },
  {
    id: 'test-tablet',
    query: '>576px',
    displayName: 'Tablet',
    displayIcon: 'tablet',
    previewSize: '820px',
  },
  {
    id: 'test-desktop',
    query: '>982px',
    displayName: 'Desktop',
    displayIcon: 'desktop',
    previewSize: '1080px',
  },
  {
    id: 'test-large-screen',
    query: '>1200px',
    displayName: 'Large Screen',
    displayIcon: 'desktop',
    previewSize: '100%',
  },
]);
```


https://github.com/user-attachments/assets/db00ac2b-c750-43fa-b6b5-ca0815bf2435

