### PR TITLE
fix: remove error in regex and turn it into a TS template literal [SPA-3131]

### DIFF
--- a/packages/experience-builder-sdk/src/core/componentRegistry.test.tsx
+++ b/packages/experience-builder-sdk/src/core/componentRegistry.test.tsx
@@ -371,19 +371,19 @@ describe('sendConnectedEventWithRegisteredComponents', () => {
     const customBreakpoints = [
       {
         id: 'test-desktop',
-        query: '*',
+        query: '*' as const,
         displayName: 'All Sizes',
         previewSize: '100%',
       },
       {
         id: 'test-tablet',
-        query: '<982px',
+        query: '<982px' as const,
         displayName: 'Tablet',
         previewSize: '820px',
       },
       {
         id: 'test-mobile',
-        query: '<576px',
+        query: '<576px' as const,
         displayName: 'Mobile',
         previewSize: '390px',
       },

--- a/packages/validators/src/schemas/v2023_09_28/common.ts
+++ b/packages/validators/src/schemas/v2023_09_28/common.ts
@@ -221,10 +221,14 @@ export const ParameterSchema = z.object({
 
 export const ParametersSchema = z.record(propertyKeySchema, ParameterSchema);
 
+type BreakpointQuery = '*' | `>${number}px` | `<${number}px`;
+const BREAKPOINT_QUERY_REGEX = /^\*$|^[<>][0-9]+px$/;
+
 export const BreakpointSchema = z
   .object({
     id: propertyKeySchema,
-    query: z.string().regex(/^\*$|^[<>][0-9*]+px$/),
+    // Can be replace with z.templateLiteral when upgrading to zod v4
+    query: z.string().refine((s): s is BreakpointQuery => BREAKPOINT_QUERY_REGEX.test(s)),
     previewSize: z.string(),
     displayName: z.string(),
     displayIcon: z.enum(['desktop', 'tablet', 'mobile']).optional(),


### PR DESCRIPTION
## Purpose

The `query` parameter is typed as `string`. Only when running the application in the browser, the zod validation error would inform you about the invalid query (e.g. `>=700px`).

<img height="202" alt="image" src="https://github.com/user-attachments/assets/a45ed5d1-f427-4179-b8fe-2d6b278d5e86" />

## Approach

While touching the logic, I noticed a mistake in the Regex as it allowed a star to be part of the number, e.g .`>70*0px` is considered a valid query

Since we don't use Zod 4 yet, I took [this](https://github.com/colinhacks/zod/issues/419) as inspiration using a type assertion function.

| Before | After |
|--------|--------|
| <img width="280" height="73" alt="Screenshot 2025-08-18 at 15 42 03" src="https://github.com/user-attachments/assets/6abf49de-5270-4f87-84d9-457f255ca7f8" /> | <img width="587" height="160" alt="Screenshot 2025-08-18 at 15 44 07" src="https://github.com/user-attachments/assets/b36cef6e-1b96-4cfa-910a-be963e622b4a" /> | 