### PR TITLE
fix(styles): emit display:none for all breakpoints when visibility is hidden on default only

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -74,6 +74,7 @@
       "version": "1.21.1",
       "resolved": "https://registry.npmjs.org/@ant-design/cssinjs/-/cssinjs-1.21.1.tgz",
       "integrity": "sha512-tyWnlK+XH7Bumd0byfbCiZNK43HEubMoCcu9VxwsAwiHdHTgWa+tMN0/yvxa+e8EzuFP1WdUNNPclRpVtD33lg==",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.11.1",
         "@emotion/hash": "^0.8.0",
@@ -418,6 +419,7 @@
       "version": "7.25.2",
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.25.2.tgz",
       "integrity": "sha512-BBt3opiCOxUr9euZ5/ro/Xv8/V7yJ5bjYMqG/C1YAo8MIKAnumZalCN+msbci3Pigy4lIQfPUpfMM27HMGaYEA==",
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.24.7",
@@ -3828,7 +3830,7 @@
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.8.1.tgz",
       "integrity": "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.4.0"
@@ -4029,7 +4031,6 @@
       "os": [
         "aix"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -4046,7 +4047,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -4063,7 +4063,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -4080,7 +4079,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -4097,7 +4095,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -4114,7 +4111,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -4131,7 +4127,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -4148,7 +4143,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -4165,7 +4159,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -4182,7 +4175,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -4199,7 +4191,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -4216,7 +4207,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -4233,7 +4223,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -4250,7 +4239,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -4267,7 +4255,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -4284,7 +4271,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -4301,7 +4287,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -4318,7 +4303,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -4335,7 +4319,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -4352,7 +4335,6 @@
       "os": [
         "sunos"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -4369,7 +4351,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -4386,7 +4367,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -4403,7 +4383,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -4764,6 +4743,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4786,6 +4766,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4808,6 +4789,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -4824,6 +4806,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -4840,6 +4823,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -4856,6 +4840,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -4872,6 +4857,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -4888,6 +4874,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -4904,6 +4891,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -4920,6 +4908,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -4936,6 +4925,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -4952,6 +4942,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -4968,6 +4959,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4990,6 +4982,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -5012,6 +5005,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -5034,6 +5028,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -5056,6 +5051,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -5078,6 +5074,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -5100,6 +5097,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -5122,6 +5120,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -5144,6 +5143,7 @@
       "cpu": [
         "wasm32"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
       "dependencies": {
@@ -5163,6 +5163,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -5182,6 +5183,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -5201,6 +5203,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -5811,6 +5814,7 @@
       "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.7.0.tgz",
       "integrity": "sha512-ok/BTPFzFKVMwO5eOHRrvnBVHdRy9IrsrW1GpMaQ9MCnilNLXQKmAX8s1YXDFaai9xJpac2ySzV0YeRRECr2Vw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@babel/core": "^7.11.6",
         "@jest/types": "^29.6.3",
@@ -5886,6 +5890,7 @@
       "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
       "deprecated": "Glob versions prior to v9 are no longer supported",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -6295,6 +6300,7 @@
       "integrity": "sha512-/g2d4sW9nUDJOMz3mabVQvOGhVa4e/BN/Um7yca9Bb2XTzPPnfTWHWQg+IsEYO7M3Vx+EXvaM/I2pJWIMun1bg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^4.0.0",
         "@octokit/graphql": "^7.1.0",
@@ -6735,6 +6741,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@napi-rs/wasm-runtime": "0.2.4",
         "@yarnpkg/lockfile": "^1.1.0",
@@ -7204,6 +7211,7 @@
       "version": "15.5.10",
       "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.10.tgz",
       "integrity": "sha512-plg+9A/KoZcTS26fe15LHg+QxReTazrIOoKKUC3Uz4leGGeNPgLHdevVraAAOX0snnUs3WkRx3eUQpj9mreG6A==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
@@ -7262,6 +7270,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7278,6 +7287,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7294,6 +7304,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7310,6 +7321,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7326,6 +7338,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7342,6 +7355,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7358,6 +7372,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7374,6 +7389,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7958,6 +7974,7 @@
       "resolved": "https://registry.npmjs.org/@octokit/core/-/core-3.6.0.tgz",
       "integrity": "sha512-7RKRKuA4xTjMhY+eG3jthb3hlZCsOwg3rztWh75Xc+ShDWOfDDATWbeZpAHBNRpm4Tv9WgBMOy1zEJYXG6NJ7Q==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^2.4.4",
         "@octokit/graphql": "^4.5.8",
@@ -8170,6 +8187,7 @@
       "version": "2.11.8",
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
       "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
@@ -9800,8 +9818,7 @@
       "optional": true,
       "os": [
         "android"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
       "version": "4.22.4",
@@ -9814,8 +9831,7 @@
       "optional": true,
       "os": [
         "android"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
       "version": "4.22.4",
@@ -9828,8 +9844,7 @@
       "optional": true,
       "os": [
         "darwin"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
       "version": "4.22.4",
@@ -9842,8 +9857,7 @@
       "optional": true,
       "os": [
         "darwin"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
       "version": "4.22.4",
@@ -9856,8 +9870,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
       "version": "4.22.4",
@@ -9870,8 +9883,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
       "version": "4.22.4",
@@ -9884,8 +9896,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
       "version": "4.22.4",
@@ -9898,8 +9909,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
       "version": "4.22.4",
@@ -9912,8 +9922,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
       "version": "4.22.4",
@@ -9926,8 +9935,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
       "version": "4.22.4",
@@ -9940,8 +9948,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
       "version": "4.22.4",
@@ -9966,8 +9973,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
       "version": "4.22.4",
@@ -9980,8 +9986,7 @@
       "optional": true,
       "os": [
         "win32"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
       "version": "4.22.4",
@@ -9994,8 +9999,7 @@
       "optional": true,
       "os": [
         "win32"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
       "version": "4.22.4",
@@ -10008,8 +10012,7 @@
       "optional": true,
       "os": [
         "win32"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
@@ -10284,6 +10287,7 @@
       "resolved": "https://registry.npmjs.org/@octokit/core/-/core-5.2.0.tgz",
       "integrity": "sha512-1LFfa/qnMQvEOAdzlQymH0ulepxbxnCYAKJZfMci/5XJyIHWgEYnDmgnKakbTh7CH2tFQ5O60oYDvns4i9RAIg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^4.0.0",
         "@octokit/graphql": "^7.1.0",
@@ -11382,6 +11386,7 @@
       "version": "7.6.20",
       "resolved": "https://registry.npmjs.org/@storybook/blocks/-/blocks-7.6.20.tgz",
       "integrity": "sha512-xADKGEOJWkG0UD5jbY4mBXRlmj2C+CIupDL0/hpzvLvwobxBMFPKZIkcZIMvGvVnI/Ui+tJxQxLSuJ5QsPthUw==",
+      "peer": true,
       "dependencies": {
         "@storybook/channels": "7.6.20",
         "@storybook/client-logger": "7.6.20",
@@ -12100,6 +12105,7 @@
       "version": "7.6.20",
       "resolved": "https://registry.npmjs.org/@storybook/components/-/components-7.6.20.tgz",
       "integrity": "sha512-0d8u4m558R+W5V+rseF/+e9JnMciADLXTpsILrG+TBhwECk0MctIWW18bkqkujdCm8kDZr5U2iM/5kS1Noy7Ug==",
+      "peer": true,
       "dependencies": {
         "@radix-ui/react-select": "^1.2.2",
         "@radix-ui/react-toolbar": "^1.0.4",
@@ -12552,6 +12558,7 @@
       "version": "7.6.20",
       "resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-7.6.20.tgz",
       "integrity": "sha512-tlVDuVbDiNkvPDFAu+0ou3xBBYbx9zUURQz4G9fAq0ScgBOs/bpzcRrFb4mLpemUViBAd47tfZKdH4MAX45KVQ==",
+      "peer": true,
       "dependencies": {
         "ts-dedent": "^2.0.0"
       },
@@ -12732,6 +12739,7 @@
       "version": "7.6.20",
       "resolved": "https://registry.npmjs.org/@storybook/manager-api/-/manager-api-7.6.20.tgz",
       "integrity": "sha512-gOB3m8hO3gBs9cBoN57T7jU0wNKDh+hi06gLcyd2awARQlAlywnLnr3s1WH5knih6Aq+OpvGBRVKkGLOkaouCQ==",
+      "peer": true,
       "dependencies": {
         "@storybook/channels": "7.6.20",
         "@storybook/client-logger": "7.6.20",
@@ -12792,6 +12800,7 @@
       "version": "7.6.20",
       "resolved": "https://registry.npmjs.org/@storybook/preview-api/-/preview-api-7.6.20.tgz",
       "integrity": "sha512-3ic2m9LDZEPwZk02wIhNc3n3rNvbi7VDKn52hDXfAxnL5EYm7yDICAkaWcVaTfblru2zn0EDJt7ROpthscTW5w==",
+      "peer": true,
       "dependencies": {
         "@storybook/channels": "7.6.20",
         "@storybook/client-logger": "7.6.20",
@@ -13004,6 +13013,7 @@
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-8.20.1.tgz",
       "integrity": "sha512-/DiOQ5xBxgdYRC8LNk7U+RWat0S3qRLeIw3ZIkMQ9kkVlRmwD/Eg8k8CqIpD6GW7u20JIUOfMKbxtiLutpjQ4g==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -13047,6 +13057,7 @@
       "version": "7.6.20",
       "resolved": "https://registry.npmjs.org/@storybook/theming/-/theming-7.6.20.tgz",
       "integrity": "sha512-iT1pXHkSkd35JsCte6Qbanmprx5flkqtSHC6Gi6Umqoxlg9IjiLPmpHbaIXzoC06DSW93hPj5Zbi1lPlTvRC7Q==",
+      "peer": true,
       "dependencies": {
         "@emotion/use-insertion-effect-with-fallbacks": "^1.0.0",
         "@storybook/client-logger": "7.6.20",
@@ -13066,6 +13077,7 @@
       "version": "7.6.20",
       "resolved": "https://registry.npmjs.org/@storybook/types/-/types-7.6.20.tgz",
       "integrity": "sha512-GncdY3x0LpbhmUAAJwXYtJDUQEwfF175gsjH0/fxPkxPoV7Sef9TM41jQLJW/5+6TnZoCZP/+aJZTJtq3ni23Q==",
+      "peer": true,
       "dependencies": {
         "@storybook/channels": "7.6.20",
         "@types/babel__core": "^7.0.0",
@@ -13226,6 +13238,7 @@
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/@svgr/core/-/core-8.1.0.tgz",
       "integrity": "sha512-8QqtOQT5ACVlmsvKOJNEaWmRPmcojMOzCz4Hs2BGG/toAp/K38LcsMRyLp349glq5AzJbCEeimEoxaX6v/fLrA==",
+      "peer": true,
       "dependencies": {
         "@babel/core": "^7.21.3",
         "@svgr/babel-preset": "8.1.0",
@@ -13350,6 +13363,7 @@
       "integrity": "sha512-XapcMgsOS0cKh01AFEj+qXOk6KM4NZhp7a5vPicdhkRR8RzvjrCa7DTtijMxfotU8bqaEHguxmiIag2HUlT8QQ==",
       "dev": true,
       "hasInstallScript": true,
+      "peer": true,
       "dependencies": {
         "@swc/counter": "^0.1.3",
         "@swc/types": "^0.1.12"
@@ -13394,7 +13408,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -13411,7 +13424,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -13428,7 +13440,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -13445,7 +13456,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -13462,7 +13472,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -13479,7 +13488,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -13496,7 +13504,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -13513,7 +13520,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -13530,7 +13536,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -13547,7 +13552,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -13581,6 +13585,7 @@
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.0.tgz",
       "integrity": "sha512-pemlzrSESWbdAloYml3bAJMEfNh1Z7EduzqPKprCH5S341frlpYnUEW0H72dLxa6IsYr+mPno20GiSm+h9dEdQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -14181,6 +14186,7 @@
       "version": "18.3.9",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.9.tgz",
       "integrity": "sha512-+BpAVyTpJkNWWSSnaLBk6ePpHLOGJKnEQNbINNovPWzvEUyAe3e+/d494QdEh71RekM/qV7lw6jzf1HGrJyAtQ==",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -14191,6 +14197,7 @@
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.0.tgz",
       "integrity": "sha512-EhwApuTmMBmXuFOikhQLIBUn6uFg81SwLMOAUgodJF14SOBOCMdU04gDoYi0WOJJHD144TL32z4yDqCW3dnkQg==",
       "devOptional": true,
+      "peer": true,
       "dependencies": {
         "@types/react": "*"
       }
@@ -14986,6 +14993,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
       "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
       "dev": true,
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -15127,6 +15135,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -15240,6 +15249,7 @@
       "version": "5.22.2",
       "resolved": "https://registry.npmjs.org/antd/-/antd-5.22.2.tgz",
       "integrity": "sha512-vihhiJbm9VG3d6boUeD1q2MXMax+qBrXhgqCEC+45v8iGUF6m4Ct+lFiCW4oWaN3EABOsbVA6Svy3Rj/QkQFKw==",
+      "peer": true,
       "dependencies": {
         "@ant-design/colors": "^7.1.0",
         "@ant-design/cssinjs": "^1.21.1",
@@ -15888,6 +15898,7 @@
       "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.7.0.tgz",
       "integrity": "sha512-BrvGY3xZSwEcCzKvKsCi2GgHqDqsYkOP4/by5xCgIwGXQxIEh+8ew3gmrE1y7XRR6LHZIj6yLYnUi/mm2KXKBg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@jest/transform": "^29.7.0",
         "@types/babel__core": "^7.1.14",
@@ -16629,6 +16640,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001735",
         "electron-to-chromium": "^1.5.204",
@@ -19106,6 +19118,7 @@
       "version": "8.3.6",
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.3.6.tgz",
       "integrity": "sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==",
+      "peer": true,
       "dependencies": {
         "import-fresh": "^3.3.0",
         "js-yaml": "^4.1.0",
@@ -19815,6 +19828,7 @@
       "version": "2.30.0",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
       "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.21.0"
       },
@@ -20734,29 +20748,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/encoding": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
-      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "iconv-lite": "^0.6.2"
-      }
-    },
-    "node_modules/encoding/node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/end-of-stream": {
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
@@ -21195,6 +21186,7 @@
       "integrity": "sha512-aARqgq8roFBj054KvQr5f1sFu0D65G+miZRCuJyJ0G13Zwx7vRar5Zhn2tkQNzIXcBrNVsv/8stehpj+GAjgbg==",
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -23085,7 +23077,8 @@
       "version": "2.16.9",
       "resolved": "https://registry.npmjs.org/fp-ts/-/fp-ts-2.16.9.tgz",
       "integrity": "sha512-+I2+FnVB+tVaxcYyQkHUq7ZdKScaBlX53A41mxQtpIccsfyv8PzdzP7fzp2AY832T4aoK6UZ5WRX/ebGd8uZuQ==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "node_modules/fragment-cache": {
       "version": "0.2.1",
@@ -25936,6 +25929,7 @@
       "resolved": "https://registry.npmjs.org/jest/-/jest-29.7.0.tgz",
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -27131,6 +27125,7 @@
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.6.tgz",
       "integrity": "sha512-2yTgeWTWzMWkHu6Jp9NKgePDaYHbntiwvYuuJLbbN9vl7DC9DvXKOB2BC3ZZ92D3cvV/aflH0osDfwpHepQ53w==",
       "dev": true,
+      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -27887,6 +27882,7 @@
       "integrity": "sha512-/g2d4sW9nUDJOMz3mabVQvOGhVa4e/BN/Um7yca9Bb2XTzPPnfTWHWQg+IsEYO7M3Vx+EXvaM/I2pJWIMun1bg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^4.0.0",
         "@octokit/graphql": "^7.1.0",
@@ -28366,6 +28362,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@napi-rs/wasm-runtime": "0.2.4",
         "@yarnpkg/lockfile": "^1.1.0",
@@ -29720,6 +29717,7 @@
       "resolved": "https://registry.npmjs.org/marked/-/marked-12.0.2.tgz",
       "integrity": "sha512-qXUm7e/YKFoqFPYPa3Ukg9xlI5cyAtGmyEIzMfW//m6kXwCy2Ps9DYf5ioijFKQ8qyuscrHoY04iJGctu2Kg0Q==",
       "dev": true,
+      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -30429,6 +30427,7 @@
       "version": "15.5.10",
       "resolved": "https://registry.npmjs.org/next/-/next-15.5.10.tgz",
       "integrity": "sha512-r0X65PNwyDDyOrWNKpQoZvOatw7BcsTPRKdwEqtc9cj3wv7mbBIk9tKed4klRaFXJdX0rugpuMTHslDrAU1bBg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@next/env": "15.5.10",
@@ -30481,6 +30480,7 @@
       "version": "8.4.31",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
       "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -35168,6 +35168,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.7",
         "picocolors": "^1.1.0",
@@ -37139,6 +37140,7 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -37246,6 +37248,7 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -38757,6 +38760,7 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.22.4.tgz",
       "integrity": "sha512-vD8HJ5raRcWOyymsR6Z3o6+RzfEPCnVLMFJ6vRslO1jt4LO6dUo5Qnpg7y4RkZFM2DMe3WUirkI5c16onjrc6A==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.5"
       },
@@ -39172,6 +39176,7 @@
       "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-23.0.2.tgz",
       "integrity": "sha512-OnVYJ6Xgzwe1x8MKswba7RU9+5djS1MWRTrTn5qsq3xZYpslroZkV9Pt0dA2YcIuieeuSZWJhn+yUWoBUHO5Fw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@semantic-release/commit-analyzer": "^11.0.0",
         "@semantic-release/error": "^4.0.0",
@@ -41707,6 +41712,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -42846,6 +42852,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.2.tgz",
       "integrity": "sha512-NW8ByodCSNCwZeghjN3o+JX5OFH0Ojg6sadjEKY4huZ52TqbJTJnDo5+Tw98lSy63NZvi4n+ez5m2u5d4PkZyw==",
       "devOptional": true,
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -42915,6 +42922,7 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.7.0.tgz",
       "integrity": "sha512-lN0btVpj2unxHlNYLI//BQ7nzbMJYBVQX5+pbNXvGYazdlgYonMn4AhhHifQ+J4fGRYA/m1DjaQjx+fDetqBOQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.7.0",
         "@typescript-eslint/types": "8.7.0",
@@ -43696,6 +43704,7 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.8.tgz",
       "integrity": "sha512-FqrItQ4DT1NC4zCUqMB4c4AZORMKIa0m8/URVCZ77OZ/QSNeJ54bU1vrFADbDsuwfIPcgknRkmqakQcgnL4GiQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",
@@ -43855,7 +43864,6 @@
       "os": [
         "aix"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -43872,7 +43880,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -43889,7 +43896,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -43906,7 +43912,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -43923,7 +43928,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -43940,7 +43944,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -43957,7 +43960,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -43974,7 +43976,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -43991,7 +43992,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -44008,7 +44008,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -44025,7 +44024,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -44042,7 +44040,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -44059,7 +44056,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -44076,7 +44072,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -44093,7 +44088,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -44110,7 +44104,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -44127,7 +44120,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -44144,7 +44136,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -44161,7 +44152,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -44178,7 +44168,6 @@
       "os": [
         "sunos"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -44195,7 +44184,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -44212,7 +44200,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -44229,7 +44216,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -44277,6 +44263,7 @@
       "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.1.tgz",
       "integrity": "sha512-97We7/VC0e9X5zBVkvt7SGQMGrRtn3KtySFQG5fpaMlS+l62eeXRQO633AYhSTC3z7IMebnPPNjGXVGNRFlxBA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "2.1.1",
         "@vitest/mocker": "2.1.1",
@@ -45749,7 +45736,7 @@
         "@svgr/webpack": "^8.1.0",
         "antd": "^5.22.2",
         "contentful": "^11.0.2",
-        "next": "15.5.14",
+        "next": "15.5.18",
         "next-i18n-router": "^5.5.0",
         "react": "^18",
         "react-dom": "^18"
@@ -45777,15 +45764,15 @@
       }
     },
     "packages/templates/nextjs-marketing-demo/node_modules/@next/env": {
-      "version": "15.5.14",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.14.tgz",
-      "integrity": "sha512-aXeirLYuASxEgi4X4WhfXsShCFxWDfNn/8ZeC5YXAS2BB4A8FJi1kwwGL6nvMVboE7fZCzmJPNdMvVHc8JpaiA==",
+      "version": "15.5.18",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.18.tgz",
+      "integrity": "sha512-hAV85Ckd9QR6RvH04MEKwsfLTksvFpO47j9xwtoIuvuPnlwecpSi+uZTtm8HirVbtlI2Fnz//xpcSTjFdyJk+g==",
       "license": "MIT"
     },
     "packages/templates/nextjs-marketing-demo/node_modules/@next/swc-darwin-arm64": {
-      "version": "15.5.14",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.5.14.tgz",
-      "integrity": "sha512-Y9K6SPzobnZvrRDPO2s0grgzC+Egf0CqfbdvYmQVaztV890zicw8Z8+4Vqw8oPck8r1TjUHxVh8299Cg4TrxXg==",
+      "version": "15.5.18",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.5.18.tgz",
+      "integrity": "sha512-w0WvQf1n+txiwns/9pwIQteCJpZTbxzO2SE0FLcwuD4v0WEh1JPOjdyxWL21XwJsdpx8cFRjyzxzCS/siP7HcQ==",
       "cpu": [
         "arm64"
       ],
@@ -45799,9 +45786,9 @@
       }
     },
     "packages/templates/nextjs-marketing-demo/node_modules/@next/swc-darwin-x64": {
-      "version": "15.5.14",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.5.14.tgz",
-      "integrity": "sha512-aNnkSMjSFRTOmkd7qoNI2/rETQm/vKD6c/Ac9BZGa9CtoOzy3c2njgz7LvebQJ8iPxdeTuGnAjagyis8a9ifBw==",
+      "version": "15.5.18",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.5.18.tgz",
+      "integrity": "sha512-znn71QmDuxm+BOaglihMZfvyySMnNljkVIY5Z2TCssBmm+WqL6c19VhtH5ktFkHa8EZ2bnTUpcNcmNSQsg67og==",
       "cpu": [
         "x64"
       ],
@@ -45815,9 +45802,9 @@
       }
     },
     "packages/templates/nextjs-marketing-demo/node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "15.5.14",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.5.14.tgz",
-      "integrity": "sha512-tjlpia+yStPRS//6sdmlVwuO1Rioern4u2onafa5n+h2hCS9MAvMXqpVbSrjgiEOoCs0nJy7oPOmWgtRRNSM5Q==",
+      "version": "15.5.18",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.5.18.tgz",
+      "integrity": "sha512-yPPe5MNL+igZUa+OsqQJisqSfh6oarIuA1Q0BDxljGJhRQyZeP+WRHh7rs/jZUGMh5aY0YdIjXZG0VohkKkUdw==",
       "cpu": [
         "arm64"
       ],
@@ -45831,9 +45818,9 @@
       }
     },
     "packages/templates/nextjs-marketing-demo/node_modules/@next/swc-linux-arm64-musl": {
-      "version": "15.5.14",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.5.14.tgz",
-      "integrity": "sha512-8B8cngBaLadl5lbDRdxGCP1Lef8ipD6KlxS3v0ElDAGil6lafrAM3B258p1KJOglInCVFUjk751IXMr2ixeQOQ==",
+      "version": "15.5.18",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.5.18.tgz",
+      "integrity": "sha512-glaCczEWIrHsokFZ3pP08U4BpKxwIdnT+txdOM32OBgpL9Yw4aqx8NejmgtZQZOdstQ5f0L3CasIZudzCuD+nw==",
       "cpu": [
         "arm64"
       ],
@@ -45847,9 +45834,9 @@
       }
     },
     "packages/templates/nextjs-marketing-demo/node_modules/@next/swc-linux-x64-gnu": {
-      "version": "15.5.14",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.5.14.tgz",
-      "integrity": "sha512-bAS6tIAg8u4Gn3Nz7fCPpSoKAexEt2d5vn1mzokcqdqyov6ZJ6gu6GdF9l8ORFrBuRHgv3go/RfzYz5BkZ6YSQ==",
+      "version": "15.5.18",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.5.18.tgz",
+      "integrity": "sha512-oUfg2EgJmU3R0OCOWiokGFUTvZiPfXtriXiuF3YNxRoROCdgvTedHIzYoeKH34gsZxS/V7mHbfq2hpAHwhH1/A==",
       "cpu": [
         "x64"
       ],
@@ -45863,9 +45850,9 @@
       }
     },
     "packages/templates/nextjs-marketing-demo/node_modules/@next/swc-linux-x64-musl": {
-      "version": "15.5.14",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.5.14.tgz",
-      "integrity": "sha512-mMxv/FcrT7Gfaq4tsR22l17oKWXZmH/lVqcvjX0kfp5I0lKodHYLICKPoX1KRnnE+ci6oIUdriUhuA3rBCDiSw==",
+      "version": "15.5.18",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.5.18.tgz",
+      "integrity": "sha512-JLxSP3KTd9iu/bvUMQxH7RJo9xKSHf55/6RPE4a6FTSZygGn7uvZbCej0AHXydwkggQGSD9UddSjwv6Xz5ESfA==",
       "cpu": [
         "x64"
       ],
@@ -45879,9 +45866,9 @@
       }
     },
     "packages/templates/nextjs-marketing-demo/node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "15.5.14",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.5.14.tgz",
-      "integrity": "sha512-OTmiBlYThppnvnsqx0rBqjDRemlmIeZ8/o4zI7veaXoeO1PVHoyj2lfTfXTiiGjCyRDhA10y4h6ZvZvBiynr2g==",
+      "version": "15.5.18",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.5.18.tgz",
+      "integrity": "sha512-ir1v7enP52K2HNz3tQQvwF+x7VNxBk1ciiZ18WBPvxf4C59IqdfmHPJYK3vH7rSxpuCVw/8C712wTXNAtEp+NA==",
       "cpu": [
         "arm64"
       ],
@@ -45895,9 +45882,9 @@
       }
     },
     "packages/templates/nextjs-marketing-demo/node_modules/@next/swc-win32-x64-msvc": {
-      "version": "15.5.14",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.5.14.tgz",
-      "integrity": "sha512-+W7eFf3RS7m4G6tppVTOSyP9Y6FsJXfOuKzav1qKniiFm3KFByQfPEcouHdjlZmysl4zJGuGLQ/M9XyVeyeNEg==",
+      "version": "15.5.18",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.5.18.tgz",
+      "integrity": "sha512-LIu5me6QTANCd25E7I5uIEfvgQ06RK7tvHAbYo3zCb3VpxQEPvMcSpd87NwUABDT6MbGPdEGR5VRiK4PPTJhQg==",
       "cpu": [
         "x64"
       ],
@@ -45911,12 +45898,13 @@
       }
     },
     "packages/templates/nextjs-marketing-demo/node_modules/next": {
-      "version": "15.5.14",
-      "resolved": "https://registry.npmjs.org/next/-/next-15.5.14.tgz",
-      "integrity": "sha512-M6S+4JyRjmKic2Ssm7jHUPkE6YUJ6lv4507jprsSZLulubz0ihO2E+S4zmQK3JZ2ov81JrugukKU4Tz0ivgqqQ==",
+      "version": "15.5.18",
+      "resolved": "https://registry.npmjs.org/next/-/next-15.5.18.tgz",
+      "integrity": "sha512-eKL8zUJkX9Y5lE+RX/2YJoItVdGlIscyVyboeD9wSpp0PaGqjoA4tTpT2qPqz9ax+5IzGESyLSeZ/RCwbSZ2uQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
-        "@next/env": "15.5.14",
+        "@next/env": "15.5.18",
         "@swc/helpers": "0.5.15",
         "caniuse-lite": "^1.0.30001579",
         "postcss": "8.4.31",
@@ -45929,14 +45917,14 @@
         "node": "^18.18.0 || ^19.8.0 || >= 20.0.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "15.5.14",
-        "@next/swc-darwin-x64": "15.5.14",
-        "@next/swc-linux-arm64-gnu": "15.5.14",
-        "@next/swc-linux-arm64-musl": "15.5.14",
-        "@next/swc-linux-x64-gnu": "15.5.14",
-        "@next/swc-linux-x64-musl": "15.5.14",
-        "@next/swc-win32-arm64-msvc": "15.5.14",
-        "@next/swc-win32-x64-msvc": "15.5.14",
+        "@next/swc-darwin-arm64": "15.5.18",
+        "@next/swc-darwin-x64": "15.5.18",
+        "@next/swc-linux-arm64-gnu": "15.5.18",
+        "@next/swc-linux-arm64-musl": "15.5.18",
+        "@next/swc-linux-x64-gnu": "15.5.18",
+        "@next/swc-linux-x64-musl": "15.5.18",
+        "@next/swc-win32-arm64-msvc": "15.5.18",
+        "@next/swc-win32-x64-msvc": "15.5.18",
         "sharp": "^0.34.3"
       },
       "peerDependencies": {
@@ -46118,6 +46106,7 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.11.1.tgz",
       "integrity": "sha512-MobhYKIoAO1s1e4VUrgx1l1Sk2JBR/Gqjjgw8+mfgoLE2xwsHur4gdfTxyTgShrhvdVFTaJSgMiQBl1jv/AWxg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.11.0",
@@ -46291,7 +46280,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@contentful/experiences-sdk-react": "file:../../experience-builder-sdk",
-        "next": "15.5.10",
+        "next": "15.5.18",
         "react": "^18",
         "react-dom": "^18"
       },
@@ -46306,6 +46295,12 @@
         "typescript": "^5"
       }
     },
+    "packages/test-apps/nextjs/node_modules/@next/env": {
+      "version": "15.5.18",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.18.tgz",
+      "integrity": "sha512-hAV85Ckd9QR6RvH04MEKwsfLTksvFpO47j9xwtoIuvuPnlwecpSi+uZTtm8HirVbtlI2Fnz//xpcSTjFdyJk+g==",
+      "license": "MIT"
+    },
     "packages/test-apps/nextjs/node_modules/@next/eslint-plugin-next": {
       "version": "14.2.4",
       "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-14.2.4.tgz",
@@ -46313,6 +46308,134 @@
       "dev": true,
       "dependencies": {
         "glob": "10.3.10"
+      }
+    },
+    "packages/test-apps/nextjs/node_modules/@next/swc-darwin-arm64": {
+      "version": "15.5.18",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.5.18.tgz",
+      "integrity": "sha512-w0WvQf1n+txiwns/9pwIQteCJpZTbxzO2SE0FLcwuD4v0WEh1JPOjdyxWL21XwJsdpx8cFRjyzxzCS/siP7HcQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "packages/test-apps/nextjs/node_modules/@next/swc-darwin-x64": {
+      "version": "15.5.18",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.5.18.tgz",
+      "integrity": "sha512-znn71QmDuxm+BOaglihMZfvyySMnNljkVIY5Z2TCssBmm+WqL6c19VhtH5ktFkHa8EZ2bnTUpcNcmNSQsg67og==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "packages/test-apps/nextjs/node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "15.5.18",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.5.18.tgz",
+      "integrity": "sha512-yPPe5MNL+igZUa+OsqQJisqSfh6oarIuA1Q0BDxljGJhRQyZeP+WRHh7rs/jZUGMh5aY0YdIjXZG0VohkKkUdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "packages/test-apps/nextjs/node_modules/@next/swc-linux-arm64-musl": {
+      "version": "15.5.18",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.5.18.tgz",
+      "integrity": "sha512-glaCczEWIrHsokFZ3pP08U4BpKxwIdnT+txdOM32OBgpL9Yw4aqx8NejmgtZQZOdstQ5f0L3CasIZudzCuD+nw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "packages/test-apps/nextjs/node_modules/@next/swc-linux-x64-gnu": {
+      "version": "15.5.18",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.5.18.tgz",
+      "integrity": "sha512-oUfg2EgJmU3R0OCOWiokGFUTvZiPfXtriXiuF3YNxRoROCdgvTedHIzYoeKH34gsZxS/V7mHbfq2hpAHwhH1/A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "packages/test-apps/nextjs/node_modules/@next/swc-linux-x64-musl": {
+      "version": "15.5.18",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.5.18.tgz",
+      "integrity": "sha512-JLxSP3KTd9iu/bvUMQxH7RJo9xKSHf55/6RPE4a6FTSZygGn7uvZbCej0AHXydwkggQGSD9UddSjwv6Xz5ESfA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "packages/test-apps/nextjs/node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "15.5.18",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.5.18.tgz",
+      "integrity": "sha512-ir1v7enP52K2HNz3tQQvwF+x7VNxBk1ciiZ18WBPvxf4C59IqdfmHPJYK3vH7rSxpuCVw/8C712wTXNAtEp+NA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "packages/test-apps/nextjs/node_modules/@next/swc-win32-x64-msvc": {
+      "version": "15.5.18",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.5.18.tgz",
+      "integrity": "sha512-LIu5me6QTANCd25E7I5uIEfvgQ06RK7tvHAbYo3zCb3VpxQEPvMcSpd87NwUABDT6MbGPdEGR5VRiK4PPTJhQg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
       }
     },
     "packages/test-apps/nextjs/node_modules/@typescript-eslint/parser": {
@@ -46499,11 +46622,62 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "packages/test-apps/nextjs/node_modules/next": {
+      "version": "15.5.18",
+      "resolved": "https://registry.npmjs.org/next/-/next-15.5.18.tgz",
+      "integrity": "sha512-eKL8zUJkX9Y5lE+RX/2YJoItVdGlIscyVyboeD9wSpp0PaGqjoA4tTpT2qPqz9ax+5IzGESyLSeZ/RCwbSZ2uQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@next/env": "15.5.18",
+        "@swc/helpers": "0.5.15",
+        "caniuse-lite": "^1.0.30001579",
+        "postcss": "8.4.31",
+        "styled-jsx": "5.1.6"
+      },
+      "bin": {
+        "next": "dist/bin/next"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^19.8.0 || >= 20.0.0"
+      },
+      "optionalDependencies": {
+        "@next/swc-darwin-arm64": "15.5.18",
+        "@next/swc-darwin-x64": "15.5.18",
+        "@next/swc-linux-arm64-gnu": "15.5.18",
+        "@next/swc-linux-arm64-musl": "15.5.18",
+        "@next/swc-linux-x64-gnu": "15.5.18",
+        "@next/swc-linux-x64-musl": "15.5.18",
+        "@next/swc-win32-arm64-msvc": "15.5.18",
+        "@next/swc-win32-x64-msvc": "15.5.18",
+        "sharp": "^0.34.3"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.1.0",
+        "@playwright/test": "^1.51.1",
+        "babel-plugin-react-compiler": "*",
+        "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0",
+        "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0",
+        "sass": "^1.3.0"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@playwright/test": {
+          "optional": true
+        },
+        "babel-plugin-react-compiler": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        }
+      }
+    },
     "packages/test-apps/nextjs/node_modules/postcss": {
       "version": "8.4.31",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
       "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",

--- a/packages/core/src/utils/styleUtils/ssrStylesPattern.spec.ts
+++ b/packages/core/src/utils/styleUtils/ssrStylesPattern.spec.ts
@@ -1866,11 +1866,11 @@ describe('pattern component', () => {
     const IMAGE_NODE_ID = 'es291-image-node-id';
 
     const customBreakpoints = [
-      { id: 'bp-xl', query: '*', displayName: 'Extra Large', previewSize: '1440px' },
-      { id: 'bp-lg', query: '<1280px', displayName: 'Large', previewSize: '1024px' },
-      { id: 'bp-md', query: '<1024px', displayName: 'Medium', previewSize: '768px' },
-      { id: 'bp-sm', query: '<768px', displayName: 'Small', previewSize: '480px' },
-      { id: 'bp-xs', query: '<480px', displayName: 'Extra Small', previewSize: '320px' },
+      { id: 'bp-xl', query: '*' as const, displayName: 'Extra Large', previewSize: '1440px' },
+      { id: 'bp-lg', query: '<1280px' as const, displayName: 'Large', previewSize: '1024px' },
+      { id: 'bp-md', query: '<1024px' as const, displayName: 'Medium', previewSize: '768px' },
+      { id: 'bp-sm', query: '<768px' as const, displayName: 'Small', previewSize: '480px' },
+      { id: 'bp-xs', query: '<480px' as const, displayName: 'Extra Small', previewSize: '320px' },
     ];
 
     const sys = (id: string, type = 'Entry') => ({

--- a/packages/core/src/utils/styleUtils/ssrStylesPattern.spec.ts
+++ b/packages/core/src/utils/styleUtils/ssrStylesPattern.spec.ts
@@ -1857,4 +1857,137 @@ describe('pattern component', () => {
     // Making sure that the extracted styles contain the updated background color for the nested pattern component
     expect(styles).toMatch('background-color:rgba(111, 111 , 111, 0)');
   });
+
+  // ES-291: Customer has 5 custom breakpoints. An image inside a Pattern is hidden (cfVisibility:false)
+  // on all breakpoints in Studio Preview. After publishing, it only stays hidden on Desktop and
+  // becomes visible at all other 4 breakpoints.
+  it('should emit display:none for all 5 custom breakpoints when image inside a pattern is hidden', () => {
+    const PATTERN_ID = 'es291-pattern-id';
+    const IMAGE_NODE_ID = 'es291-image-node-id';
+
+    const customBreakpoints = [
+      { id: 'bp-xl', query: '*', displayName: 'Extra Large', previewSize: '1440px' },
+      { id: 'bp-lg', query: '<1280px', displayName: 'Large', previewSize: '1024px' },
+      { id: 'bp-md', query: '<1024px', displayName: 'Medium', previewSize: '768px' },
+      { id: 'bp-sm', query: '<768px', displayName: 'Small', previewSize: '480px' },
+      { id: 'bp-xs', query: '<480px', displayName: 'Extra Small', previewSize: '320px' },
+    ];
+
+    const sys = (id: string, type = 'Entry') => ({
+      id,
+      type,
+      locale: 'en-US',
+      createdAt: '2024-01-01T00:00:00Z',
+      updatedAt: '2024-01-01T00:00:00Z',
+      revision: 1,
+      publishedVersion: 1,
+      contentType: { sys: { id: 'contentful-component', type: 'Link', linkType: 'ContentType' } },
+      space: { sys: { id: 'space-id', type: 'Link', linkType: 'Space' } },
+      environment: { sys: { id: 'master', type: 'Link', linkType: 'Environment' } },
+    });
+
+    // Pattern entry: contains a single image node with cfVisibility:false on the default (bp-xl) breakpoint.
+    // Studio stores cfVisibility:false on each breakpoint when you hide for all — but even the cascade
+    // case (only set on default) must work.
+    const patternWithHiddenImage: ExperienceEntry = {
+      metadata: { tags: [] },
+      sys: sys(PATTERN_ID) as ExperienceEntry['sys'],
+      fields: {
+        title: 'Pattern with hidden image',
+        slug: 'es291-pattern',
+        componentTree: {
+          schemaVersion: '2023-09-28',
+          breakpoints: customBreakpoints,
+          children: [
+            {
+              definitionId: 'contentful-container',
+              id: 'container-node-id',
+              variables: {
+                cfWidth: { type: 'DesignValue', valuesByBreakpoint: { 'bp-xl': '100%' } },
+              },
+              children: [
+                {
+                  definitionId: 'contentful-image',
+                  id: IMAGE_NODE_ID,
+                  variables: {
+                    // cfVisibility:false set only on the default breakpoint — cascade must apply to all 5
+                    cfVisibility: {
+                      type: 'DesignValue',
+                      valuesByBreakpoint: { 'bp-xl': false },
+                    },
+                  },
+                  children: [],
+                },
+              ],
+            },
+          ],
+        },
+        dataSource: {},
+        unboundValues: {},
+        componentSettings: { variableDefinitions: {} },
+      },
+    };
+
+    // Experience entry: references the pattern
+    const patternNodeId = 'es291-pattern-node-id';
+    const experienceWithCustomBreakpoints: ExperienceEntry = {
+      metadata: { tags: [] },
+      sys: sys('es291-experience-id') as ExperienceEntry['sys'],
+      fields: {
+        title: 'ES-291 Experience',
+        slug: '/es291',
+        componentTree: {
+          schemaVersion: '2023-09-28',
+          breakpoints: customBreakpoints,
+          children: [
+            {
+              definitionId: PATTERN_ID,
+              id: patternNodeId,
+              variables: {},
+              children: [],
+            },
+          ],
+        },
+        dataSource: {},
+        unboundValues: {},
+        usedComponents: [patternWithHiddenImage as unknown as ExperienceEntry],
+      },
+    };
+
+    const experience = createExperience({
+      experienceEntry: experienceWithCustomBreakpoints as unknown as Entry,
+      locale: 'en-US',
+      referencedEntries: [patternWithHiddenImage as unknown as Entry],
+      referencedAssets: [],
+    });
+
+    const styles = detachExperienceStyles(experience);
+
+    // The generated CSS must include display:none for EACH of the 5 custom breakpoints.
+    // Before the fix, only the default breakpoint (bp-xl / Desktop) would have display:none,
+    // causing the image to reappear at all narrower breakpoints after publishing.
+    expect(styles).toMatch(/display:none !important/);
+
+    // Verify disjunct media query coverage for each breakpoint:
+    // bp-xl (default): @media not (max-width:1280px)
+    expect(styles).toMatch(
+      /@media not \(max-width:1280px\)\{\.cf-[a-f0-9]+\{display:none !important;\}\}/,
+    );
+    // bp-lg: @media(max-width:1280px) and (not (max-width:1024px))
+    expect(styles).toMatch(
+      /@media\(max-width:1280px\) and \(not \(max-width:1024px\)\)\{\.cf-[a-f0-9]+\{display:none !important;\}\}/,
+    );
+    // bp-md: @media(max-width:1024px) and (not (max-width:768px))
+    expect(styles).toMatch(
+      /@media\(max-width:1024px\) and \(not \(max-width:768px\)\)\{\.cf-[a-f0-9]+\{display:none !important;\}\}/,
+    );
+    // bp-sm: @media(max-width:768px) and (not (max-width:480px))
+    expect(styles).toMatch(
+      /@media\(max-width:768px\) and \(not \(max-width:480px\)\)\{\.cf-[a-f0-9]+\{display:none !important;\}\}/,
+    );
+    // bp-xs: @media(max-width:480px)
+    expect(styles).toMatch(
+      /@media\(max-width:480px\)\{\.cf-[a-f0-9]+\{display:none !important;\}\}/,
+    );
+  });
 });

--- a/packages/experience-builder-sdk/src/core/styles/convertResolvedDesignValuesToMediaQuery.spec.ts
+++ b/packages/experience-builder-sdk/src/core/styles/convertResolvedDesignValuesToMediaQuery.spec.ts
@@ -1,8 +1,18 @@
 import { toMediaQuery } from '@contentful/experiences-core';
+import { Breakpoint } from '@contentful/experiences-core/types';
 import { createBreakpoints } from '../../../test/__fixtures__/breakpoints';
 import { createComponentTreeNode } from '../../../test/__fixtures__/componentTreeNode';
 import { createStylesheetsForBuiltInStyles } from './createStylesheetsForBuiltInStyles';
 import { convertResolvedDesignValuesToMediaQuery } from './convertResolvedDesignValuesToMediaQuery';
+
+// ES-291: Custom breakpoints (5 instead of standard 3) with non-standard IDs
+const customBreakpoints: Breakpoint[] = [
+  { id: 'bp-xl', query: '*', displayName: 'Extra Large', previewSize: '1440px' },
+  { id: 'bp-lg', query: '<1280px', displayName: 'Large', previewSize: '1024px' },
+  { id: 'bp-md', query: '<1024px', displayName: 'Medium', previewSize: '768px' },
+  { id: 'bp-sm', query: '<768px', displayName: 'Small', previewSize: '480px' },
+  { id: 'bp-xs', query: '<480px', displayName: 'Extra Small', previewSize: '320px' },
+];
 
 const designPropertiesByBreakpoint = {
   desktop: { cfMargin: '7px' },
@@ -80,6 +90,96 @@ describe('convertResolvedDesignValuesToMediaQuery', () => {
       expect(expectedResult.css).toContain(
         `@media(max-width:992px) and (not (max-width:576px)){.${tablet.className}{display:none !important;}}`,
       );
+    });
+  });
+
+  describe('when visibility is only set on the default breakpoint', () => {
+    // Regression: tablet/mobile had no design properties at all, so the visibility cascade was
+    // skipped for those breakpoints and hidden content became visible after publishing.
+    const designPropertiesByBreakpoint = {
+      desktop: { cfVisibility: false },
+    };
+
+    it('cascades hide to all narrower breakpoints', () => {
+      const stylesheetData = createStylesheetsForBuiltInStyles({
+        designPropertiesByBreakpoint,
+        breakpoints,
+        node,
+      });
+      expect(stylesheetData).toHaveLength(3);
+      const [desktop, tablet, mobile] = stylesheetData;
+      expect(desktop.visibilityCss).toEqual('display:none !important;');
+      expect(tablet.visibilityCss).toEqual('display:none !important;');
+      expect(mobile.visibilityCss).toEqual('display:none !important;');
+    });
+
+    it('emits disjunct media queries that hide content at all breakpoints', () => {
+      const stylesheetData = createStylesheetsForBuiltInStyles({
+        designPropertiesByBreakpoint,
+        breakpoints,
+        node,
+      });
+      const [desktop, tablet, mobile] = stylesheetData;
+      const { css } = convertResolvedDesignValuesToMediaQuery(stylesheetData);
+      expect(css).toContain(
+        `@media not (max-width:992px){.${desktop.className}{display:none !important;}}`,
+      );
+      expect(css).toContain(
+        `@media(max-width:992px) and (not (max-width:576px)){.${tablet.className}{display:none !important;}}`,
+      );
+      expect(css).toContain(
+        `@media(max-width:576px){.${mobile.className}{display:none !important;}}`,
+      );
+    });
+  });
+
+  // ES-291: Regression — custom breakpoints (5 breakpoints, non-standard IDs).
+  // When cfVisibility:false is set only on the default breakpoint, the cascade must apply
+  // display:none to all narrower breakpoints in the emitted CSS.
+  describe('when using 5 custom breakpoints and visibility is set only on the default breakpoint (ES-291)', () => {
+    const designPropertiesByBreakpoint = {
+      'bp-xl': { cfVisibility: false },
+    };
+
+    it('cascades hide to all 4 narrower custom breakpoints', () => {
+      const stylesheetData = createStylesheetsForBuiltInStyles({
+        designPropertiesByBreakpoint,
+        breakpoints: customBreakpoints,
+        node,
+      });
+      expect(stylesheetData).toHaveLength(5);
+      for (const entry of stylesheetData) {
+        expect(entry.visibilityCss).toEqual('display:none !important;');
+      }
+    });
+
+    it('emits disjunct media queries that hide content at all 5 custom breakpoints', () => {
+      const stylesheetData = createStylesheetsForBuiltInStyles({
+        designPropertiesByBreakpoint,
+        breakpoints: customBreakpoints,
+        node,
+      });
+      const [xl, lg, md, sm, xs] = stylesheetData;
+      const { css } = convertResolvedDesignValuesToMediaQuery(stylesheetData);
+
+      // Default breakpoint: "not tablet" (not <1280px)
+      expect(css).toContain(
+        `@media not (max-width:1280px){.${xl.className}{display:none !important;}}`,
+      );
+      // Large: <1280px but not <1024px
+      expect(css).toContain(
+        `@media(max-width:1280px) and (not (max-width:1024px)){.${lg.className}{display:none !important;}}`,
+      );
+      // Medium: <1024px but not <768px
+      expect(css).toContain(
+        `@media(max-width:1024px) and (not (max-width:768px)){.${md.className}{display:none !important;}}`,
+      );
+      // Small: <768px but not <480px
+      expect(css).toContain(
+        `@media(max-width:768px) and (not (max-width:480px)){.${sm.className}{display:none !important;}}`,
+      );
+      // Extra small: <480px (last breakpoint — no next condition)
+      expect(css).toContain(`@media(max-width:480px){.${xs.className}{display:none !important;}}`);
     });
   });
 });

--- a/packages/experience-builder-sdk/src/core/styles/createStylesheetsForBuiltInStyles.ts
+++ b/packages/experience-builder-sdk/src/core/styles/createStylesheetsForBuiltInStyles.ts
@@ -59,11 +59,11 @@ export const createStylesheetsForBuiltInStyles = ({
   for (const breakpoint of breakpoints) {
     let visibilityCss: string | undefined;
     const designProperties = designPropertiesByBreakpoint[breakpoint.id];
-    if (!designProperties) {
+    if (!designProperties && !isAnyVisibilityValueHidden) {
       continue;
     }
 
-    const designPropertiesWithResolvedDesignTokens = Object.entries(designProperties).reduce(
+    const designPropertiesWithResolvedDesignTokens = Object.entries(designProperties ?? {}).reduce(
       (acc, [propertyName, value]) => ({
         ...acc,
         [propertyName]: maybePopulateDesignTokenValue(
@@ -109,10 +109,21 @@ export const createStylesheetsForBuiltInStyles = ({
      * breakpointCss = "margin:42px;background-color:rgba(246, 246, 246, 1);"
      */
 
-    // Create a hash ensuring stability across nodes (and breakpoints between nodes)
+    // When visibility is involved, include the breakpoint ID to prevent hash collisions between
+    // breakpoints that share the same (empty) CSS — otherwise convertResolvedDesignValuesToMediaQuery
+    // deduplicates them and the visibility media queries for narrower breakpoints are never emitted.
+    const breakpointSegment = isAnyVisibilityValueHidden ? breakpoint.id : '';
     const styleHash = patternRootNodeIdsChain
-      ? md5([...patternRootNodeIdsChain, node.id, breakpointCss, visibilityCss].join('-'))
-      : md5(`${node.id}-${breakpointCss}-${visibilityCss}`);
+      ? md5(
+          [
+            ...patternRootNodeIdsChain,
+            node.id,
+            breakpointSegment,
+            breakpointCss,
+            visibilityCss,
+          ].join('-'),
+        )
+      : md5(`${node.id}-${breakpointSegment}-${breakpointCss}-${visibilityCss}`);
 
     // Create a CSS className with internal prefix to make sure the value can be processed
     const className = `cfstyles-${styleHash}`;


### PR DESCRIPTION
When cfVisibility:false was set only on the default breakpoint, narrower breakpoints with no
design properties were skipped entirely in createStylesheetsForBuiltInStyles, so no
display:none media query was emitted for them. Hidden content would stay hidden in Studio
preview (which applies styles directly) but reappear at tablet/mobile after publishing.

Fix: skip the early-continue when any visibility is hidden, and carry previousVisibilityValue
forward so every breakpoint gets an explicit visibilityCss. Include the breakpoint ID in the
style hash when visibility is involved to prevent deduplication collisions between breakpoints
that otherwise produce identical (empty) CSS. 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>This PR fixes a bug where cfVisibility:false set only on the default breakpoint would not cascade to narrower breakpoints that have no design properties, causing hidden content to reappear at tablet/mobile after publishing. The fix modifies createStylesheetsForBuiltInStyles to skip the early-continue when any visibility is hidden, carries the visibility value forward so every breakpoint gets an explicit visibilityCss, and includes the breakpoint ID in the style hash to prevent deduplication collisions.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Modified the early-continue condition in createStylesheetsForBuiltInStyles.ts to not skip breakpoints when any visibility value is hidden, ensuring display:none is emitted for all breakpoints even when cfVisibility:false is set only on the default breakpoint</li>

<li>Added null-safe handling with 'designProperties ?? {}' to prevent errors when iterating breakpoints with no design properties</li>

<li>Included breakpoint ID in the style hash when visibility is involved to prevent deduplication collisions between breakpoints that would otherwise produce identical empty CSS</li>

<li>Added comprehensive regression tests in ssrStylesPattern.spec.ts verifying display:none is emitted for all 5 custom breakpoints when an image inside a pattern is hidden</li>

<li>Added tests in convertResolvedDesignValuesToMediaQuery.spec.ts covering visibility cascade for both standard 3-breakpoint and custom 5-breakpoint configurations</li>

</ul>
</details>

</div>