### PR TITLE
feat: change placeholder value for image width to 100% [SPA-3133]

### DIFF
--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -172,8 +172,6 @@ export const EMPTY_CONTAINER_SIZE = '80px';
 
 export const HYPERLINK_DEFAULT_PATTERN = `/{locale}/{entry.fields.slug}/`;
 
-export const DEFAULT_IMAGE_WIDTH = '500px';
-
 export enum PostMessageMethods {
   REQUEST_ENTITIES = 'REQUEST_ENTITIES',
   REQUESTED_ENTITIES = 'REQUESTED_ENTITIES',

--- a/packages/core/src/definitions/styles.ts
+++ b/packages/core/src/definitions/styles.ts
@@ -1,4 +1,3 @@
-import { DEFAULT_IMAGE_WIDTH } from '@/constants';
 import { DesignVariableMap } from '../types';
 
 // These styles get added to every component, user custom or contentful provided
@@ -203,9 +202,9 @@ export const optionalBuiltInStyles: Partial<DesignVariableMap> = {
     type: 'Object',
     group: 'style',
     defaultValue: {
-      width: DEFAULT_IMAGE_WIDTH,
+      width: '100%',
       height: '100%',
-      targetSize: DEFAULT_IMAGE_WIDTH,
+      targetSize: 'unset',
     },
   },
   cfBackgroundColor: {


### PR DESCRIPTION
## Purpose
We decided in the past to initialize every new image node with a width of `500px`. We saw multiple situations in the past where this would behave not as expected, e.g. when putting an image inside a column or adding it in a smaller breakpoint view, it would overflow.

## Approach
After discussing with our designer, we decided to switch to `100%`, so that it takes up the space that is available without overflowing. The only culprit in this approach is that the height is growing proportionally to the width, and thus getting quite big for large viewports. We accept this drawback, assuming that it brings more advantages than disadvantages.

| Before | After |
|--------|--------|
| <img width="459" height="478" alt="Screenshot 2025-08-19 at 11 48 41" src="https://github.com/user-attachments/assets/776c5b8c-ad0a-4b54-9607-aaf7d7970e19" /> | <img width="375" height="473" alt="Screenshot 2025-08-19 at 11 48 56" src="https://github.com/user-attachments/assets/8d5f058f-948c-4f6d-a78d-bac759339461" /> |
 