### PR TITLE
fix: treat undefined cfVisibility as true in editor [SPA-3216]

### DIFF
--- a/packages/visual-editor/src/utils/checkIsNodeVisible.spec.ts
+++ b/packages/visual-editor/src/utils/checkIsNodeVisible.spec.ts
@@ -59,5 +59,27 @@ describe('checkIsNodeVisible', () => {
       } as unknown as ExperienceTreeNode;
       expect(checkIsNodeVisible(node, resolveDesignValue)).toBe(false);
     });
+
+    it('returns true if node has children with cfVisibility being undefined', () => {
+      const nodeWithUndefinedVisibility = {
+        type: 'block',
+        data: {
+          props: {
+            cfVisibility: {
+              type: 'DesignValue',
+              valuesByBreakpoint: { 'invalid-breakpoint': true },
+            },
+          },
+        },
+        children: [],
+      } as unknown as ExperienceTreeNode;
+
+      const node = {
+        type: ASSEMBLY_NODE_TYPE,
+        data: {},
+        children: [nodeWithUndefinedVisibility],
+      } as unknown as ExperienceTreeNode;
+      expect(checkIsNodeVisible(node, resolveDesignValue)).toBe(true);
+    });
   });
 });

--- a/packages/visual-editor/src/utils/checkIsNodeVisible.ts
+++ b/packages/visual-editor/src/utils/checkIsNodeVisible.ts
@@ -16,5 +16,9 @@ export const checkIsNodeVisible = (
   }
 
   // Check if the current node is visible (`cfVisibility` is enforced on all nodes)
-  return !!resolveDesignValue((node.data.props['cfVisibility'] as DesignValue).valuesByBreakpoint);
+  // Check explicitly for false, as `undefined` is treated as `true`. It could become undefined when the breakpoint IDs changed.
+  return (
+    resolveDesignValue((node.data.props['cfVisibility'] as DesignValue).valuesByBreakpoint) !==
+    false
+  );
 };


### PR DESCRIPTION
## Purpose
When changing breakpoint IDs and thereby causing `cfVisibility` to become `undefined`, the editor wouldn't render those nodes as the pre-check in `checkIsNodeVisible` would treat `undefined` as false while the actual rendering mechanics don't actively hide it in that case.

## Approach
Check explicitly for `false` values in `cfVisibility` to treat `undefined` as truthy.