### PR TITLE
fix: prebinding sdk feature [SPA-3262]

### DIFF
--- a/packages/experience-builder-sdk/src/core/sdkFeatures.ts
+++ b/packages/experience-builder-sdk/src/core/sdkFeatures.ts
@@ -8,4 +8,5 @@ export const sdkFeatures: Record<string, unknown> = {
   patternBreakpointDesignValues: true,
   // DND is moving to the host application enabling smoother native event handling
   dndMigration: true,
+  hasPrebinding: true,
 };


### PR DESCRIPTION
## Purpose

* Adds `hasPrebinding` feature in the SDK, to prevent SDK versions that don't support it to have prebinding available.
* Needs to be merged/released together or after #1326 

https://contentful.atlassian.net/browse/SPA-3262

## Approach

<!--
Remember when merging:
- Use "Squash and merge" when merging changes into development.
- Use "Create a merge commit" when releasing changes into next and main.

Three important notes on pull requests:
- In general, you should ask yourself whether this code change will improve or worsen the overall code quality. Any new tech debt will probably never be cleaned up.
- Please remember that newly introduced logic should be validated and protected through testing.
- Take a look at PR guides:
  Google's Code Review Guidelines: https://google.github.io/eng-practices/
  Blockly - Writing a Good Pull Request: https://developers.google.com/blockly/guides/contribute/get-started/write_a_good_pr
-->
