### PR TITLE
fix: remove NoValue to detect bound instance variables, and rely on `allowedVariableOverrides` instead

### DIFF
--- a/packages/create-studio-experiences/package.json
+++ b/packages/create-studio-experiences/package.json
@@ -39,7 +39,6 @@
     "build": "tsc",
     "lint": "eslint src --ext '.ts,.tsx,.js,.jsx' --max-warnings 0 --ignore-path ../../.eslintignore",
     "lint:fix": "eslint src --ext '.ts,.tsx,.js,.jsx' --fix",
-    "test": "echo \"Error: no test specified\" && exit 1",
     "depcruise": "depcruise src",
     "create-studio-experiences": "node dist/index.js"
   },

--- a/packages/experience-builder-sdk/src/core/preview/assemblyUtils.ts
+++ b/packages/experience-builder-sdk/src/core/preview/assemblyUtils.ts
@@ -39,7 +39,6 @@ export const deserializePatternNode = ({
         componentSettings,
         componentValueKey,
         parameters: parameters,
-        variable: instanceProperty,
       });
       const path = resolvePrebindingPath({
         componentSettings,

--- a/packages/experience-builder-sdk/src/core/preview/assemblyUtils.ts
+++ b/packages/experience-builder-sdk/src/core/preview/assemblyUtils.ts
@@ -62,7 +62,11 @@ export const deserializePatternNode = ({
           key: instanceProperty.key,
         };
       } else if (instanceProperty?.type === 'NoValue') {
-        variables[variableName] = instanceProperty;
+        throw new Error(
+          `Unexpected NoValue for variable "${variableName}" when deserializing pattern "${node.definitionId}". ` +
+            `This can only happen if you created experience in pre-release version of prebinding and experience contains NoValue properties. ` +
+            `Resave experience to fix this issue.`,
+        );
       } else if (instanceProperty?.type === 'BoundValue') {
         variables[variableName] = {
           type: 'BoundValue',

--- a/packages/experience-builder-sdk/src/utils/prebindingUtils.ts
+++ b/packages/experience-builder-sdk/src/utils/prebindingUtils.ts
@@ -1,10 +1,6 @@
 import { type EntityStore, isLink } from '@contentful/experiences-core';
 import { SIDELOADED_PREFIX } from '@contentful/experiences-core/constants';
-import {
-  ComponentPropertyValue,
-  ExperienceComponentSettings,
-  Parameter,
-} from '@contentful/experiences-validators';
+import { ExperienceComponentSettings, Parameter } from '@contentful/experiences-validators';
 
 export const shouldUsePrebinding = ({
   componentValueKey,
@@ -14,7 +10,6 @@ export const shouldUsePrebinding = ({
   componentValueKey: string;
   componentSettings: ExperienceComponentSettings;
   parameters: Record<string, Parameter>;
-  variable: ComponentPropertyValue;
 }) => {
   const { prebindingDefinitions } = componentSettings;
   const { parameterDefinitions, variableMappings, allowedVariableOverrides } =

--- a/packages/experience-builder-sdk/src/utils/prebindingUtils.ts
+++ b/packages/experience-builder-sdk/src/utils/prebindingUtils.ts
@@ -10,7 +10,6 @@ export const shouldUsePrebinding = ({
   componentValueKey,
   componentSettings,
   parameters,
-  variable,
 }: {
   componentValueKey: string;
   componentSettings: ExperienceComponentSettings;
@@ -18,16 +17,25 @@ export const shouldUsePrebinding = ({
   variable: ComponentPropertyValue;
 }) => {
   const { prebindingDefinitions } = componentSettings;
-  const { parameterDefinitions, variableMappings } = prebindingDefinitions?.[0] || {};
+  const { parameterDefinitions, variableMappings, allowedVariableOverrides } =
+    prebindingDefinitions?.[0] || {};
 
   const variableMapping = variableMappings?.[componentValueKey];
 
   const parameterDefinition = parameterDefinitions?.[variableMapping?.parameterId || ''];
   const parameter = parameters?.[variableMapping?.parameterId || ''];
 
-  const isValidForPrebinding = !!parameterDefinition && !!parameter && !!variableMapping;
+  const isValidForPrebinding =
+    !!parameterDefinition &&
+    !!parameter &&
+    !!variableMapping &&
+    !!allowedVariableOverrides &&
+    Array.isArray(allowedVariableOverrides);
 
-  return isValidForPrebinding && variable?.type === 'NoValue';
+  const isForDirectBindingOnly = (allowedVariableOverrides: string[]) =>
+    allowedVariableOverrides.includes(componentValueKey); // removed 'NoValue' check
+
+  return isValidForPrebinding && !isForDirectBindingOnly(allowedVariableOverrides);
 };
 
 export const resolvePrebindingPath = ({

--- a/packages/storybook-addon/package.json
+++ b/packages/storybook-addon/package.json
@@ -53,7 +53,6 @@
     "prebuild": "npm run clean",
     "build": "tsup",
     "build:watch": "npm run build --watch",
-    "test": "echo \"Error: no test specified\" && exit 1",
     "start": "run-p build:watch 'storybook --quiet'",
     "prerelease": "zx scripts/prepublish-checks.mjs",
     "release": "npm run build && auto shipit",


### PR DESCRIPTION
## Purpose

This is sister PR for the user_interface PR https://github.com/contentful/user_interface/pull/27845


