### PR TITLE
feat: replace node editorProp with isEmpty and nodeBlocKId

### DIFF
--- a/packages/components/src/components/Columns/SingleColumn.tsx
+++ b/packages/components/src/components/Columns/SingleColumn.tsx
@@ -15,8 +15,7 @@ export const SingleColumn: React.FC<SingleColumnProps> = (props) => {
     return <Flex className={className}>{props.children}</Flex>;
   }
 
-  const { node, children } = props;
-  const isEmpty = !node.children.length;
+  const { isEmpty, children } = props;
   const mixedClassName = combineClasses(
     'cf-single-column-wrapper',
     className,

--- a/packages/components/src/components/ContentfulContainer/ContentfulContainer.tsx
+++ b/packages/components/src/components/ContentfulContainer/ContentfulContainer.tsx
@@ -28,9 +28,8 @@ export const ContentfulContainer: React.FC<ContentfulContainerAsHyperlinkProps> 
   }
 
   // Extract properties that are only available in editor mode
-  const { node } = props;
-  const isEmpty = !node.children.length;
-  const isSection = node.data.blockId === CONTENTFUL_COMPONENTS.section.id;
+  const { isEmpty, nodeBlockId } = props;
+  const isSection = nodeBlockId === CONTENTFUL_COMPONENTS.section.id;
 
   return (
     <Flex

--- a/packages/components/src/types.ts
+++ b/packages/components/src/types.ts
@@ -1,15 +1,5 @@
-import { ExperienceTreeNode } from '@contentful/experiences-core/types';
-
-type StructuralEditorModeProps =
-  | {
-      isEditorMode: true;
-      node: ExperienceTreeNode;
-    }
-  | {
-      isEditorMode?: false;
-      node: undefined;
-    };
+import { EditorProperties } from '@contentful/experiences-core/types';
 
 export type StructureComponentProps<OtherProps> = React.PropsWithChildren<
-  StructuralEditorModeProps & OtherProps
+  Partial<EditorProperties> & OtherProps
 >;

--- a/packages/components/src/utils/extractRenderProps.ts
+++ b/packages/components/src/utils/extractRenderProps.ts
@@ -1,7 +1,8 @@
 import type { StructureComponentProps } from '@/types';
+import { EditorPropertyNames } from '@contentful/experiences-core/types';
 
-export function extractRenderProps<T>(props: T): Omit<T, 'node' | 'isEditorMode' | 'children'> {
-  const { isEditorMode, node, children, ...renderProps } =
+export function extractRenderProps<T>(props: T): Omit<T, EditorPropertyNames> {
+  const { isEditorMode, isEmpty, nodeBlockId, children, ...renderProps } =
     props as StructureComponentProps<unknown>;
-  return renderProps as Omit<T, 'node' | 'isEditorMode' | 'children'>;
+  return renderProps as Omit<T, EditorPropertyNames>;
 }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -143,13 +143,13 @@ export type ComponentRegistration = {
      * If true, the component receives the optional boolean property `isInExpEditorMode` to
      * render different content between editor and delivery mode.
      *
-     * @deprecated this will be replaced by editorProperties in the next major version
+     * @deprecated this will be replaced by enableEditorProperties in the next major version
      */
     enableCustomEditorView?: boolean;
     /**
      * If set, the specified properties are passed to the component when rendered in the editor.
      */
-    editorProperties?: {
+    enableEditorProperties?: {
       /**
        * Enable the property `isEditorMode` which will be `true` if being rendered inside the Studio editor.
        */

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -150,8 +150,22 @@ export type ComponentRegistration = {
      * If set, the specified properties are passed to the component when rendered in the editor.
      */
     editorProperties?: {
-      node?: boolean;
+      /**
+       * Enable the property `isEditorMode` which will be `true` if being rendered inside the Studio editor.
+       */
       isEditorMode?: boolean;
+      /**
+       * Enable the property `isEmpty` which will be `true` if the component has no children.
+       * This can be used to render a placeholder or label in the editor when the component is empty.
+       *
+       * @note This will be false if there are no direct children nor slot children.
+       */
+      isEmpty?: boolean;
+      /**
+       * Enable the string property `nodeBlockId` which is equal to the component ID
+       * passed during registration, i.e. `ComponentDefinition['id']`.
+       */
+      nodeBlockId?: boolean;
     };
     wrapComponent?: boolean;
     wrapContainer?: keyof JSX.IntrinsicElements;
@@ -160,6 +174,27 @@ export type ComponentRegistration = {
      * next major release v4. */
     wrapContainerWidth?: React.CSSProperties['width'];
   };
+};
+
+/**
+ * Use this for type-safe access to editor properties in your custom components
+ * @example
+ * type MyCustomProps = { myValue: string }
+ * type MyComponentProps = EditorProperties<'isEmpty'> & MyCustomProps
+ */
+export type EditorProperties<T extends EditorPropertyNames = EditorPropertyNames> = Pick<
+  BaseEditorProperties,
+  T
+>;
+
+export type EditorPropertyNames = keyof BaseEditorProperties;
+
+type BaseEditorProperties = {
+  isEditorMode?: boolean;
+  isEmpty?: boolean;
+  nodeBlockId?: string;
+  /** @deprecated will be replaced by `isEditorMode` with the next major version of the SDK */
+  isInExpEditorMode?: boolean;
 };
 
 export type ComponentRegistrationOptions = {

--- a/packages/experience-builder-sdk/src/blocks/preview/CompositionBlock.tsx
+++ b/packages/experience-builder-sdk/src/blocks/preview/CompositionBlock.tsx
@@ -10,17 +10,21 @@ import {
   transformBoundContentValue,
   splitDirectAndSlotChildren,
 } from '@contentful/experiences-core';
-import { HYPERLINK_DEFAULT_PATTERN } from '@contentful/experiences-core/constants';
+import {
+  CONTENTFUL_COMPONENTS,
+  HYPERLINK_DEFAULT_PATTERN,
+} from '@contentful/experiences-core/constants';
 import type {
   ComponentTreeNode,
   DesignValue,
   Parameter,
   PrimitiveValue,
   ResolveDesignValueType,
+  StyleProps,
 } from '@contentful/experiences-core/types';
 import { createAssemblyRegistration, getComponentRegistration } from '../../core/componentRegistry';
 import { useInjectStylesheet } from '../../hooks/useInjectStylesheet';
-import { Assembly } from '@contentful/experiences-components-react';
+import { Assembly, ContentfulContainer } from '@contentful/experiences-components-react';
 import { resolvePattern } from '../../core/preview/assemblyUtils';
 import { resolveMaybePrebindingDefaultValuePath } from '../../utils/prebindingUtils';
 import { parseComponentProps } from '../../utils/parseComponentProps';
@@ -114,7 +118,7 @@ export const CompositionBlock = ({
     return registration;
   }, [isPatternNode, node.definitionId]);
 
-  const { ssrProps, props, mediaQuery } = useMemo(() => {
+  const { ssrProps, contentProps, props, mediaQuery } = useMemo(() => {
     // In SSR, we store the className under breakpoints[0] which is resolved here to the actual string
     const cfSsrClassNameValues = node.variables.cfSsrClassName as DesignValue | undefined;
     const mainBreakpoint = entityStore.breakpoints[0];
@@ -286,6 +290,18 @@ export const CompositionBlock = ({
 
   const renderedChildren = directChildNodes?.map(renderChildNode);
 
+  // TODO: we might be able to remove this special case as well by not dropping the two props in the sanitizeNodeProps function
+  if (isContainerOrSection(node.definitionId)) {
+    return (
+      <ContentfulContainer
+        cfHyperlink={(contentProps as StyleProps).cfHyperlink}
+        cfOpenInNewTab={(contentProps as StyleProps).cfOpenInNewTab}
+        className={props.className as string | undefined}>
+        {renderedChildren}
+      </ContentfulContainer>
+    );
+  }
+
   return React.createElement(
     component,
     {
@@ -295,3 +311,10 @@ export const CompositionBlock = ({
     renderedChildren,
   );
 };
+
+const isContainerOrSection = (
+  nodeDefinitionId: string,
+): nodeDefinitionId is 'contentful-container' | 'contentful-section' =>
+  [CONTENTFUL_COMPONENTS.container.id, CONTENTFUL_COMPONENTS.section.id].includes(
+    nodeDefinitionId as 'contentful-container' | 'contentful-section',
+  );

--- a/packages/experience-builder-sdk/src/core/componentRegistry.ts
+++ b/packages/experience-builder-sdk/src/core/componentRegistry.ts
@@ -97,7 +97,8 @@ const DEFAULT_COMPONENT_REGISTRATIONS = {
     options: {
       editorProperties: {
         isEditorMode: true,
-        node: true,
+        isEmpty: true,
+        nodeBlockId: true,
       },
     },
   },
@@ -107,7 +108,8 @@ const DEFAULT_COMPONENT_REGISTRATIONS = {
     options: {
       editorProperties: {
         isEditorMode: true,
-        node: true,
+        isEmpty: true,
+        nodeBlockId: true,
       },
     },
   },
@@ -121,7 +123,7 @@ const DEFAULT_COMPONENT_REGISTRATIONS = {
     options: {
       editorProperties: {
         isEditorMode: true,
-        node: true,
+        isEmpty: true,
       },
     },
   },

--- a/packages/experience-builder-sdk/src/core/componentRegistry.ts
+++ b/packages/experience-builder-sdk/src/core/componentRegistry.ts
@@ -95,7 +95,7 @@ const DEFAULT_COMPONENT_REGISTRATIONS = {
     component: Components.ContentfulContainer,
     definition: containerDefinition,
     options: {
-      editorProperties: {
+      enableEditorProperties: {
         isEditorMode: true,
         isEmpty: true,
         nodeBlockId: true,
@@ -106,7 +106,7 @@ const DEFAULT_COMPONENT_REGISTRATIONS = {
     component: Components.ContentfulContainer,
     definition: sectionDefinition,
     options: {
-      editorProperties: {
+      enableEditorProperties: {
         isEditorMode: true,
         isEmpty: true,
         nodeBlockId: true,
@@ -121,7 +121,7 @@ const DEFAULT_COMPONENT_REGISTRATIONS = {
     component: Components.SingleColumn,
     definition: singleColumnDefinition,
     options: {
-      editorProperties: {
+      enableEditorProperties: {
         isEditorMode: true,
         isEmpty: true,
       },

--- a/packages/visual-editor/src/components/EditorBlock/useComponentProps.ts
+++ b/packages/visual-editor/src/components/EditorBlock/useComponentProps.ts
@@ -276,13 +276,13 @@ export const useComponentProps = ({
   // through registry options as the component has to be aware of this prop to not cause any React warnings.
   const editorProps = useMemo(() => {
     const editorProps: Partial<EditorProperties> = {};
-    if (options?.editorProperties?.isEditorMode) {
+    if (options?.enableEditorProperties?.isEditorMode) {
       editorProps.isEditorMode = true;
     }
-    if (options?.editorProperties?.isEmpty) {
+    if (options?.enableEditorProperties?.isEmpty) {
       editorProps.isEmpty = node.children.length === 0;
     }
-    if (options?.editorProperties?.nodeBlockId) {
+    if (options?.enableEditorProperties?.nodeBlockId) {
       editorProps.nodeBlockId = node.data.blockId!;
     }
     if (options?.enableCustomEditorView) {
@@ -292,9 +292,9 @@ export const useComponentProps = ({
   }, [
     node.children.length,
     node.data.blockId,
-    options?.editorProperties?.isEditorMode,
-    options?.editorProperties?.isEmpty,
-    options?.editorProperties?.nodeBlockId,
+    options?.enableEditorProperties?.isEditorMode,
+    options?.enableEditorProperties?.isEmpty,
+    options?.enableEditorProperties?.nodeBlockId,
     options?.enableCustomEditorView,
   ]);
 

--- a/packages/visual-editor/src/components/EditorBlock/useComponentProps.ts
+++ b/packages/visual-editor/src/components/EditorBlock/useComponentProps.ts
@@ -21,6 +21,7 @@ import type {
   ComponentRegistration,
   Link,
   DesignValue,
+  EditorProperties,
 } from '@contentful/experiences-core/types';
 import { useMemo } from 'react';
 import { useEditorModeClassName } from './useEditorModeClassName';
@@ -271,6 +272,32 @@ export const useComponentProps = ({
     nodeId: node.data.id,
   });
 
+  // Allows custom components to render differently in the editor. This needs to be activated
+  // through registry options as the component has to be aware of this prop to not cause any React warnings.
+  const editorProps = useMemo(() => {
+    const editorProps: Partial<EditorProperties> = {};
+    if (options?.editorProperties?.isEditorMode) {
+      editorProps.isEditorMode = true;
+    }
+    if (options?.editorProperties?.isEmpty) {
+      editorProps.isEmpty = node.children.length === 0;
+    }
+    if (options?.editorProperties?.nodeBlockId) {
+      editorProps.nodeBlockId = node.data.blockId!;
+    }
+    if (options?.enableCustomEditorView) {
+      editorProps.isInExpEditorMode = true;
+    }
+    return editorProps;
+  }, [
+    node.children.length,
+    node.data.blockId,
+    options?.editorProperties?.isEditorMode,
+    options?.editorProperties?.isEmpty,
+    options?.editorProperties?.nodeBlockId,
+    options?.enableCustomEditorView,
+  ]);
+
   const componentProps = useMemo(() => {
     const sharedProps = {
       'data-cf-node-id': node.data.id,
@@ -281,21 +308,10 @@ export const useComponentProps = ({
 
     return {
       ...sharedProps,
-      // Allows custom components to render differently in the editor. This needs to be activated
-      // through options as the component has to be aware of this prop to not cause any React warnings.
-      ...(options?.enableCustomEditorView ? { isInExpEditorMode: true } : {}),
-      ...(options?.editorProperties?.isEditorMode ? { isEditorMode: true } : {}),
-      ...(options?.editorProperties?.node ? { node } : {}),
+      ...editorProps,
       ...sanitizeNodeProps(props),
     };
-  }, [
-    cfCsrClassName,
-    node,
-    options?.editorProperties?.isEditorMode,
-    options?.editorProperties?.node,
-    options?.enableCustomEditorView,
-    props,
-  ]);
+  }, [cfCsrClassName, editorProps, node, props]);
 
   return { componentProps };
 };


### PR DESCRIPTION
## Purpose

Based on the feedback for #1291, I filed another PR to revisit the shape of the new registry options.

## Approach

Replacing the complex object `node` with `isEmpty` and `nodeBlockId` as we only need those internally and the shape of `node` could change at some point, causing a breaking change otherwise.

Defining a component:
```ts
defineComponents([{
  component: MyComponent
  definition: myComponentDefinition,
  options: {
    enableEditorProperties: {
      isEditorMode: true,
      isEmpty: true,
    },
  },
}])
```

Using it:
```ts
type MyComponentProps = EditorProperties<'isEditorMode' | 'isEmpty'> & {
  myValue: string;
}
export const MyComponent = (props: MyComponentProps) => {
  // ...
}
```