### PR TITLE
fix: remove editor wrapper [SPA-3197]

### DIFF
--- a/packages/visual-editor/src/components/RootRenderer/RootRenderer.module.css
+++ b/packages/visual-editor/src/components/RootRenderer/RootRenderer.module.css
@@ -1,9 +1,3 @@
-.rootContainer {
-  position: relative;
-  display: flex;
-  flex-direction: column;
-}
-
 body {
   margin: 0;
 }

--- a/packages/visual-editor/src/components/RootRenderer/RootRenderer.tsx
+++ b/packages/visual-editor/src/components/RootRenderer/RootRenderer.tsx
@@ -32,22 +32,20 @@ export const RootRenderer = ({ inMemoryEntitiesStore, canvasMode }: RootRenderer
 
   return (
     <>
-      <div data-ctfl-root className={styles.rootContainer}>
-        {!tree.root.children.length ? (
-          <EmptyCanvasMessage />
-        ) : (
-          tree.root.children.map((topLevelChildNode) => (
-            <EditorBlock
-              key={topLevelChildNode.data.id}
-              node={topLevelChildNode}
-              resolveDesignValue={resolveDesignValue}
-              wrappingPatternIds={wrappingPatternIds}
-              entityStore={entityStore}
-              areEntitiesFetched={areEntitiesFetched}
-            />
-          ))
-        )}
-      </div>
+      {!tree.root.children.length ? (
+        <EmptyCanvasMessage />
+      ) : (
+        tree.root.children.map((topLevelChildNode) => (
+          <EditorBlock
+            key={topLevelChildNode.data.id}
+            node={topLevelChildNode}
+            resolveDesignValue={resolveDesignValue}
+            wrappingPatternIds={wrappingPatternIds}
+            entityStore={entityStore}
+            areEntitiesFetched={areEntitiesFetched}
+          />
+        ))
+      )}
     </>
   );
 };

--- a/packages/visual-editor/src/components/RootRenderer/RootRenderer.tsx
+++ b/packages/visual-editor/src/components/RootRenderer/RootRenderer.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { useTreeStore } from '@/store/tree';
-import styles from './RootRenderer.module.css';
 import { useBreakpoints } from '@/hooks/useBreakpoints';
 import { useEditorSubscriber } from '@/hooks/useEditorSubscriber';
 import { EditorBlock } from '@components/EditorBlock';
@@ -9,6 +8,8 @@ import { ROOT_ID } from '@/types/constants';
 import { type InMemoryEntitiesStore } from '@contentful/experiences-core';
 import type { StudioCanvasMode } from '@contentful/experiences-core/constants';
 import { useCanvasGeometryUpdates } from './useCanvasGeometryUpdates';
+
+import './RootRenderer.module.css';
 
 type RootRendererProperties = {
   inMemoryEntitiesStore: InMemoryEntitiesStore;


### PR DESCRIPTION
## Purpose

To achieve complete parity between editor and preview mode, and allow having experiences without `divs`, we drop the root node of the experience in editor mode.