### PR TITLE
fix: handle validation errors gracefully and allow expanding it in the editor mode [SPA-3210]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2508,6 +2508,7 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {

--- a/packages/experience-builder-sdk/src/blocks/editor/VisualEditorRoot.tsx
+++ b/packages/experience-builder-sdk/src/blocks/editor/VisualEditorRoot.tsx
@@ -14,7 +14,7 @@ type VisualEditorRootProps = {
   initialLocale: string;
 };
 
-export const VisualEditorRoot: React.FC<VisualEditorRootProps> = ({
+const VisualEditorRoot: React.FC<VisualEditorRootProps> = ({
   visualEditorMode,
   canvasMode,
   experience,
@@ -28,16 +28,22 @@ export const VisualEditorRoot: React.FC<VisualEditorRootProps> = ({
   });
 
   return (
+    <Suspense fallback={<div>Loading...</div>}>
+      <VisualEditorLoader
+        experience={experience}
+        visualEditorMode={visualEditorMode}
+        canvasMode={canvasMode}
+      />
+    </Suspense>
+  );
+};
+
+const VisualEditorRootWithErrorBoundary: React.FC<VisualEditorRootProps> = (props) => {
+  return (
     <ErrorBoundary>
-      <Suspense fallback={<div>Loading...</div>}>
-        <VisualEditorLoader
-          experience={experience}
-          visualEditorMode={visualEditorMode}
-          canvasMode={canvasMode}
-        />
-      </Suspense>
+      <VisualEditorRoot {...props} />
     </ErrorBoundary>
   );
 };
 
-export default VisualEditorRoot;
+export default VisualEditorRootWithErrorBoundary;


### PR DESCRIPTION
## Purpose
We recently added some logic to the editor UI that automatically drops the interaction layer when there is a critical SDK error. To unfold those and read them fully, the user can then interact directly with the iframe.

When an error happens during the registration, e.g. a invalid component definition causes a validation error, this logic wouldn't apply as the eror boundary was not wrapping this part of the SDK.

## Approach
Moved the `ErrorBoundary` higher to wrap all editor-related logic, incl. validation