### PR TITLE
fix: support for wrapComponent and adding deprecation notices [SPA-3087]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44384,7 +44384,6 @@
         "@contentful/experiences-validators": "file:../validators",
         "@contentful/experiences-visual-editor-react": "file:../visual-editor",
         "@contentful/rich-text-types": "^17.0.0",
-        "classnames": "^2.3.2",
         "csstype": "^3.1.2",
         "immer": "^10.0.3",
         "lodash-es": "^4.17.21",
@@ -45209,7 +45208,6 @@
       "dependencies": {
         "@contentful/experiences-components-react": "file:../components",
         "@contentful/experiences-core": "file:../core",
-        "classnames": "^2.3.2",
         "contentful": "^10.6.14",
         "immer": "^10.0.3",
         "lodash-es": "^4.17.21",

--- a/packages/components/src/components/Divider/ContentfulDivider.tsx
+++ b/packages/components/src/components/Divider/ContentfulDivider.tsx
@@ -3,15 +3,9 @@ import './ContentfulDivider.css';
 
 export type ContentfulDividerProps = {
   className?: string;
-  dragProps?: unknown;
 };
 
-export const ContentfulDivider = ({
-  className = '',
-  // We have to exclude this explicitly from rendering as withComponentWrapper is not used
-  dragProps: _,
-  ...props
-}: ContentfulDividerProps) => {
+export const ContentfulDivider = ({ className = '', ...props }: ContentfulDividerProps) => {
   return (
     <div className="cf-divider" {...props}>
       <hr className={className} />

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -115,7 +115,17 @@ export type ComponentDefinition<
   // FIXME: While it's technically possible, we don't want to allow using built-in content props via
   // the styles configuration. We should split this up in the future into content and style and adjust
   // components like `Container` for that.
+  /**
+   * List of built-in styles that can be applied to the component.
+   *
+   * Note that the property 'cfVisibility' is enforced on every component to control its visibility.
+   * @example ['cfWidth', 'cfPadding']
+   * @default ['cfMargin']
+   */
   builtInStyles?: Array<keyof Omit<StyleProps, 'cfHyperlink' | 'cfOpenInNewTab'>>;
+  /** Component allows passing child components inside it.
+   * @default false
+   */
   children?: boolean;
   tooltip?: {
     imageUrl?: string;
@@ -132,13 +142,26 @@ export type ComponentRegistration = {
      * render different content between editor and delivery mode.
      */
     enableCustomEditorView?: boolean;
+    /**
+     * @deprecated Using a wrapper is not recommended. Please migrate your components layout
+     * to work without this setting as it will be removed in the next major release v4. */
     wrapComponent?: boolean;
-    wrapContainer?: keyof JSX.IntrinsicElements | React.ReactElement;
+    /**
+     * @deprecated Using a wrapper is not recommended. Please migrate your components layout
+     * to work without this setting as it will be removed in the next major release v4. */
+    wrapContainer?: keyof JSX.IntrinsicElements;
+    /**
+     * @deprecated This option is not supported anymore and will be fully removed in the
+     * next major release v4. */
     wrapContainerWidth?: React.CSSProperties['width'];
   };
 };
 
 export type ComponentRegistrationOptions = {
+  /**
+   * Restrict the list of built-in components to a defined set of IDs.
+   * @example ['contentful-container', 'contentful-button']
+   */
   enabledBuiltInComponents?: string[];
   experimentalComponents?: {
     carousel?: boolean;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -142,13 +142,7 @@ export type ComponentRegistration = {
      * render different content between editor and delivery mode.
      */
     enableCustomEditorView?: boolean;
-    /**
-     * @deprecated Using a wrapper is not recommended. Please migrate your components layout
-     * to work without this setting as it will be removed in the next major release v4. */
     wrapComponent?: boolean;
-    /**
-     * @deprecated Using a wrapper is not recommended. Please migrate your components layout
-     * to work without this setting as it will be removed in the next major release v4. */
     wrapContainer?: keyof JSX.IntrinsicElements;
     /**
      * @deprecated This option is not supported anymore and will be fully removed in the

--- a/packages/experience-builder-sdk/package.json
+++ b/packages/experience-builder-sdk/package.json
@@ -46,7 +46,6 @@
     "@contentful/experiences-validators": "file:../validators",
     "@contentful/experiences-visual-editor-react": "file:../visual-editor",
     "@contentful/rich-text-types": "^17.0.0",
-    "classnames": "^2.3.2",
     "csstype": "^3.1.2",
     "immer": "^10.0.3",
     "lodash-es": "^4.17.21",

--- a/packages/experience-builder-sdk/src/core/componentRegistry.ts
+++ b/packages/experience-builder-sdk/src/core/componentRegistry.ts
@@ -48,10 +48,6 @@ const applyComponentDefinitionFallbacks = (componentDefinition: ComponentDefinit
 };
 
 const applyBuiltInStyleDefinitions = (componentDefinition: ComponentDefinition) => {
-  if (componentDefinition.id === CONTENTFUL_COMPONENTS.container.id) {
-    return componentDefinition;
-  }
-
   const clone = cloneObject(componentDefinition);
 
   // set margin built-in style by default
@@ -141,14 +137,13 @@ const DEFAULT_COMPONENT_REGISTRATIONS = {
       wrapComponent: false,
     },
   }),
-  divider: {
-    // Don't wrap this component `withComponentWrapper`. Need to explicitly ignore dragProps
+  divider: enrichComponentDefinition({
     component: Components.ContentfulDivider,
     definition: dividerDefinition,
     options: {
       wrapComponent: false,
     },
-  },
+  }),
   carousel: enrichComponentDefinition({
     component: Components.Carousel,
     definition: Components.carouselDefinition,

--- a/packages/experience-builder-sdk/src/utils/withComponentWrapper.spec.tsx
+++ b/packages/experience-builder-sdk/src/utils/withComponentWrapper.spec.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { withComponentWrapper } from './withComponentWrapper';
-import { fireEvent, render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 
 const MyButton: React.FC<React.PropsWithChildren> = ({ children, ...props }) => (
   <button {...props}>{children}</button>
@@ -15,81 +15,50 @@ describe('withComponentWrapper', () => {
   describe('when component is wrapped', () => {
     const WrappedButton = withComponentWrapper(MyButton);
 
-    it('classes get added to the correct elements', () => {
-      const { container, getByRole } = render(
+    it('passes all required attribuets to the wrapper and the rest to the component', () => {
+      const { container } = render(
         <WrappedButton
           data-cf-node-block-id="test1"
           data-cf-node-block-type="test2"
           data-cf-node-id="test3"
-          className="my-wrapper"
-          classes="my-class"
+          className="cfstyles-randomhash"
           data-caca="yep">
           Click me
         </WrappedButton>,
       );
 
-      expect(container.firstChild).toHaveClass('my-wrapper');
-      expect(getByRole('button')).toHaveClass('my-class');
-      expect(getByRole('button')).toHaveAttribute('data-caca', 'yep');
+      expect(container.firstChild).toBeInstanceOf(HTMLDivElement);
+      expect(container.firstChild).toHaveClass('cfstyles-randomhash');
+      expect(container.firstChild).toHaveAttribute('data-cf-node-block-id', 'test1');
+      expect(container.firstChild).toHaveAttribute('data-cf-node-block-type', 'test2');
+      expect(container.firstChild).toHaveAttribute('data-cf-node-id', 'test3');
+
+      expect(screen.getByRole('button')).not.toHaveClass('cfstyles-randomhash');
+      expect(screen.getByRole('button')).not.toHaveAttribute('data-cf-node-block-id', 'test1');
+      expect(screen.getByRole('button')).not.toHaveAttribute('data-cf-node-block-type', 'test2');
+      expect(screen.getByRole('button')).not.toHaveAttribute('data-cf-node-id', 'test3');
+      expect(screen.getByRole('button')).toHaveAttribute('data-caca', 'yep');
     });
   });
 
   describe('when component is not wrapped', () => {
     const Button = withComponentWrapper(MyButton, { wrapComponent: false });
 
-    it('classes should be applied to the component itself', () => {
-      const { getByRole } = render(<Button classes="test">Click me</Button>);
-      expect(getByRole('button')).toHaveClass('test');
-    });
-
-    it('events should be bound to the component itself', () => {
-      const onClickSpy = jest.fn();
-      const onMouseDownSpy = jest.fn();
-      const onMouseUpSpy = jest.fn();
-
-      const { container } = render(
-        <Button onClick={onClickSpy} onMouseDown={onMouseDownSpy} onMouseUp={onMouseUpSpy}>
-          Click me
-        </Button>,
-      );
-
-      fireEvent.click(container.firstChild!);
-      expect(onClickSpy).toHaveBeenCalledTimes(1);
-
-      fireEvent.mouseDown(container.firstChild!);
-      expect(onMouseDownSpy).toHaveBeenCalledTimes(1);
-
-      fireEvent.mouseUp(container.firstChild!);
-      expect(onMouseUpSpy).toHaveBeenCalledTimes(1);
-    });
-
-    it('extra props should be passed to the component', () => {
-      const { container } = render(
-        <Button
-          data-cf-node-block-id="test1"
-          data-cf-node-block-type="test2"
-          data-cf-node-id="test3">
-          Click me
-        </Button>,
-      );
-      expect(container.firstChild).toHaveAttribute('data-cf-node-block-id', 'test1');
-      expect(container.firstChild).toHaveAttribute('data-cf-node-block-type', 'test2');
-      expect(container.firstChild).toHaveAttribute('data-cf-node-id', 'test3');
-    });
-
-    it('classes get added to the correct elements', () => {
+    it('passes all required attributes to the component', () => {
       const { container } = render(
         <Button
           data-cf-node-block-id="test1"
           data-cf-node-block-type="test2"
           data-cf-node-id="test3"
-          className="my-button" //so we can select it later
-          classes="my-class">
+          className="cfstyles-randomhash">
           Click me
         </Button>,
       );
-      expect(container.firstChild).toHaveClass('my-button');
-      expect(container.firstChild).toHaveClass('my-class');
+      expect(container.firstChild).toBeInstanceOf(HTMLButtonElement);
+      expect(container.firstChild).toHaveClass('cfstyles-randomhash');
+      expect(container.firstChild).toHaveAttribute('data-cf-node-block-id', 'test1');
+      expect(container.firstChild).toHaveAttribute('data-cf-node-block-type', 'test2');
+      expect(container.firstChild).toHaveAttribute('data-cf-node-id', 'test3');
     });
   });
 });

--- a/packages/experience-builder-sdk/src/utils/withComponentWrapper.tsx
+++ b/packages/experience-builder-sdk/src/utils/withComponentWrapper.tsx
@@ -24,7 +24,7 @@ export function withComponentWrapper<T>(
   const mergedOptions = {
     // Merge default values with overwriting options
     wrapComponent: true,
-    wrapContainer: 'div',
+    wrapContainer: 'div' as keyof JSX.IntrinsicElements,
     ...options,
   };
   const Wrapped: React.FC<CFProps & T> = (props) => {

--- a/packages/experience-builder-sdk/src/utils/withComponentWrapper.tsx
+++ b/packages/experience-builder-sdk/src/utils/withComponentWrapper.tsx
@@ -1,16 +1,13 @@
 import { ComponentRegistration } from '@contentful/experiences-core/types';
-import classNames from 'classnames';
 import React from 'react';
 interface CFProps extends React.HtmlHTMLAttributes<HTMLElement> {
   /**
    * Classes to be applied to the container component if `wrapComponent` is true, or directly to the child component if false.
    */
   className?: string;
-  /**
-   * Classes to be applied to the child component if `wrapComponent` is true, or directly to the child component if false.
-   */
-  classes?: string;
-  dragProps?: any;
+  'data-cf-node-id': string;
+  'data-cf-node-block-id': string;
+  'data-cf-node-block-type': string;
 }
 
 /**
@@ -22,39 +19,34 @@ interface CFProps extends React.HtmlHTMLAttributes<HTMLElement> {
  */
 export function withComponentWrapper<T>(
   Component: React.ElementType,
-  options: ComponentRegistration['options'] = {
+  options: ComponentRegistration['options'] = {},
+) {
+  const mergedOptions = {
+    // Merge default values with overwriting options
     wrapComponent: true,
     wrapContainer: 'div',
-  },
-) {
-  const Wrapped: React.FC<CFProps & T> = ({
-    classes = '',
-    className = '',
-    dragProps = {},
-    ...props
-  }) => {
+    ...options,
+  };
+  const Wrapped: React.FC<CFProps & T> = (props) => {
+    const Tag = mergedOptions.wrapContainer;
     const {
-      innerRef,
-      className: dragClassName,
-      ToolTipAndPlaceholder,
-      ...restOfDragProps
-    } = dragProps;
-    const component = options.wrapComponent ? (
-      <div
+      className = '',
+      'data-cf-node-id': dataCfNodeId,
+      'data-cf-node-block-id': dataCfNodeBlockId,
+      'data-cf-node-block-type': dataCfNodeBlockType,
+      ...componentProps
+    } = props;
+    const component = mergedOptions.wrapComponent ? (
+      <Tag
         data-component-wrapper
-        className={classNames(classes, className, dragClassName)}
-        {...restOfDragProps}
-        ref={(refNode: HTMLElement | null) => {
-          if (innerRef && refNode) innerRef(refNode);
-        }}>
-        {ToolTipAndPlaceholder}
-        <Component className={classNames(classes)} {...(props as T)} />
-      </div>
+        className={className}
+        data-cf-node-id={dataCfNodeId}
+        data-cf-node-block-id={dataCfNodeBlockId}
+        data-cf-node-block-type={dataCfNodeBlockType}>
+        <Component {...componentProps} />
+      </Tag>
     ) : (
-      React.createElement(Component, {
-        className: classNames(classes, className),
-        ...(props as T),
-      })
+      React.createElement(Component, props)
     );
     return component;
   };

--- a/packages/test-apps/react-vite/src/studio-config.ts
+++ b/packages/test-apps/react-vite/src/studio-config.ts
@@ -31,9 +31,6 @@ defineComponents(
         category: 'Custom Components',
         variables: {},
       },
-      options: {
-        wrapContainerWidth: '50%',
-      },
     },
     {
       component: ComponentWithChildren,

--- a/packages/visual-editor/package.json
+++ b/packages/visual-editor/package.json
@@ -37,7 +37,6 @@
   "dependencies": {
     "@contentful/experiences-components-react": "file:../components",
     "@contentful/experiences-core": "file:../core",
-    "classnames": "^2.3.2",
     "contentful": "^10.6.14",
     "immer": "^10.0.3",
     "lodash-es": "^4.17.21",


### PR DESCRIPTION
## Purpose

After removing the dragging wrapper, another wrapper logic remains that is added during registration (`withComponentWrapper`). Unfortunately, we realized only now that by default, we add the wrapping container to every registered component, and changing that would be a breaking change as every component would have to forward HTMK attributes like `data-cf-node-id`.

Background for the research was a component in our demo applications, which was not clickable. It is registered together with a `wrapContainer`, which caused a bug: With the new DND system, we don't need a `ref` anymore, but instead fully rely on every component to render the attribute `data-cf-node-id` to calculate its coordinates. The wrapping logic didn't render those anymore (it did in [the beginning](https://github.com/contentful/experience-builder/commit/56100403bbc6d87b98c5f3c7713f5142d584431b#diff-032b7a2eac51d40c7a9354cf29f7e1e654073acfd5af7a0b0dc50267b1d309c2)).

## Approach

1. Since the option `wrapContainerWidth` was only applied to the drag wrapper in the past but not the wrapper shipped in delivery (see [here](https://github.com/contentful/experience-builder/blob/v2.0.0/packages/visual-editor/src/hooks/useComponent.tsx#L131)), we're not supporting this anymore. To not cause breaking changes, the option is marked as deprecated in the options type.

2. Again, to not cause a breaking change, we continue supporting the options `wrapComponent` and `wrapContainer` and stick to the default behaviour.

4. Remove all DND-related properties from the wrapping logic as it's not used anymore (`dragProps` and `classes`).

5. Correctly pass `data-cf-node-id`, `data-cf-node-block-id`, and `data-cf-node-block-type` to the wrapper.

6. Drop unused package `classnames` from visual-editor and experience-builder-sdk

7. Registry changes: Remove duplicated check to not wrap container nodes and remove the special case for `dragProps` on divider.