### PR TITLE
fix: add experience prebiding validations [SPA-3285]

### DIFF
--- a/packages/validators/src/schemas/v2023_09_28/common.ts
+++ b/packages/validators/src/schemas/v2023_09_28/common.ts
@@ -276,6 +276,16 @@ export const ComponentVariableSchema = z.object({
 export const ComponentTreeNodeSchema: z.ZodType<ComponentTreeNode> =
   BaseComponentTreeNodeSchema.extend({
     children: z.lazy(() => ComponentTreeNodeSchema.array()),
+  }).superRefine(({ id, prebindingId, parameters }, ctx) => {
+    // We don't fail if parameters are present but prebindingId is not because
+    // older experiences (updated before 21-09-2025) always included parameters
+    // and they will start failing if we do.
+    if (prebindingId && !parameters) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `Found "prebindingId" but no "parameters" for node with id: "${id}"`,
+      });
+    }
   });
 
 export const ComponentTreeSchema = z

--- a/packages/validators/src/validators/tests/componentTree.spec.ts
+++ b/packages/validators/src/validators/tests/componentTree.spec.ts
@@ -551,5 +551,102 @@ describe('componentTree', () => {
         });
       });
     });
+    describe('pre-binding attributes', () => {
+      it(`succeeds if both prebindingId and parameters are present`, () => {
+        const componentTree = experience.fields.componentTree[locale];
+        const child = {
+          id: 'nodeId',
+          definitionId: 'test',
+          variables: {},
+          children: [],
+          prebindingId: 'prebindingId',
+          parameters: {
+            param1: { type: 'BoundValue', path: '/paramKey' },
+          },
+        };
+        const updatedExperience = {
+          ...experience,
+          fields: {
+            ...experience.fields,
+            componentTree: { [locale]: { ...componentTree, children: [child] } },
+          },
+        };
+        const result = validateExperienceFields(updatedExperience, schemaVersion);
+
+        expect(result.success).toBe(true);
+        expect(result.errors).toBeUndefined();
+      });
+      it(`succeeds if parameters is an empty object`, () => {
+        const componentTree = experience.fields.componentTree[locale];
+        const child = {
+          id: 'nodeId',
+          definitionId: 'test',
+          variables: {},
+          children: [],
+          prebindingId: 'prebindingId',
+          parameters: {},
+        };
+        const updatedExperience = {
+          ...experience,
+          fields: {
+            ...experience.fields,
+            componentTree: { [locale]: { ...componentTree, children: [child] } },
+          },
+        };
+        const result = validateExperienceFields(updatedExperience, schemaVersion);
+
+        expect(result.success).toBe(true);
+        expect(result.errors).toBeUndefined();
+      });
+      it(`fails if prebindingId is present but parameters is missing`, () => {
+        const componentTree = experience.fields.componentTree[locale];
+        const child = {
+          id: 'nodeId',
+          definitionId: 'test',
+          variables: {},
+          children: [],
+          prebindingId: 'prebindingId',
+        };
+        const updatedExperience = {
+          ...experience,
+          fields: {
+            ...experience.fields,
+            componentTree: { [locale]: { ...componentTree, children: [child] } },
+          },
+        };
+        const result = validateExperienceFields(updatedExperience, schemaVersion);
+
+        const expectedError = {
+          details: 'Found "prebindingId" but no "parameters" for node with id: "nodeId"',
+          name: 'custom',
+          path: ['componentTree', 'en-US', 'children', '0'],
+        };
+        expect(result.success).toBe(false);
+        expect(result.errors).toEqual([expectedError]);
+      });
+      it(`does not fail if parameters is present but prebindingId is missing`, () => {
+        const componentTree = experience.fields.componentTree[locale];
+        const child = {
+          id: 'nodeId',
+          definitionId: 'test',
+          variables: {},
+          children: [],
+          parameters: {
+            param1: { type: 'BoundValue', path: '/paramKey' },
+          },
+        };
+        const updatedExperience = {
+          ...experience,
+          fields: {
+            ...experience.fields,
+            componentTree: { [locale]: { ...componentTree, children: [child] } },
+          },
+        };
+        const result = validateExperienceFields(updatedExperience, schemaVersion);
+
+        expect(result.success).toBe(true);
+        expect(result.errors).toBeUndefined();
+      });
+    });
   });
 });


### PR DESCRIPTION
## Purpose

* Add validation for Experiences to ensure that when `prebindingId` is present, `parameters` are also present.
* We don't throw an error if `parameters` are present but `prebindingId` is not as older experiences were always including `parameters: {}`.

https://contentful.atlassian.net/browse/SPA-3285

## Approach

<!--
Remember when merging:
- Use "Squash and merge" when merging changes into development.
- Use "Create a merge commit" when releasing changes into next and main.

Three important notes on pull requests:
- In general, you should ask yourself whether this code change will improve or worsen the overall code quality. Any new tech debt will probably never be cleaned up.
- Please remember that newly introduced logic should be validated and protected through testing.
- Take a look at PR guides:
  Google's Code Review Guidelines: https://google.github.io/eng-practices/
  Blockly - Writing a Good Pull Request: https://developers.google.com/blockly/guides/contribute/get-started/write_a_good_pr
-->
