### PR TITLE
feat: introduce SDK option to enable full structure overwrites [SPA-3198]

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -217,6 +217,14 @@ export type ComponentRegistrationOptions = {
    * @deprecated This is a temporary solution and will be removed in a future major version.
    */
   __disableTextAlignmentTransform?: boolean;
+  /**
+   * If you need to adjust the built-in structural components (e.g. `container`),
+   * enable this flag. It is marked as *unsafe* since the logic of those components
+   * might evolve in future versions. By overwriting their implementation, you accept
+   * the risk of potential breaking changes and running out of sync with the original
+   * implementation.
+   */
+  __unsafe__enableBuiltInStructureOverwrites?: boolean;
 };
 
 export type Binding = {
@@ -423,6 +431,7 @@ export type DesignTokensDefinition = {
 
 export type SdkOptions = {
   __disableTextAlignmentTransform?: ComponentRegistrationOptions['__disableTextAlignmentTransform'];
+  __unsafe__enableBuiltInStructureOverwrites?: ComponentRegistrationOptions['__unsafe__enableBuiltInStructureOverwrites'];
 };
 
 /** Type of experience entry JSON data structure as returned by CPA/CDA */

--- a/packages/experience-builder-sdk/src/blocks/preview/CompositionBlock.tsx
+++ b/packages/experience-builder-sdk/src/blocks/preview/CompositionBlock.tsx
@@ -9,6 +9,7 @@ import {
   sanitizeNodeProps,
   transformBoundContentValue,
   splitDirectAndSlotChildren,
+  getSdkOptions,
 } from '@contentful/experiences-core';
 import {
   CONTENTFUL_COMPONENTS,
@@ -290,8 +291,14 @@ export const CompositionBlock = ({
 
   const renderedChildren = directChildNodes?.map(renderChildNode);
 
+  const sdkOptions = getSdkOptions();
+
   // TODO: we might be able to remove this special case as well by not dropping the two props in the sanitizeNodeProps function
-  if (isContainerOrSection(node.definitionId)) {
+  // We allow custom container rendering through a new sdk option (not introducing a breaking change for existing customers).
+  if (
+    isContainerOrSection(node.definitionId) &&
+    !sdkOptions.__unsafe__enableBuiltInStructureOverwrites
+  ) {
     return (
       <ContentfulContainer
         cfHyperlink={(contentProps as StyleProps).cfHyperlink}

--- a/packages/experience-builder-sdk/src/core/componentRegistry.ts
+++ b/packages/experience-builder-sdk/src/core/componentRegistry.ts
@@ -18,8 +18,8 @@ import {
   optionalBuiltInStyles,
   sendMessage,
   defineSdkOptions,
-  isContentfulStructureComponent,
   debug,
+  isContentfulStructureComponent,
 } from '@contentful/experiences-core';
 import { validateComponentDefinition } from '@contentful/experiences-validators';
 import { withComponentWrapper } from '../utils/withComponentWrapper';
@@ -371,16 +371,22 @@ export const defineComponents = (
     }
   }
 
-  if (options?.__disableTextAlignmentTransform) {
-    defineSdkOptions({
-      __disableTextAlignmentTransform: true,
-    });
-  }
+  defineSdkOptions({
+    __disableTextAlignmentTransform: !!options?.__disableTextAlignmentTransform,
+    __unsafe__enableBuiltInStructureOverwrites:
+      !!options?.__unsafe__enableBuiltInStructureOverwrites,
+  });
 
   for (const registration of componentRegistrations) {
-    if (isContentfulStructureComponent(registration.definition.id)) {
+    if (
+      isContentfulStructureComponent(registration.definition.id) &&
+      !options?.__unsafe__enableBuiltInStructureOverwrites
+    ) {
       debug.warn(
-        `[experience-builder-sdk:defineComponents] You are registering a structure component with the reserved id '${registration.definition.id}'. This is not recommended and can lead to unexpected behaviour.`,
+        `[experience-builder-sdk:defineComponents] You are registering a ` +
+          `structure component with the reserved id '${registration.definition.id}'. This is not recommended ` +
+          `and can lead to unexpected behavior. If you still want to register it, please provide the registry option ` +
+          `'__unsafe__enableBuiltInStructureOverwrites' to fully enable built-in structure overwrites.`,
       );
     }
 


### PR DESCRIPTION
## Purpose

So far, the SDK allowed customers to overwrite built-in components, including the very basic structural ones. It is already possible to remove support properties from it or change other parts of its definition. However, so far the preview mode would always render the built-in `ContentfulContainer` causing a mismatch between editor and preview mode and giving the impression that this is supported.

As we learned from customers that they want to exploit this, we want to open this last protection and let them render any React component, replacing the built-in ones.

## Approach

Since those components are tied to our protocol and internal behaviour, we foresee that at some point, we might apply changes to those components. If customers already use their own custom solutions, this could lead to unexpected behaviour. For this reason, this feature as flagged as `UNSAFE` and could change in the future. To not lock customers in, we're offering this temporary solution.

To not cause a breaking change for everyone else, we're protecting the preview render logic to only change by providing the new SDK option `__unsafe__enableBuiltInStructureOverwrites`.

<img width="1432" height="124" alt="Screenshot 2025-09-02 at 18 44 53" src="https://github.com/user-attachments/assets/319f2e85-1f1f-400f-b149-b319eb5df780" />

_Disclaimer: since we render the iframe twice for v3 to initialize properly, initial logs show up twice right now. We might be able to fix this soon on the UI side, e.g. by assuming first that customers use v3._