### PR TITLE
fix: remove unused Google Font from components package [SPA-3219]

### DIFF
--- a/packages/components/src/components/variables.css
+++ b/packages/components/src/components/variables.css
@@ -54,10 +54,6 @@
   --cf-border-radius-3xl: 1.5rem; /* 24px */
   --cf-border-radius-full: 9999px; /* full */
 
-  /* font-family */
-  --cf-font-family-sans: Archivo, Helvetica, Arial, sans-serif;
-  --cf-font-family-serif: Georgia, Cambria, Times New Roman, Times, serif;
-
   /* max widths */
   --cf-max-width-full: 100%;
 

--- a/packages/components/src/global.css
+++ b/packages/components/src/global.css
@@ -1,4 +1,3 @@
-@import url(https://fonts.googleapis.com/css2?family=Archivo:ital,wght@0,400;0,500;0,600;1,400;1,600&display=swap);
 @import url('./components/variables.css');
 
 /* Initially added with PR #253 for each component, this is now a global setting


### PR DESCRIPTION
## Purpose

In [this ancient PR](https://github.com/contentful/experience-builder/pull/201), we added a Google Font to the `components` package which was added to loaded in editor and **preview mode**. We want to reduce load times and remove unnecessary dependencies.

## Approach
The font family was never used, so it can be removed.