### PR TITLE
fix: align image transformation recovery [SPA-4719]

### DIFF
--- a/packages/core/src/utils/transformers/media/transformMedia.ts
+++ b/packages/core/src/utils/transformers/media/transformMedia.ts
@@ -97,7 +97,7 @@ export const transformMedia = (
     } catch (error) {
       debug.error('[experiences-core::transformMedia] Error transforming image asset', error);
     }
-    return;
+    return asset.fields.file?.url;
   }
 
   return asset.fields.file?.url;


### PR DESCRIPTION
## Purpose

When the image optimization failed to compile, we'd return nothing. I aligned it with the way we handle the other cases - returning the asset url 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>This PR fixes error recovery behavior in the image transformation logic. When the image optimization fails to compile, the function now returns the original asset URL instead of returning nothing, consistent with how background image transformation handles the same scenario.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Changed error handling in the `cfImageAsset` catch block (line 9) to return `asset.fields.file?.url` instead of returning `undefined`, aligning it with the `cfBackgroundImageUrl` error handling pattern (line 100) to provide graceful fallback on optimization failure.</li>

</ul>
</details>

</div>