### PR TITLE
Revert "Revert "feat: add validations for pre-binding attributes in component tree nodes [SPA-3201]""

### DIFF
--- a/packages/validators/src/schemas/v2023_09_28/common.ts
+++ b/packages/validators/src/schemas/v2023_09_28/common.ts
@@ -276,6 +276,20 @@ export const ComponentVariableSchema = z.object({
 export const ComponentTreeNodeSchema: z.ZodType<ComponentTreeNode> =
   BaseComponentTreeNodeSchema.extend({
     children: z.lazy(() => ComponentTreeNodeSchema.array()),
+  }).superRefine(({ id, prebindingId, parameters }, ctx) => {
+    if (prebindingId && !parameters) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `Found "prebindingId" but no "parameters" for node with id: "${id}"`,
+      });
+    }
+
+    if (parameters && !prebindingId) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `Found "parameters" but no "prebindingId" for node with id: "${id}"`,
+      });
+    }
   });
 
 export const ComponentTreeSchema = z

--- a/packages/validators/src/validators/tests/componentTree.spec.ts
+++ b/packages/validators/src/validators/tests/componentTree.spec.ts
@@ -551,5 +551,107 @@ describe('componentTree', () => {
         });
       });
     });
+    describe('pre-binding attributes', () => {
+      it(`succeeds if both prebindingId and parameters are present`, () => {
+        const componentTree = experience.fields.componentTree[locale];
+        const child = {
+          id: 'nodeId',
+          definitionId: 'test',
+          variables: {},
+          children: [],
+          prebindingId: 'prebindingId',
+          parameters: {
+            param1: { type: 'BoundValue', path: '/paramKey' },
+          },
+        };
+        const updatedExperience = {
+          ...experience,
+          fields: {
+            ...experience.fields,
+            componentTree: { [locale]: { ...componentTree, children: [child] } },
+          },
+        };
+        const result = validateExperienceFields(updatedExperience, schemaVersion);
+
+        expect(result.success).toBe(true);
+        expect(result.errors).toBeUndefined();
+      });
+      it(`succeeds if parameters is an empty object`, () => {
+        const componentTree = experience.fields.componentTree[locale];
+        const child = {
+          id: 'nodeId',
+          definitionId: 'test',
+          variables: {},
+          children: [],
+          prebindingId: 'prebindingId',
+          parameters: {},
+        };
+        const updatedExperience = {
+          ...experience,
+          fields: {
+            ...experience.fields,
+            componentTree: { [locale]: { ...componentTree, children: [child] } },
+          },
+        };
+        const result = validateExperienceFields(updatedExperience, schemaVersion);
+
+        expect(result.success).toBe(true);
+        expect(result.errors).toBeUndefined();
+      });
+      it(`fails if prebindingId is present but parameters is missing`, () => {
+        const componentTree = experience.fields.componentTree[locale];
+        const child = {
+          id: 'nodeId',
+          definitionId: 'test',
+          variables: {},
+          children: [],
+          prebindingId: 'prebindingId',
+        };
+        const updatedExperience = {
+          ...experience,
+          fields: {
+            ...experience.fields,
+            componentTree: { [locale]: { ...componentTree, children: [child] } },
+          },
+        };
+        const result = validateExperienceFields(updatedExperience, schemaVersion);
+
+        const expectedError = {
+          details: 'Found "prebindingId" but no "parameters" for node with id: "nodeId"',
+          name: 'custom',
+          path: ['componentTree', 'en-US', 'children', '0'],
+        };
+        expect(result.success).toBe(false);
+        expect(result.errors).toEqual([expectedError]);
+      });
+      it(`fails if prebindingId is present but parameters is missing`, () => {
+        const componentTree = experience.fields.componentTree[locale];
+        const child = {
+          id: 'nodeId',
+          definitionId: 'test',
+          variables: {},
+          children: [],
+          parameters: {
+            param1: { type: 'BoundValue', path: '/paramKey' },
+          },
+        };
+        const updatedExperience = {
+          ...experience,
+          fields: {
+            ...experience.fields,
+            componentTree: { [locale]: { ...componentTree, children: [child] } },
+          },
+        };
+        const result = validateExperienceFields(updatedExperience, schemaVersion);
+
+        const expectedError = {
+          details: 'Found "parameters" but no "prebindingId" for node with id: "nodeId"',
+          name: 'custom',
+          path: ['componentTree', 'en-US', 'children', '0'],
+        };
+        expect(result.success).toBe(false);
+        expect(result.errors).toEqual([expectedError]);
+      });
+    });
   });
 });


### PR DESCRIPTION
Revert of revert contentful/experience-builder#1334.

Bring back prebinding validations now that UI is adjusted to respect them: https://github.com/contentful/experience-builder/pull/1328