### PR TITLE
fix(visual-editor): remove redundant storage in assembliesRegistry [SPA-3239]

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -251,11 +251,6 @@ export type ExperienceTreeNode = {
     id: string;
     blockId?: string; // will be undefined in case string node or if root component
     slotId?: string;
-    assembly?: {
-      id: string;
-      componentId: string;
-      nodeLocation: string | null;
-    };
     displayName?: string;
     props: Record<string, ComponentPropertyValue>;
     dataSource: ExperienceDataSource;
@@ -679,6 +674,7 @@ export type RequestReadOnlyModePayload = undefined;
 export type RequestEditorModePayload = undefined;
 export type ExperienceUpdatedPayload = {
   tree: ExperienceTree;
+  /** @deprecated this is derived from the tree and list of all available assemblies */
   assemblies?: ExperienceUsedComponents;
   locale: string;
   changedNode?: ExperienceTreeNode;

--- a/packages/visual-editor/src/store/registries.ts
+++ b/packages/visual-editor/src/store/registries.ts
@@ -1,16 +1,5 @@
-import type { ComponentRegistration, Link } from '@contentful/experiences-core/types';
-
+import type { ComponentRegistration } from '@contentful/experiences-core/types';
 import { ASSEMBLY_DEFAULT_CATEGORY } from '@contentful/experiences-core/constants';
-
-// Note: During development, the hot reloading might empty this and it
-// stays empty leading to not rendering assemblies. Ideally, this is
-// integrated into the state machine to keep track of its state.
-export const assembliesRegistry = new Map<string, Link<'Entry'>>([]);
-export const setAssemblies = (assemblies: Link<'Entry'>[]) => {
-  for (const assembly of assemblies) {
-    assembliesRegistry.set(assembly.sys.id, assembly);
-  }
-};
 
 export const componentRegistry = new Map<string, ComponentRegistration>();
 
@@ -46,4 +35,10 @@ export const createAssemblyRegistration = ({
   addComponentRegistration({ component, definition });
 
   return componentRegistry.get(definitionId);
+};
+
+export const getAllAssemblyRegistrations = () => {
+  return Array.from(componentRegistry.values()).filter((registration) => {
+    return registration.definition.category === ASSEMBLY_DEFAULT_CATEGORY;
+  });
 };


### PR DESCRIPTION
## Purpose
The initialization process first registeres all available assemblies before sending the tree. At the same time, we also send a list of "used assemblies" in the treeUpdated message.

## Approach
Given this complete list of assemblies and the tree, we can derive the list of used assemblies to fetch their entries. We're removing the assembliesRegistry for that reason.