### PR TITLE
fix: Pattern editor crashes [temp fix] (SPA-3212)

### DIFF
--- a/packages/visual-editor/src/components/EditorBlock/useComponentProps.ts
+++ b/packages/visual-editor/src/components/EditorBlock/useComponentProps.ts
@@ -139,8 +139,10 @@ export const useComponentProps = ({
           const [, uuid, maybePath] = variableMapping.path.split('/');
           const link = dataSource[uuid] as Link<'Entry' | 'Asset'>;
 
+          // starting from here, if the prop is of type 'BoundValue', and has prebinding
+          // we are going to resolve the incomplete path
           let boundValue: ReturnType<typeof transformBoundContentValue>;
-          // TODO: Temporary fix while we look into SPA-3212 it occurs where we ahve prebound props but data source link is missing
+          // TODO: Temporary fix while we look into SPA-3212 it occurs where we have prebound props but data source link is missing
           // this only occurs after live updates of nested patterns.
           if (!link && isPreboundProp(variableMapping) && variableMapping.isPrebound) {
             return {


### PR DESCRIPTION
## Pattern editor crashes on save

This change introduces a temporary workaround to prevent the error found in SPA-3212, which occurs when saving a Template pattern after removing content types from a Nested child pattern in another browser tab.

Rather than resolving the underlying data inconsistency, this update simply prevents the error from being thrown. A manual refresh will restore a valid state, but the inconsistency in preview data will persist.

The root cause will be addressed in a follow-up fix. Once that is in place, this temporary handling can be safely removed.

Ticket: https://contentful.atlassian.net/browse/SPA-3212