### PR TITLE
Feat: support prebindingId on component tree node [SPA-3184]

### DIFF
--- a/packages/validators/src/schemas/v2023_09_28/common.ts
+++ b/packages/validators/src/schemas/v2023_09_28/common.ts
@@ -239,6 +239,7 @@ export const BreakpointSchema = z
 const BaseComponentTreeNodeSchema = z.object({
   id: ComponentTreeNodeIdSchema.optional(),
   definitionId: DefinitionPropertyKeySchema,
+  prebindingId: z.string().optional(),
   displayName: z.string().optional(),
   slotId: z.string().optional(),
   variables: z.record(propertyKeySchema, ComponentPropertyValueSchema),


### PR DESCRIPTION
## Purpose

Support optional `prebindingId` on ComponentTree node.

https://contentful.atlassian.net/browse/SPA-3184

## Approach

<!--
Remember when merging:
- Use "Squash and merge" when merging changes into development.
- Use "Create a merge commit" when releasing changes into next and main.

Three important notes on pull requests:
- In general, you should ask yourself whether this code change will improve or worsen the overall code quality. Any new tech debt will probably never be cleaned up.
- Please remember that newly introduced logic should be validated and protected through testing.
- Take a look at PR guides:
  Google's Code Review Guidelines: https://google.github.io/eng-practices/
  Blockly - Writing a Good Pull Request: https://developers.google.com/blockly/guides/contribute/get-started/write_a_good_pr
-->
