### PR TITLE
fix: add prebindingId to the ExperienceTreeNode type [SPA-3184]

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -252,6 +252,7 @@ export type ExperienceTreeNode = {
     unboundValues: ExperienceUnboundValues;
     breakpoints: Breakpoint[];
     parameters?: Record<string, Parameter>;
+    prebindingId?: string;
     pattern?: {
       id: string;
       nodeId: string;


### PR DESCRIPTION
## Purpose

Adds prebindingId in the ExperienceTreeNode['data'] type.

## Approach

<!--
Remember when merging:
- Use "Squash and merge" when merging changes into development.
- Use "Create a merge commit" when releasing changes into next and main.

Three important notes on pull requests:
- In general, you should ask yourself whether this code change will improve or worsen the overall code quality. Any new tech debt will probably never be cleaned up.
- Please remember that newly introduced logic should be validated and protected through testing.
- Take a look at PR guides:
  Google's Code Review Guidelines: https://google.github.io/eng-practices/
  Blockly - Writing a Good Pull Request: https://developers.google.com/blockly/guides/contribute/get-started/write_a_good_pr
-->
