### PR TITLE
fix: deny overwriting internal properties by custom ones [SPA-3210]

### DIFF
--- a/packages/visual-editor/src/components/EditorBlock/useComponentProps.ts
+++ b/packages/visual-editor/src/components/EditorBlock/useComponentProps.ts
@@ -307,9 +307,10 @@ export const useComponentProps = ({
     };
 
     return {
-      ...sharedProps,
-      ...editorProps,
       ...sanitizeNodeProps(props),
+      // Add those at last to not let them get overwritten by custom properties
+      ...editorProps,
+      ...sharedProps,
     };
   }, [cfCsrClassName, editorProps, node, props]);
 


### PR DESCRIPTION
## Purpose

While defining a custom component, the developer could define a property to override our internal ones, e.g. `data-cf-node-id` (which would break the editing experience).

## Approach

To protect any reserved properties, they get a high priority during the object destruction in `useComponentProps`