### PR TITLE
fix: preselect asset type for media variables [SPA-3214]

### DIFF
--- a/packages/components/src/components/Image/index.ts
+++ b/packages/components/src/components/Image/index.ts
@@ -20,7 +20,7 @@ export const ImageComponentDefinition: ComponentDefinition = {
       type: 'Text',
       description: 'Alternative text for the image',
       validations: {
-        bindingSourceType: ['entry', 'manual', 'asset'],
+        bindingSourceType: ['asset', 'entry', 'manual'],
       },
     },
   },

--- a/packages/core/src/definitions/styles.ts
+++ b/packages/core/src/definitions/styles.ts
@@ -194,7 +194,7 @@ export const optionalBuiltInStyles: Partial<DesignVariableMap> = {
     type: 'Media',
     description: 'Image to display',
     validations: {
-      bindingSourceType: ['entry', 'asset', 'manual'],
+      bindingSourceType: ['asset', 'entry', 'manual'],
     },
   },
   cfImageOptions: {
@@ -219,7 +219,7 @@ export const optionalBuiltInStyles: Partial<DesignVariableMap> = {
     type: 'Media',
     description: 'Background image for component',
     validations: {
-      bindingSourceType: ['entry', 'asset', 'manual'],
+      bindingSourceType: ['asset', 'entry', 'manual'],
     },
   },
   cfBackgroundImageOptions: {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -85,6 +85,8 @@ export type ComponentDefinitionVariableValidation<T extends ComponentDefinitionP
   required?: boolean;
   in?: ValidationOption<T>[];
   format?: VariableFormats;
+  /** Define the type of entity that can be bound to this variable. The provided list order defines
+   * the order of select options in the editor UI, i.e. the first item will be pre-selected by default. */
   bindingSourceType?: BindingSourceTypeEnum;
 };
 


### PR DESCRIPTION
## Purpose
When editing an image, the default entity type should be `Asset`.
<img height="308" alt="image" src="https://github.com/user-attachments/assets/0c91c5c2-838c-4989-b515-f3c2f7a6730d" />

## Approach
The editor logic plainly renders the first option from the list `validations.bindingSourceType`. Adjusted the defaults to account for that and added a JSDoc so external devs could discover this hidden feature.