### PR TITLE
fix: dont render cfHyperlink and cfOpenInNewTab as HTML attributes [SPA-3198]

### DIFF
--- a/packages/components/src/components/ContentfulContainer/ContentfulContainer.tsx
+++ b/packages/components/src/components/ContentfulContainer/ContentfulContainer.tsx
@@ -10,7 +10,16 @@ import { extractRenderProps } from '@/utils/extractRenderProps';
 
 export const ContentfulContainer: React.FC<ContentfulContainerAsHyperlinkProps> = (props) => {
   // Extract hyperlink-related props to not pass them to the regular container
-  const { className, isEditorMode, children, cfHyperlink, cfOpenInNewTab, ...otherProps } = props;
+  const {
+    className,
+    isEditorMode,
+    isEmpty,
+    nodeBlockId,
+    children,
+    cfHyperlink,
+    cfOpenInNewTab,
+    ...otherProps
+  } = props;
 
   if (cfHyperlink) {
     return <ContentfulContainerAsHyperlink {...props}>{children}</ContentfulContainerAsHyperlink>;
@@ -27,14 +36,12 @@ export const ContentfulContainer: React.FC<ContentfulContainerAsHyperlinkProps> 
     );
   }
 
-  // Extract properties that are only available in editor mode
-  const { isEmpty, nodeBlockId } = props;
   const isSection = nodeBlockId === CONTENTFUL_COMPONENTS.section.id;
 
   return (
     <Flex
       data-test-id="contentful-container"
-      {...extractRenderProps(props)}
+      {...extractRenderProps(otherProps)}
       className={combineClasses(
         className,
         'contentful-container',


### PR DESCRIPTION
When `cfHyperlink` and `cfOpenInNewTab` are undefined but still keys of the `props` object, the container would still pass them down to the DOM causing a React warning:

<img width="841" height="158" alt="Screenshot 2025-09-02 at 19 16 23" src="https://github.com/user-attachments/assets/e1f69811-744f-4b8d-a103-89f3e3427dcb" />
<img width="792" height="148" alt="Screenshot 2025-09-02 at 19 16 17" src="https://github.com/user-attachments/assets/8718b42a-4f1f-4ae8-b100-2b43b0297ec0" />
<img width="653" height="90" alt="Screenshot 2025-09-02 at 19 18 58" src="https://github.com/user-attachments/assets/c927495f-dc07-4a8f-9993-027facbf685b" />
