### PR TITLE
fix: allow passing children property if there are no children [SPA-3210]

### DIFF
--- a/packages/experience-builder-sdk/src/blocks/preview/CompositionBlock.tsx
+++ b/packages/experience-builder-sdk/src/blocks/preview/CompositionBlock.tsx
@@ -308,7 +308,8 @@ export const CompositionBlock = ({
       ...sanitizeNodeProps(props),
       ...renderedSlotNodesMap,
     },
-    renderedChildren,
+    // If there are no children, a custom property called `children` can be passed through to the custom component
+    ...(renderedChildren ?? []),
   );
 };
 

--- a/packages/visual-editor/src/components/EditorBlock/EditorBlock.tsx
+++ b/packages/visual-editor/src/components/EditorBlock/EditorBlock.tsx
@@ -91,14 +91,15 @@ export function EditorBlock({
   );
 }
 
-type RegistrationComponentProps = React.PropsWithChildren<{
+type RegistrationComponentProps = {
   node: ExperienceTreeNode;
   resolveDesignValue: ResolveDesignValueType;
   componentRegistration: ComponentRegistration;
   slotNodes?: Record<string, React.JSX.Element>;
   entityStore: EntityStoreBase;
   areEntitiesFetched: boolean;
-}>;
+  children?: React.JSX.Element[];
+};
 const RegistrationComponent = ({
   node,
   resolveDesignValue,
@@ -123,7 +124,8 @@ const RegistrationComponent = ({
     React.createElement(
       componentRegistration.component,
       { ...componentProps, ...slotNodes },
-      children,
+      // If there are no children, a custom property called `children` can be passed through to the custom component
+      ...(children ?? []),
     ),
   );
 };


### PR DESCRIPTION
## Purpose

If the user defined a custom property `children`, it should be passed through to their custom component.

Only if the component accepts true child nodes (`children: true`) and it's a non-empty list, they will take precedence over that custom property.

## Approach
After having a look at the type of `React.createElement`, I learned that `children` should be passed as [rest parameters](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/rest_parameters) (`...children`). I worked probably this way because React can now render multiple nodes on the top-level of one render call ([added in React 16.0](https://legacy.reactjs.org/blog/2017/09/26/react-v16.0.html)).

This is a regression of the change I did [here](https://github.com/contentful/experience-builder/pull/1275/files#diff-e801c2e3de23af7313c1e3cd5d16aed2dd3a7e5389409fac9b59db20bb522136).