### PR TITLE
fix: bring back cfVisibility rendering in CSR preview mode [SPA-3215]

### DIFF
--- a/packages/experience-builder-sdk/src/core/styles/convertResolvedDesignValuesToMediaQuery.spec.ts
+++ b/packages/experience-builder-sdk/src/core/styles/convertResolvedDesignValuesToMediaQuery.spec.ts
@@ -36,4 +36,50 @@ describe('convertResolvedDesignValuesToMediaQuery', () => {
       css: `${expectedDesktopCss}${expectedTabletCss}`,
     });
   });
+
+  describe('when using visibility styles', () => {
+    const designPropertiesByBreakpoint = {
+      desktop: { cfMargin: '7px', cfVisibility: false },
+      tablet: { cfMargin: '42px' },
+      mobile: { cfVisibility: true },
+    };
+
+    it("doesn't add them to the regular CSS code", () => {
+      const [desktop, tablet, mobile] = createStylesheetsForBuiltInStyles({
+        designPropertiesByBreakpoint,
+        breakpoints,
+        node,
+      });
+      expect(desktop.css).not.toContain('display:');
+      expect(tablet.css).not.toContain('display:');
+      expect(mobile.css).not.toContain('display:');
+    });
+
+    it('creates explicit visibility styles for each breakpoint', () => {
+      const [desktop, tablet, mobile] = createStylesheetsForBuiltInStyles({
+        designPropertiesByBreakpoint,
+        breakpoints,
+        node,
+      });
+      expect(desktop.visibilityCss).toEqual('display:none !important;');
+      expect(tablet.visibilityCss).toEqual('display:none !important;');
+      expect(mobile.visibilityCss).toEqual('');
+    });
+
+    it('creates disjunct media queries for each breakpoint', () => {
+      const stylesheetData = createStylesheetsForBuiltInStyles({
+        designPropertiesByBreakpoint,
+        breakpoints,
+        node,
+      });
+      const [desktop, tablet] = stylesheetData;
+      const expectedResult = convertResolvedDesignValuesToMediaQuery(stylesheetData);
+      expect(expectedResult.css).toContain(
+        `@media not (max-width:992px){.${desktop.className}{display:none !important;}}`,
+      );
+      expect(expectedResult.css).toContain(
+        `@media(max-width:992px) and (not (max-width:576px)){.${tablet.className}{display:none !important;}}`,
+      );
+    });
+  });
 });


### PR DESCRIPTION
## Purpose
`cfVIsibility` toggle is not considered in preview mode.

## Approach
The logic introduced in #1158 was accidentally removed in #1216 when dropping the duplicated code in `useMediaQuery`. In the first PR we just forgot to adjust both places and then didn't notice the difference between both implementations when dropping one.

Re-added the logic from the original PR in the next place.
