### PR TITLE
fix: enable debug mode per default for react-vite test app []

### DIFF
--- a/packages/test-apps/react-vite/src/Page.tsx
+++ b/packages/test-apps/react-vite/src/Page.tsx
@@ -94,7 +94,7 @@ export default function Page() {
           Loading additional levels... <sup>(won't trigger on hot-reload)</sup>
         </h3>
       )}
-      <ExperienceRoot experience={experience} locale={localeCode} />
+      <ExperienceRoot experience={experience} locale={localeCode} debug />
     </>
   );
 }


### PR DESCRIPTION
When working with the test app, we always want to have the debug mode enabled.